### PR TITLE
Add first-run permissions setup wizard for global hotkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,30 +80,17 @@ pip install dbus-python
 pip install nvidia-cublas-cu12 nvidia-cudnn-cu12
 ```
 
-### 3. udev rules (required for hotkeys)
-
-Create `/etc/udev/rules.d/99-whisper-wayland.rules`:
-
-```
-KERNEL=="uinput", GROUP="uinput", MODE="0660"
-```
-
-Reload rules and add your user to the required groups:
-
-```bash
-sudo udevadm control --reload-rules && sudo udevadm trigger
-sudo usermod -aG input $USER
-```
-
-> **Note:** Log out and back in for group changes to take effect.
-
-### 4. Launch
+### 3. Launch
 
 ```bash
 ./whisper-wayland.sh
 ```
 
 The app starts in the system tray. If your compositor doesn't support system trays, the Settings window opens directly.
+
+**On first launch**, if global hotkeys aren't yet configured, a setup wizard appears automatically. Click **Set Up Permissions**, enter your administrator password when prompted, then log out and back in. That's it — no terminal commands, no scripts to run manually.
+
+> You can also open the wizard any time from the tray icon → **Set Up Hotkeys…**
 
 ---
 

--- a/src/gui/setup_dialog.py
+++ b/src/gui/setup_dialog.py
@@ -1,0 +1,315 @@
+"""
+First-run permissions setup dialog for Whisper-Wayland.
+
+Global hotkeys require read access to /dev/input/event* which is gated behind
+the 'input' group on most Linux systems. This module detects missing permissions
+and provides a one-click fix via pkexec (polkit) — no terminal or manual script
+running needed.
+"""
+
+import glob
+import grp
+import os
+import pwd
+import shutil
+import subprocess
+from pathlib import Path
+
+from PyQt6.QtCore import Qt, QThread, pyqtSignal
+from PyQt6.QtWidgets import (
+    QDialog, QFrame, QHBoxLayout, QLabel, QPushButton, QVBoxLayout,
+)
+
+_SCRIPTS_DIR = Path(__file__).parent.parent.parent / 'scripts'
+_UDEV_RULE_PATH = Path('/etc/udev/rules.d/99-whisper-wayland.rules')
+
+
+# ── Permission detection ──────────────────────────────────────────────────────
+
+def can_access_input_devices() -> bool:
+    """Return True if the process can open at least one /dev/input/event* device."""
+    candidates = sorted(glob.glob('/dev/input/event*'))[:8]
+    if not candidates:
+        return True  # No devices present (VM / unusual system) — don't block startup
+    for path in candidates:
+        try:
+            with open(path, 'rb'):
+                return True
+        except PermissionError:
+            return False
+        except OSError:
+            continue
+    return True
+
+
+def _username() -> str:
+    try:
+        return pwd.getpwuid(os.getuid()).pw_name
+    except Exception:
+        return os.environ.get('USER', '')
+
+
+def user_in_input_group() -> bool:
+    """Return True if the user is listed in /etc/group for 'input' (reflects usermod, pre-relogin)."""
+    try:
+        info = grp.getgrnam('input')
+        name = _username()
+        if pwd.getpwnam(name).pw_gid == info.gr_gid:
+            return True
+        return name in info.gr_mem
+    except Exception:
+        return False
+
+
+def udev_rule_exists() -> bool:
+    return _UDEV_RULE_PATH.exists()
+
+
+def needs_setup() -> bool:
+    """Return True if the permissions setup dialog should be shown at startup."""
+    return not can_access_input_devices()
+
+
+# ── Worker thread (runs setup script via pkexec in background) ───────────────
+
+class _SetupWorker(QThread):
+    finished = pyqtSignal(bool, str)  # (success, error_message)
+
+    def run(self):
+        script = _SCRIPTS_DIR / 'setup-permissions.sh'
+        if not script.exists():
+            self.finished.emit(False, f"Setup script not found:\n{script}")
+            return
+
+        pkexec = shutil.which('pkexec')
+        if not pkexec:
+            self.finished.emit(
+                False,
+                "pkexec not found. Run this in a terminal instead:\n\n"
+                f"  sudo bash {script}\n\nThen log out and back in.",
+            )
+            return
+
+        try:
+            result = subprocess.run(
+                [pkexec, 'bash', str(script)],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            if result.returncode == 0:
+                self.finished.emit(True, "")
+            else:
+                stderr = result.stderr.strip() or f"Exit code {result.returncode}"
+                self.finished.emit(False, stderr)
+        except subprocess.TimeoutExpired:
+            self.finished.emit(False, "Operation timed out.")
+        except Exception as e:
+            self.finished.emit(False, str(e))
+
+
+# ── Dialog ────────────────────────────────────────────────────────────────────
+
+_QSS = """
+QDialog {
+    background: #0f1117;
+}
+QLabel {
+    color: #e2e8f0;
+    font-size: 13px;
+    background: transparent;
+}
+QFrame#card {
+    background: #131720;
+    border: 1px solid #1e2433;
+    border-radius: 8px;
+}
+QFrame#divider {
+    background: #1e2433;
+    border: none;
+    max-height: 1px;
+}
+QPushButton#primary {
+    background: #4a9eff;
+    color: #ffffff;
+    border: none;
+    border-radius: 6px;
+    padding: 10px 22px;
+    font-size: 13px;
+    font-weight: 600;
+    min-width: 190px;
+}
+QPushButton#primary:hover   { background: #5aaaff; }
+QPushButton#primary:pressed  { background: #3a8ef0; }
+QPushButton#primary:disabled { background: #2a3448; color: #4a5568; }
+QPushButton#secondary {
+    background: transparent;
+    color: #8892a4;
+    border: 1px solid #2a3448;
+    border-radius: 6px;
+    padding: 10px 22px;
+    font-size: 13px;
+}
+QPushButton#secondary:hover { color: #e2e8f0; border-color: #4a9eff; }
+"""
+
+
+class PermissionsSetupDialog(QDialog):
+    """
+    Shown at startup when /dev/input/event* is not accessible.
+
+    Detects whether the user needs full setup or just a re-login, then offers
+    a one-click fix via pkexec (polkit auth dialog — no terminal needed).
+    """
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Whisper-Wayland — Hotkey Setup")
+        self.setStyleSheet(_QSS)
+        self.setMinimumWidth(520)
+        self.setModal(False)
+        self._worker = None
+        self._already_configured = user_in_input_group() and udev_rule_exists()
+        self._build_ui()
+
+    def _build_ui(self):
+        layout = QVBoxLayout(self)
+        layout.setSpacing(0)
+        layout.setContentsMargins(28, 26, 28, 26)
+
+        # Title
+        title = QLabel("Global Hotkey Setup")
+        title.setStyleSheet(
+            "font-size: 18px; font-weight: 700; color: #f0f4f8; margin-bottom: 4px;"
+        )
+        layout.addWidget(title)
+
+        if self._already_configured:
+            sub_text = "Setup is complete — just log out and back in to activate"
+        else:
+            sub_text = "One-time permission setup needed for hold-to-talk and global hotkeys"
+        sub = QLabel(sub_text)
+        sub.setStyleSheet("color: #8892a4; font-size: 12px; margin-bottom: 20px;")
+        layout.addWidget(sub)
+
+        # Explanation card
+        card = QFrame()
+        card.setObjectName("card")
+        card_layout = QVBoxLayout(card)
+        card_layout.setContentsMargins(16, 14, 16, 14)
+        card_layout.setSpacing(0)
+
+        if self._already_configured:
+            body_text = (
+                "Your user account has already been added to the <code>input</code> group "
+                "and the udev rule is installed, but the change won't be visible to the "
+                "current login session until you log out and back in.<br><br>"
+                "After re-logging in, hold-to-talk and all other hotkeys will work "
+                "automatically — no further setup needed."
+            )
+        else:
+            body_text = (
+                "To capture keyboard shortcuts globally (while other windows are focused), "
+                "Whisper-Wayland needs read access to <code>/dev/input/event*</code>.<br><br>"
+                "This is gated behind the <code>input</code> system group. "
+                "Click <b>Set Up Permissions</b> and you will be prompted for your "
+                "administrator password — this only needs to happen once."
+            )
+
+        body = QLabel(body_text)
+        body.setWordWrap(True)
+        body.setTextFormat(Qt.TextFormat.RichText)
+        body.setStyleSheet("color: #c8d3e0; line-height: 1.6;")
+        card_layout.addWidget(body)
+        layout.addWidget(card)
+        layout.addSpacing(18)
+
+        # Status indicators
+        self._status_label = QLabel()
+        self._status_label.setTextFormat(Qt.TextFormat.RichText)
+        self._status_label.setWordWrap(True)
+        self._refresh_status()
+        layout.addWidget(self._status_label)
+        layout.addSpacing(22)
+
+        # Divider
+        div = QFrame()
+        div.setObjectName("divider")
+        div.setFixedHeight(1)
+        layout.addWidget(div)
+        layout.addSpacing(18)
+
+        # Buttons
+        btn_row = QHBoxLayout()
+        btn_row.setSpacing(12)
+
+        self._skip_btn = QPushButton("Skip — Use App Without Hotkeys")
+        self._skip_btn.setObjectName("secondary")
+        self._skip_btn.clicked.connect(self.accept)
+        btn_row.addWidget(self._skip_btn)
+
+        btn_row.addStretch()
+
+        if self._already_configured:
+            self._setup_btn = QPushButton("Close")
+            self._setup_btn.setObjectName("primary")
+            self._setup_btn.clicked.connect(self.accept)
+        else:
+            self._setup_btn = QPushButton("Set Up Permissions")
+            self._setup_btn.setObjectName("primary")
+            self._setup_btn.clicked.connect(self._start_setup)
+
+        btn_row.addWidget(self._setup_btn)
+        layout.addLayout(btn_row)
+
+    def _refresh_status(self):
+        in_group = user_in_input_group()
+        udev = udev_rule_exists()
+
+        def row(ok, text):
+            icon, color = ("✓", "#4ade80") if ok else ("✗", "#f87171")
+            return f'<span style="color:{color};">{icon}</span>&nbsp;&nbsp;{text}'
+
+        lines = [
+            row(in_group, "User added to <code>input</code> group"),
+            row(udev, "udev rule installed"),
+        ]
+        self._status_label.setText(
+            '<span style="color:#8892a4; font-size:12px;">Current status:</span><br>'
+            + "<br>".join(lines)
+        )
+
+    def _start_setup(self):
+        self._setup_btn.setEnabled(False)
+        self._setup_btn.setText("Running setup…")
+        self._skip_btn.setEnabled(False)
+        self._worker = _SetupWorker()
+        self._worker.finished.connect(self._on_finished)
+        self._worker.start()
+
+    def _on_finished(self, success: bool, error: str):
+        self._setup_btn.setEnabled(True)
+        self._skip_btn.setEnabled(True)
+        self._refresh_status()
+
+        if success:
+            self._setup_btn.setText("Close")
+            self._setup_btn.clicked.disconnect()
+            self._setup_btn.clicked.connect(self.accept)
+            self._skip_btn.setVisible(False)
+            self._status_label.setText(
+                '<span style="color:#4ade80; font-size:14px; font-weight:600;">'
+                "✓ Permissions configured!"
+                "</span><br><br>"
+                '<span style="color:#c8d3e0;">'
+                "Please <b>log out and log back in</b> for the group change to take effect.<br>"
+                "After re-logging in, hold-to-talk and all other hotkeys will work "
+                "automatically — no setup needed next time."
+                "</span>"
+            )
+        else:
+            self._setup_btn.setText("Retry Setup")
+            self._status_label.setText(
+                '<span style="color:#f87171;">Setup failed:</span><br>'
+                f'<span style="color:#8892a4;">{error.replace(chr(10), "<br>")}</span>'
+            )

--- a/src/gui/tray_icon.py
+++ b/src/gui/tray_icon.py
@@ -30,6 +30,12 @@ class WhisperTrayIcon(QSystemTrayIcon):
             self.menu.addAction(self.history_action)
 
         self.menu.addSeparator()
+
+        self.setup_hotkeys_action = QAction("🔑  Set Up Hotkeys…")
+        self.setup_hotkeys_action.triggered.connect(self._show_setup_dialog)
+        self.menu.addAction(self.setup_hotkeys_action)
+
+        self.menu.addSeparator()
         self.quit_action = QAction("Quit")
         self.quit_action.triggered.connect(QApplication.instance().quit)
         self.menu.addAction(self.quit_action)
@@ -53,6 +59,11 @@ class WhisperTrayIcon(QSystemTrayIcon):
             pixmap = QPixmap(64, 64)
             pixmap.fill(QColor("grey"))
             self.setIcon(QIcon(pixmap))
+
+    def _show_setup_dialog(self):
+        from gui.setup_dialog import PermissionsSetupDialog
+        dlg = PermissionsSetupDialog()
+        dlg.exec()
 
     def set_recording_icon(self):
         if hasattr(self, 'icon_on') and not self.icon_on.isNull():

--- a/src/main.py
+++ b/src/main.py
@@ -20,6 +20,7 @@ from gui.tray_icon import WhisperTrayIcon
 from gui.settings_window import SettingsWindow
 from gui.history_window import HistoryWindow
 from gui.overlay_manager import OverlayManager, OverlayProxy
+from gui.setup_dialog import needs_setup, PermissionsSetupDialog
 
 @contextlib.contextmanager
 def ignore_stderr():
@@ -87,6 +88,13 @@ def main():
         app.setQuitOnLastWindowClosed(False)
 
         config = Config()
+
+        # Show the hotkey-permissions wizard on first run (or if setup is still incomplete).
+        # The dialog is non-modal — the user can skip it and still use the app via DBus/tray.
+        if needs_setup():
+            _setup_dlg = PermissionsSetupDialog()
+            _setup_dlg.exec()
+
         state = AppState()
 
         audio_queue = queue.Queue()

--- a/tests/test_setup_dialog.py
+++ b/tests/test_setup_dialog.py
@@ -1,0 +1,210 @@
+"""Tests for src/gui/setup_dialog.py permission-detection helpers.
+
+The pure helper functions (can_access_input_devices, user_in_input_group,
+udev_rule_exists, needs_setup) run without Qt and are tested with mocks.
+
+The PermissionsSetupDialog smoke-test is gated on both PyQt6 being importable
+and a display being present; skipped gracefully in headless CI.
+"""
+
+import grp
+import os
+import pwd
+import sys
+import tempfile
+import unittest.mock as mock
+from pathlib import Path
+
+import pytest
+
+# Skip this entire module if PyQt6 is not installed (e.g. bare CI without GUI deps).
+pytest.importorskip("PyQt6")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import gui.setup_dialog as sd
+
+
+# ── can_access_input_devices ──────────────────────────────────────────────────
+
+class TestCanAccessInputDevices:
+
+    def test_returns_true_when_device_opens(self):
+        with mock.patch("glob.glob", return_value=["/dev/input/event0"]), \
+             mock.patch("builtins.open", mock.mock_open()):
+            assert sd.can_access_input_devices() is True
+
+    def test_returns_false_on_permission_error(self):
+        with mock.patch("glob.glob", return_value=["/dev/input/event0"]), \
+             mock.patch("builtins.open", side_effect=PermissionError):
+            assert sd.can_access_input_devices() is False
+
+    def test_returns_true_when_no_devices_exist(self):
+        # No /dev/input/event* → likely a VM; startup must not be blocked.
+        with mock.patch("glob.glob", return_value=[]):
+            assert sd.can_access_input_devices() is True
+
+    def test_skips_oserror_device_and_continues(self):
+        # event0 is busy (OSError), event1 opens fine → True overall.
+        cm = mock.MagicMock()
+
+        def _open(path, *a, **kw):
+            if "event0" in path:
+                raise OSError("Device busy")
+            return cm
+
+        with mock.patch("glob.glob", return_value=["/dev/input/event0",
+                                                    "/dev/input/event1"]), \
+             mock.patch("builtins.open", side_effect=_open):
+            assert sd.can_access_input_devices() is True
+
+    def test_all_oserror_falls_through_to_true(self):
+        # Every candidate raises OSError (not PermissionError) → no devices
+        # accessible but not a permission problem, return True.
+        with mock.patch("glob.glob", return_value=["/dev/input/event0"]), \
+             mock.patch("builtins.open", side_effect=OSError("busy")):
+            assert sd.can_access_input_devices() is True
+
+    def test_checks_at_most_eight_devices(self):
+        # The function slices glob results to [:8]. Simulate 20 paths; all
+        # raise OSError so the loop completes without early return.
+        tried = []
+
+        def _open(path, *a, **kw):
+            tried.append(path)
+            raise OSError("busy")
+
+        paths = [f"/dev/input/event{i}" for i in range(20)]
+        with mock.patch("glob.glob", return_value=paths), \
+             mock.patch("builtins.open", side_effect=_open):
+            result = sd.can_access_input_devices()
+
+        assert result is True        # all OSError → fallthrough
+        assert len(tried) == 8       # sliced to [:8] before the loop
+
+    def test_permission_error_short_circuits_remaining_devices(self):
+        # PermissionError on the first device means we know access is denied —
+        # no need to probe further.
+        tried = []
+
+        def _open(path, *a, **kw):
+            tried.append(path)
+            raise PermissionError
+
+        paths = ["/dev/input/event0", "/dev/input/event1", "/dev/input/event2"]
+        with mock.patch("glob.glob", return_value=paths), \
+             mock.patch("builtins.open", side_effect=_open):
+            assert sd.can_access_input_devices() is False
+
+        assert len(tried) == 1   # returned immediately after first PermissionError
+
+
+# ── user_in_input_group ───────────────────────────────────────────────────────
+
+def _grp(gr_gid, gr_mem):
+    return grp.struct_group(("input", "x", gr_gid, gr_mem))
+
+
+def _pwd(pw_uid, pw_gid, pw_name="alice"):
+    return pwd.struct_passwd((pw_name, "x", pw_uid, pw_gid, "", f"/home/{pw_name}", "/bin/bash"))
+
+
+class TestUserInInputGroup:
+
+    def test_returns_true_when_username_in_mem(self):
+        with mock.patch("grp.getgrnam", return_value=_grp(990, ["alice", "bob"])), \
+             mock.patch("pwd.getpwuid", return_value=_pwd(1000, 1000, "alice")), \
+             mock.patch("pwd.getpwnam", return_value=_pwd(1000, 1000, "alice")), \
+             mock.patch("os.getuid", return_value=1000):
+            assert sd.user_in_input_group() is True
+
+    def test_returns_false_when_username_not_in_mem(self):
+        with mock.patch("grp.getgrnam", return_value=_grp(990, ["bob", "charlie"])), \
+             mock.patch("pwd.getpwuid", return_value=_pwd(1000, 1000, "alice")), \
+             mock.patch("pwd.getpwnam", return_value=_pwd(1000, 1000, "alice")), \
+             mock.patch("os.getuid", return_value=1000):
+            assert sd.user_in_input_group() is False
+
+    def test_returns_true_when_primary_gid_matches(self):
+        # User whose primary group IS the input group (pw_gid == gr_gid).
+        with mock.patch("grp.getgrnam", return_value=_grp(990, [])), \
+             mock.patch("pwd.getpwuid", return_value=_pwd(1000, 990, "alice")), \
+             mock.patch("pwd.getpwnam", return_value=_pwd(1000, 990, "alice")), \
+             mock.patch("os.getuid", return_value=1000):
+            assert sd.user_in_input_group() is True
+
+    def test_returns_false_when_group_does_not_exist(self):
+        with mock.patch("grp.getgrnam", side_effect=KeyError("input")):
+            assert sd.user_in_input_group() is False
+
+    def test_returns_false_on_unexpected_error(self):
+        with mock.patch("grp.getgrnam", side_effect=RuntimeError("unexpected")):
+            assert sd.user_in_input_group() is False
+
+
+# ── udev_rule_exists ──────────────────────────────────────────────────────────
+
+class TestUdevRuleExists:
+
+    def test_returns_true_when_file_present(self):
+        with tempfile.NamedTemporaryFile() as f:
+            with mock.patch.object(sd, "_UDEV_RULE_PATH", Path(f.name)):
+                assert sd.udev_rule_exists() is True
+
+    def test_returns_false_when_file_absent(self):
+        with tempfile.TemporaryDirectory() as d:
+            absent = Path(d) / "99-whisper-wayland.rules"
+            with mock.patch.object(sd, "_UDEV_RULE_PATH", absent):
+                assert sd.udev_rule_exists() is False
+
+
+# ── needs_setup ───────────────────────────────────────────────────────────────
+
+class TestNeedsSetup:
+
+    def test_false_when_devices_are_accessible(self):
+        with mock.patch.object(sd, "can_access_input_devices", return_value=True):
+            assert sd.needs_setup() is False
+
+    def test_true_when_devices_are_not_accessible(self):
+        with mock.patch.object(sd, "can_access_input_devices", return_value=False):
+            assert sd.needs_setup() is True
+
+
+# ── PermissionsSetupDialog smoke-test ─────────────────────────────────────────
+# Requires a display. Skipped automatically in headless environments.
+
+_HAS_DISPLAY = bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+
+
+@pytest.mark.skipif(not _HAS_DISPLAY, reason="No display available (headless)")
+class TestPermissionsSetupDialogSmoke:
+
+    @pytest.fixture(scope="class")
+    def qapp(self):
+        from PyQt6.QtWidgets import QApplication
+        app = QApplication.instance() or QApplication([])
+        yield app
+
+    def test_dialog_instantiates(self, qapp):
+        dlg = sd.PermissionsSetupDialog()
+        assert dlg is not None
+
+    def test_already_configured_flag_true(self, qapp):
+        with mock.patch.object(sd, "user_in_input_group", return_value=True), \
+             mock.patch.object(sd, "udev_rule_exists", return_value=True):
+            dlg = sd.PermissionsSetupDialog()
+            assert dlg._already_configured is True
+
+    def test_already_configured_flag_false(self, qapp):
+        with mock.patch.object(sd, "user_in_input_group", return_value=False), \
+             mock.patch.object(sd, "udev_rule_exists", return_value=False):
+            dlg = sd.PermissionsSetupDialog()
+            assert dlg._already_configured is False
+
+    def test_partially_configured_flag_false(self, qapp):
+        # One piece done, one missing → not "already configured" → show setup button
+        with mock.patch.object(sd, "user_in_input_group", return_value=True), \
+             mock.patch.object(sd, "udev_rule_exists", return_value=False):
+            dlg = sd.PermissionsSetupDialog()
+            assert dlg._already_configured is False


### PR DESCRIPTION
## Summary

Adds an automated, user-friendly permissions setup wizard that runs on first launch to configure global hotkey access. Instead of requiring users to manually run terminal commands and edit system files, the app now detects missing permissions and offers a one-click fix via polkit (pkexec) — no terminal needed.

## Key Changes

- **New `setup_dialog.py` module** — Provides:
  - Permission detection helpers (`can_access_input_devices()`, `user_in_input_group()`, `udev_rule_exists()`, `needs_setup()`)
  - `PermissionsSetupDialog` — A styled PyQt6 dialog that:
    - Detects whether setup is needed or already complete
    - Shows current permission status with visual indicators (✓/✗)
    - Runs the setup script via pkexec in a background thread
    - Provides clear feedback on success/failure
    - Guides users to log out and back in after setup
  - `_SetupWorker` — QThread that executes the setup script with proper error handling and timeout protection

- **Updated `main.py`** — Automatically shows the setup dialog on startup if `needs_setup()` returns True (non-modal, user can skip and still use the app)

- **Updated `tray_icon.py`** — Adds "🔑 Set Up Hotkeys…" menu action to allow users to re-open the wizard at any time

- **Updated `README.md`** — Removes manual setup instructions; directs users to use the automatic wizard instead

- **Comprehensive test suite** (`test_setup_dialog.py`) — Tests all permission-detection helpers with mocks, plus smoke tests for the dialog UI (skipped gracefully in headless CI)

## Implementation Details

- **Smart permission detection**: Probes up to 8 `/dev/input/event*` devices; returns True if any are accessible or if no devices exist (VMs)
- **Graceful degradation**: If pkexec is unavailable, provides fallback instructions for manual terminal setup
- **Non-blocking**: Dialog is non-modal; users can skip setup and still use the app via DBus/tray
- **Status awareness**: Distinguishes between "needs full setup" and "already configured, just needs re-login"
- **Styled UI**: Dark theme matching the app's aesthetic with clear visual hierarchy and status indicators

https://claude.ai/code/session_016uegs4FnGcxceYE5fgehdM