### PR TITLE
Add routing indicator badge to recording overlays

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A native, on-device voice-to-text tool for Linux with first-class Wayland suppor
 
 ### System & UI
 - **Transcription history** — persistent, searchable panel with one-click copy
-- **Swappable recording overlays** — Waveform, Pulse Circle, Voice Card, or drop in your own
+- **Swappable recording overlays** — Waveform, Pulse Circle, Voice Card, or drop in your own; each displays a **routing indicator badge** showing exactly which output target is active while you record
 - **Noise suppression** — optional `noisereduce` filter
 - **DBus interface** — control from Waybar, scripts, or Rofi
 - **Settings UI** — tabbed PyQt6 dialog covering all features
@@ -307,7 +307,21 @@ The visual overlay shown while recording is fully swappable. Three styles ship o
 
 Switch styles in **Settings → Appearance → Recording Overlay**. Changes take effect immediately — no restart needed.
 
-Build your own overlay by dropping a single Python file into `~/.config/whisper-wayland/overlays/`. Click **"Open Overlays Folder"** in Settings to go there directly. A ready-to-edit template (`_template.py`) is created automatically the first time you open the folder.
+### Routing Indicator Badge
+
+Every overlay displays a **routing indicator badge** while recording — a small label showing the human-readable name of the active output target (e.g. `Focused Window`, `Hermes Agent`, `Voice Journal`). This gives you an unambiguous, at-a-glance confirmation of where your speech is being sent before you say a word.
+
+- **Voice Card** — badge appears in the top-right corner of the card
+- **Waveform** — badge appears centered above the waveform box
+- **Pulse Circle** — badge appears centered above the pulse ring
+
+The badge text comes directly from the `label` field of the active `OutputTarget` in `targets.toml`. When you use multiple hotkeys to route to different destinations, the badge changes with each activation so you always know which route is live.
+
+Custom overlays receive the routing label through the `label` parameter of `show_mode(label)` and can use it however they like — or ignore it.
+
+### Building Custom Overlays
+
+Drop a single Python file into `~/.config/whisper-wayland/overlays/`. Click **"Open Overlays Folder"** in Settings to go there directly. A ready-to-edit template (`_template.py`) is created automatically the first time you open the folder.
 
 Full specification and examples: **[docs/overlays.md](docs/overlays.md)**
 

--- a/src/gui/overlay_manager.py
+++ b/src/gui/overlay_manager.py
@@ -78,8 +78,9 @@ class OverlayUI(QWidget):
         # Thread-safe repaint request:
         QMetaObject.invokeMethod(self, "update", Qt.ConnectionType.QueuedConnection)
 
-    def show_mode(self):
-        """Called when recording starts.  Expand to full screen."""
+    def show_mode(self, label: str = ""):
+        """Called when recording starts.  label is the routing target name (e.g. "Focused Window")."""
+        self._routing_label = label
         screen = QApplication.primaryScreen()
         if screen:
             g = screen.geometry()
@@ -136,10 +137,10 @@ class OverlayProxy:
             except Exception:
                 pass
 
-    def show_mode(self):
+    def show_mode(self, label: str = ""):
         if self._overlay is not None:
             try:
-                self._overlay.show_mode()
+                self._overlay.show_mode(label)
             except Exception:
                 pass
 

--- a/src/gui/overlays/base.py
+++ b/src/gui/overlays/base.py
@@ -67,8 +67,8 @@ class OverlayUIBase(QWidget):
         """Called from the audio thread with float32 PCM samples (~1024 per call, ±32768 range)."""
         raise NotImplementedError
 
-    def show_mode(self):
-        """Expand to full screen and become visible."""
+    def show_mode(self, label: str = ""):
+        """Expand to full screen and become visible.  label is the routing target name."""
         raise NotImplementedError
 
     def hide_mode(self):

--- a/src/gui/overlays/pulse.py
+++ b/src/gui/overlays/pulse.py
@@ -4,8 +4,8 @@ VERSION      = "1.0"
 
 import numpy as np
 from PyQt6.QtWidgets import QWidget, QApplication
-from PyQt6.QtCore import Qt, QTimer, QMetaObject
-from PyQt6.QtGui import QPainter, QColor, QBrush, QPen
+from PyQt6.QtCore import Qt, QTimer, QMetaObject, QRectF
+from PyQt6.QtGui import QPainter, QColor, QBrush, QPen, QFont, QFontMetrics
 
 from gui.overlays.base import OverlayUIBase
 
@@ -18,6 +18,7 @@ class OverlayUI(OverlayUIBase):
         super().__init__()
         self._amplitude = 0.0
         self._smooth_amp = 0.0
+        self._routing_label: str = ""
 
         self.setWindowFlags(
             Qt.WindowType.ToolTip |
@@ -75,7 +76,23 @@ class OverlayUI(OverlayUIBase):
         painter.setPen(Qt.PenStyle.NoPen)
         painter.drawEllipse(cx - inner_r, cy - inner_r, inner_r * 2, inner_r * 2)
 
-    def show_mode(self):
+        if self._routing_label:
+            badge_text = self._routing_label
+            badge_font = QFont("Segoe UI", 8, QFont.Weight.Medium)
+            painter.setFont(badge_font)
+            fm = QFontMetrics(badge_font)
+            badge_w = fm.horizontalAdvance(badge_text) + 16
+            badge_h = 18
+            max_r = base_r + 20 + 3 * 7  # outermost glow ring radius
+            badge_rect = QRectF(cx - badge_w / 2, cy - max_r - badge_h - 6, badge_w, badge_h)
+            painter.setBrush(QBrush(QColor(12, 15, 25, 230)))
+            painter.setPen(QPen(QColor(74, 158, 255, 200), 1))
+            painter.drawRoundedRect(badge_rect, 4, 4)
+            painter.setPen(QPen(QColor(160, 200, 255, 220)))
+            painter.drawText(badge_rect, Qt.AlignmentFlag.AlignCenter, badge_text)
+
+    def show_mode(self, label: str = ""):
+        self._routing_label = label
         screen = QApplication.primaryScreen()
         if screen:
             geom = screen.geometry()

--- a/src/gui/overlays/voice_card.py
+++ b/src/gui/overlays/voice_card.py
@@ -47,6 +47,8 @@ class OverlayUI(OverlayUIBase):
         self._n_bars = wf_w // (_BAR_W + _BAR_GAP)
         self._amplitudes: deque = deque([0.0] * self._n_bars, maxlen=self._n_bars)
 
+        self._routing_label: str = ""
+
         self._timer = QTimer(self)
         self._timer.timeout.connect(self.update)
         self._timer.start(30)
@@ -59,7 +61,8 @@ class OverlayUI(OverlayUIBase):
         rms = float(np.sqrt(np.mean(data.astype(np.float32) ** 2)))
         self._amplitudes.append(min(1.0, rms / 8192.0))
 
-    def show_mode(self):
+    def show_mode(self, label: str = ""):
+        self._routing_label = label
         screen = QApplication.primaryScreen()
         if screen:
             geom = screen.geometry()
@@ -96,8 +99,8 @@ class OverlayUI(OverlayUIBase):
         painter.setPen(QPen(QColor(130, 145, 170, 200)))
         painter.drawText(int(card_x) + 14, int(card_y) + 22, "Voice Activity")
 
-        # ── App badge (top-right) ────────────────────────────────────────
-        badge_text = "whisper / Wayland"
+        # ── Routing badge (top-right) ────────────────────────────────────
+        badge_text = self._routing_label or "whisper / Wayland"
         badge_font = QFont("Segoe UI", 9, QFont.Weight.Medium)
         painter.setFont(badge_font)
         fm = QFontMetrics(badge_font)

--- a/src/gui/overlays/waveform.py
+++ b/src/gui/overlays/waveform.py
@@ -5,8 +5,8 @@ VERSION      = "1.0"
 import numpy as np
 from PyQt6.QtWidgets import QWidget, QVBoxLayout
 from PyQt6.QtOpenGLWidgets import QOpenGLWidget
-from PyQt6.QtCore import Qt, QMetaObject, QRect
-from PyQt6.QtGui import QColor, QSurfaceFormat, QPainter, QBrush, QPen
+from PyQt6.QtCore import Qt, QMetaObject, QRect, QRectF
+from PyQt6.QtGui import QColor, QSurfaceFormat, QPainter, QBrush, QPen, QFont, QFontMetrics
 from OpenGL.GL import *
 from OpenGL.GL import shaders
 
@@ -121,6 +121,8 @@ class OverlayUI(OverlayUIBase):
         self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents)
         self.setStyleSheet("border: 1px solid transparent;")
 
+        self._routing_label: str = ""
+
         self.gl_widget = _WaveformGLWidget()
         self.gl_widget.setFixedSize(70, 70)
         self.gl_widget.setAttribute(Qt.WidgetAttribute.WA_AlwaysStackOnTop)
@@ -144,14 +146,30 @@ class OverlayUI(OverlayUIBase):
         painter = QPainter(self)
         painter.setRenderHint(QPainter.RenderHint.Antialiasing)
         box_width, box_height = 70, 70
-        x = (self.width() - box_width) // 2
+        cx = self.width() // 2
+        x = cx - box_width // 2
         y = self.height() - box_height - 100
         box_rect = QRect(x, y, box_width, box_height).adjusted(1, 1, -1, -1)
         painter.setBrush(QBrush(QColor(0, 0, 0, 230)))
         painter.setPen(QPen(QColor(68, 68, 68), 1))
         painter.drawRoundedRect(box_rect, 15, 15)
 
-    def show_mode(self):
+        if self._routing_label:
+            badge_text = self._routing_label
+            badge_font = QFont("Segoe UI", 8, QFont.Weight.Medium)
+            painter.setFont(badge_font)
+            fm = QFontMetrics(badge_font)
+            badge_w = fm.horizontalAdvance(badge_text) + 16
+            badge_h = 18
+            badge_rect = QRectF(cx - badge_w / 2, y - badge_h - 4, badge_w, badge_h)
+            painter.setBrush(QBrush(QColor(12, 15, 25, 230)))
+            painter.setPen(QPen(QColor(55, 190, 155, 200), 1))
+            painter.drawRoundedRect(badge_rect, 4, 4)
+            painter.setPen(QPen(QColor(165, 215, 200, 220)))
+            painter.drawText(badge_rect, Qt.AlignmentFlag.AlignCenter, badge_text)
+
+    def show_mode(self, label: str = ""):
+        self._routing_label = label
         from PyQt6.QtWidgets import QApplication
         screen = QApplication.primaryScreen()
         if screen:

--- a/src/main.py
+++ b/src/main.py
@@ -171,8 +171,10 @@ def main():
         listener = InputListener(config, on_press, on_release)
 
         # UI Toggles
-        def show_recording_ui():
-            overlay_proxy.show_mode()
+        def show_recording_ui(target_id: str = ""):
+            tgt = router.get_target(target_id)
+            label = tgt.label if tgt else ""
+            overlay_proxy.show_mode(label)
 
         def hide_recording_ui():
             overlay_proxy.hide_mode()


### PR DESCRIPTION
## Summary
This PR adds a **routing indicator badge** to all recording overlays, displaying the active output target name (e.g., "Focused Window", "Hermes Agent") while recording. This gives users an at-a-glance confirmation of where their speech is being routed before they start speaking.

## Key Changes

- **Overlay base class** (`base.py`): Updated `show_mode()` signature to accept an optional `label` parameter representing the routing target name
- **Waveform overlay** (`waveform.py`): 
  - Added `_routing_label` instance variable
  - Renders a centered badge above the waveform box with teal accent color
  - Updated `show_mode()` to accept and store the routing label
- **Pulse Circle overlay** (`pulse.py`):
  - Added `_routing_label` instance variable
  - Renders a centered badge above the pulse ring with blue accent color
  - Updated `show_mode()` to accept and store the routing label
- **Voice Card overlay** (`voice_card.py`):
  - Added `_routing_label` instance variable
  - Replaced static "whisper / Wayland" badge text with dynamic routing label (falls back to static text if no label provided)
  - Updated `show_mode()` to accept and store the routing label
- **Overlay manager** (`overlay_manager.py`): Updated `show_mode()` calls to pass the routing label through to underlying overlays
- **Main entry point** (`main.py`): Modified `show_recording_ui()` to retrieve the target label from the router and pass it to the overlay
- **Documentation** (`README.md`): Added new "Routing Indicator Badge" section explaining the feature and how custom overlays can use it

## Implementation Details

- Badge styling is consistent across overlays: dark background (RGB 12, 15, 25) with colored borders and text
- Badge positioning is overlay-specific: top-right for Voice Card, centered above for Waveform and Pulse Circle
- Font used: Segoe UI, 8pt, Medium weight
- Badge dimensions are calculated dynamically based on text width
- The feature is backward-compatible: overlays without a label simply don't display the badge
- Custom overlays can implement the feature by reading the `label` parameter in their `show_mode()` method

https://claude.ai/code/session_019fjFxtxmsPs4bMZAPmCjah