### PR TITLE
Add AT-SPI2 accessibility integration for context-aware dictation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ A native, on-device voice-to-text tool for Linux with first-class Wayland suppor
 - **Response loopback** — per-target `response_pipe` FIFO: agents write responses there and they are spoken automatically
 - Full documentation: **[docs/mcp_documentation.md](docs/mcp_documentation.md)**
 
+### AT-SPI2 Accessibility Integration (optional)
+- **Direct text insertion** — injects transcribed text via `AT-SPI2 Text.insertText` instead of simulating keystrokes; no modifier-key conflicts, no need for `wtype` or `xdotool`
+- **Context-aware transcription** — reads the text preceding your cursor at recording start and passes it to Whisper as an `initial_prompt`, improving accuracy by priming the model with your document's vocabulary and style
+- **Auto code mode** — automatically switches to code dictation mode when a terminal or IDE text widget is focused, without changing your global Settings
+
 ### System & UI
 - **Transcription history** — persistent, searchable panel with one-click copy
 - **Swappable recording overlays** — Waveform, Pulse Circle, Voice Card, or drop in your own; each displays a **routing indicator badge** showing exactly which output target is active while you record
@@ -102,6 +107,13 @@ pip install noisereduce
 
 # Optional: DBus control interface
 pip install dbus-python
+
+# Optional: AT-SPI2 accessibility integration (focus tracking, context-aware
+# transcription, direct text insertion — see section below)
+# Arch Linux:
+sudo pacman -S python-atspi
+# Debian / Ubuntu:
+# sudo apt install python3-pyatspi
 
 # Optional: NVIDIA GPU acceleration
 pip install nvidia-cublas-cu12 nvidia-cudnn-cu12
@@ -186,6 +198,58 @@ pip install pywhispercpp
 # For Vulkan-enabled builds, install from source:
 GGML_VULKAN=1 pip install git+https://github.com/abdeladim-s/pywhispercpp
 ```
+
+---
+
+## AT-SPI2 Accessibility Integration
+
+AT-SPI2 (Assistive Technology Service Provider Interface) is the standard Linux accessibility bus. When the optional `pyatspi` library is installed, Whisper-Wayland gains three capabilities that work transparently alongside the existing injection chain.
+
+### Installation
+
+```bash
+# Arch Linux
+sudo pacman -S python-atspi
+
+# Debian / Ubuntu
+sudo apt install python3-pyatspi
+```
+
+No restart is needed — the module is loaded at startup and gracefully disabled when the library is absent.
+
+### What it does
+
+#### 1. Direct text insertion (no keystrokes)
+
+When AT-SPI2 is available, transcribed text is inserted directly into the focused widget via the `AT-SPI2 Text.insertText` interface instead of simulating key events with `wtype` or `xdotool`. This eliminates the modifier-key conflicts that can occur when a hotkey is released at the same time virtual keyboard events are sent.
+
+The app falls back automatically to `wtype` → portal → `xdotool` → clipboard for widgets that do not expose the `Text` interface (e.g. Electron apps, native terminal emulators using raw PTY I/O).
+
+#### 2. Context-aware transcription
+
+When you press your recording hotkey, Whisper-Wayland reads up to 300 characters of text immediately before the cursor in the focused widget and passes it to Whisper as an `initial_prompt`. This primes the model with your document's vocabulary, spelling, and sentence style, reducing errors on specialised terminology and proper nouns without any manual prompt configuration.
+
+#### 3. Auto code mode
+
+When the focused widget is a terminal or IDE text area (AT-SPI2 role `terminal` or `text`), the app automatically switches to **code dictation mode** for that recording session. Spoken constructs are converted to syntax (`"get underscore user dot name"` → `get_user.name`) without changing your global Settings. The mode resets to your configured default on the next recording.
+
+### Configuration
+
+All three behaviours are individually switchable in `~/.config/whisper-wayland/config.json`:
+
+```json
+{
+  "atspi_injection":       true,
+  "atspi_context_prompt":  true,
+  "atspi_auto_code_mode":  true
+}
+```
+
+| Key | Default | Description |
+|---|---|---|
+| `atspi_injection` | `true` | Try AT-SPI2 `insertText` before falling back to `wtype`/`xdotool` |
+| `atspi_context_prompt` | `true` | Feed surrounding text to Whisper as `initial_prompt` at recording start |
+| `atspi_auto_code_mode` | `true` | Switch to code dictation mode when a terminal/IDE widget is focused |
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,3 +56,6 @@ typer==0.24.1
 typing_extensions==4.15.0
 # Optional: install for in-process whisper.cpp (lower latency than subprocess)
 # pywhispercpp>=1.2.0
+# Optional: install for AT-SPI2 accessibility integration (focus tracking, context-aware
+# transcription, direct text insertion). Arch: python-atspi; Debian/Ubuntu: python3-pyatspi
+# pyatspi

--- a/src/atspi_context.py
+++ b/src/atspi_context.py
@@ -1,0 +1,198 @@
+"""AT-SPI2 accessibility integration for context-aware dictation.
+
+Provides three capabilities:
+  - Focus tracking: remembers the last focused accessible widget via an event listener.
+  - Context reading: returns the app name, widget role, and text preceding the cursor.
+  - Text injection: inserts text directly via the AT-SPI2 Text interface, bypassing
+    keypress simulation and avoiding modifier-key conflicts.
+
+All public symbols degrade gracefully when pyatspi is not installed.
+"""
+
+import logging
+import threading
+from typing import NamedTuple, Optional
+
+logger = logging.getLogger(__name__)
+
+try:
+    import pyatspi  # python-atspi on Arch; python3-pyatspi on Debian/Ubuntu
+    _AVAILABLE = True
+except ImportError:
+    _AVAILABLE = False
+    logger.debug("pyatspi not installed; AT-SPI2 integration disabled")
+
+# Roles that are typically code/terminal contexts → suggest code dictation mode
+_CODE_ROLES = frozenset({
+    "terminal",
+    "text",          # generic editable text (often IDEs)
+})
+
+# Roles of widgets that implement the AT-SPI2 Text interface
+_TEXT_ROLES = frozenset({
+    "entry",
+    "text",
+    "terminal",
+    "paragraph",
+    "document frame",
+    "document web",
+    "document email content",
+    "spin button",
+    "combo box",
+    "editable combo box",
+})
+
+
+class FocusContext(NamedTuple):
+    """Snapshot of the focused accessible widget at a point in time."""
+    app_name: str
+    role_name: str
+    surrounding_text: str  # text before the caret, up to max_chars
+    cursor_offset: int
+    is_code_context: bool  # True when terminal/IDE-like role detected
+
+
+# ── internal state ────────────────────────────────────────────────────────────
+
+_focused: object = None   # pyatspi.Accessible (or None)
+_lock = threading.Lock()
+_running = False
+
+
+# ── lifecycle ─────────────────────────────────────────────────────────────────
+
+def is_available() -> bool:
+    """Return True when pyatspi is importable."""
+    return _AVAILABLE
+
+
+def start() -> None:
+    """Start the AT-SPI2 event listener in a background daemon thread.
+
+    Safe to call multiple times; subsequent calls are no-ops.
+    """
+    global _running
+    if not _AVAILABLE or _running:
+        return
+    try:
+        pyatspi.Registry.registerEventListener(
+            _on_focus_changed, "object:state-changed:focused"
+        )
+        t = threading.Thread(target=_run_loop, daemon=True, name="atspi-loop")
+        t.start()
+        _running = True
+        logger.info("AT-SPI2 focus tracker started")
+    except Exception as exc:
+        logger.warning("AT-SPI2 start failed: %s", exc)
+
+
+def stop() -> None:
+    """Deregister the focus listener and stop the AT-SPI2 event loop."""
+    global _running
+    if not _AVAILABLE or not _running:
+        return
+    try:
+        pyatspi.Registry.deregisterEventListener(
+            _on_focus_changed, "object:state-changed:focused"
+        )
+        pyatspi.Registry.stop()
+    except Exception:
+        pass
+    _running = False
+    logger.debug("AT-SPI2 focus tracker stopped")
+
+
+def _run_loop() -> None:
+    """Entry point for the daemon thread; runs the AT-SPI2 GLib event loop."""
+    try:
+        pyatspi.Registry.start()
+    except Exception as exc:
+        logger.debug("AT-SPI2 event loop exited: %s", exc)
+
+
+def _on_focus_changed(event) -> None:
+    """Called by the AT-SPI2 event loop when a widget gains or loses focus."""
+    global _focused
+    if event.detail1:  # detail1 == 1 → gained focus
+        with _lock:
+            _focused = event.source
+
+
+# ── public API ────────────────────────────────────────────────────────────────
+
+def get_focused_context(max_chars: int = 500) -> Optional[FocusContext]:
+    """Return a FocusContext snapshot for the currently focused widget.
+
+    Returns None when AT-SPI2 is unavailable or no widget is tracked yet.
+    The ``surrounding_text`` field contains up to *max_chars* characters
+    immediately before the caret — useful as a Whisper initial_prompt.
+    """
+    if not _AVAILABLE:
+        return None
+    with _lock:
+        focused = _focused
+    if focused is None:
+        return None
+    try:
+        app_name = _safe_app_name(focused)
+        role_name = _safe_role(focused)
+        surrounding_text, cursor_offset = _safe_text(focused, max_chars)
+        is_code = role_name in _CODE_ROLES
+        return FocusContext(app_name, role_name, surrounding_text, cursor_offset, is_code)
+    except Exception as exc:
+        logger.debug("get_focused_context error: %s", exc)
+        return None
+
+
+def inject_text(text: str) -> bool:
+    """Insert *text* at the caret position via the AT-SPI2 Text interface.
+
+    Returns True on success, False when the focused widget does not expose
+    the Text interface or when AT-SPI2 is unavailable. Falls back silently
+    so callers can chain to wtype / xdotool.
+    """
+    if not _AVAILABLE or not text:
+        return False
+    with _lock:
+        focused = _focused
+    if focused is None:
+        return False
+    try:
+        text_iface = focused.queryText()
+        offset = text_iface.caretOffset
+        ok = bool(text_iface.insertText(offset, text, len(text)))
+        if ok:
+            logger.debug("AT-SPI2 injected %d chars at offset %d", len(text), offset)
+        return ok
+    except Exception as exc:
+        logger.debug("AT-SPI2 inject_text failed: %s", exc)
+        return False
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _safe_app_name(accessible) -> str:
+    try:
+        app = accessible.getApplication()
+        return app.name if app else ""
+    except Exception:
+        return ""
+
+
+def _safe_role(accessible) -> str:
+    try:
+        return accessible.getRoleName()
+    except Exception:
+        return ""
+
+
+def _safe_text(accessible, max_chars: int) -> tuple[str, int]:
+    """Return (surrounding_text, cursor_offset) or ("", 0) on failure."""
+    try:
+        iface = accessible.queryText()
+        offset = iface.caretOffset
+        start = max(0, offset - max_chars)
+        text = iface.getText(start, offset)
+        return text, offset
+    except Exception:
+        return "", 0

--- a/src/config.py
+++ b/src/config.py
@@ -49,6 +49,10 @@ DEFAULT_CONFIG = {
     # MCP Server
     "mcp_server_enabled": False,
     "mcp_record_timeout": 15.0,         # max seconds for MCP-triggered recording
+    # AT-SPI2 accessibility integration (requires: pip install pyatspi)
+    "atspi_injection": True,            # try AT-SPI2 Text.insertText before wtype/xdotool
+    "atspi_context_prompt": True,       # feed surrounding text to Whisper as initial_prompt
+    "atspi_auto_code_mode": True,       # auto-switch to code mode for terminal/IDE widgets
 }
 
 CONFIG_PATH = Path.home() / ".config" / "whisper-wayland" / "config.json"

--- a/src/inference_engine.py
+++ b/src/inference_engine.py
@@ -97,6 +97,7 @@ class InferenceEngine(threading.Thread):
         self._current_target_id: str = 'default'
         self._current_post_processing: str = 'default'
         self._current_initial_prompt_override: str | None = None
+        self._atspi_context_at_start = None  # FocusContext snapshot taken on recording start
 
         # P2.1: LLM post-processor (probe happens lazily on first use)
         self.llm = LLMPostprocessor(config)
@@ -230,10 +231,20 @@ class InferenceEngine(threading.Thread):
     def _build_initial_prompt(self):
         if self._current_initial_prompt_override is not None:
             return self._current_initial_prompt_override
+
+        parts = []
+
+        # Prepend surrounding text captured at recording start so Whisper can
+        # match vocabulary and sentence style to the current document context.
+        ctx = self._atspi_context_at_start
+        if ctx and ctx.surrounding_text.strip():
+            parts.append(ctx.surrounding_text.strip())
+
         vocab = self.config.get("custom_vocabulary", [])
-        if not vocab:
-            return None
-        return ", ".join(vocab)
+        if vocab:
+            parts.append(", ".join(vocab))
+
+        return " ".join(parts) if parts else None
 
     def _apply_spoken_punctuation(self, text):
         for pattern, symbol in _PUNCT_MAP:
@@ -284,6 +295,8 @@ class InferenceEngine(threading.Thread):
 
         # 'default' or unknown: full pipeline
         mode = self.config.get("dictation_mode", "normal")
+        if getattr(self, '_atspi_forced_code_mode', False):
+            mode = "code"
         if mode == "code":
             text = self._apply_code_mode(text)
         else:
@@ -307,10 +320,32 @@ class InferenceEngine(threading.Thread):
             self._current_target_id = target_id
             self._current_post_processing = post_processing
             self._current_initial_prompt_override = initial_prompt_override
+            self._atspi_context_at_start = self._capture_atspi_context()
         else:
             self.process_buffer(incremental=False)
             with self._buffer_lock:
                 self.buffer.clear()
+
+    def _capture_atspi_context(self):
+        """Snapshot the focused widget's AT-SPI2 context at the moment recording starts."""
+        if not self.config.get('atspi_context_prompt', True):
+            return None
+        try:
+            import atspi_context
+            ctx = atspi_context.get_focused_context(max_chars=300)
+            if ctx is None:
+                return None
+            # Auto-switch to code mode when focused on a terminal or IDE text widget,
+            # unless the user has explicitly overridden dictation_mode in settings.
+            if (ctx.is_code_context
+                    and self.config.get('atspi_auto_code_mode', True)
+                    and self.config.get('dictation_mode', 'normal') == 'normal'):
+                self._atspi_forced_code_mode = True
+            else:
+                self._atspi_forced_code_mode = False
+            return ctx
+        except Exception:
+            return None
 
     @property
     def last_language(self):

--- a/src/main.py
+++ b/src/main.py
@@ -26,6 +26,12 @@ from gui.overlay_manager import OverlayManager, OverlayProxy
 from gui.setup_dialog import needs_setup, PermissionsSetupDialog
 from gui.overlays.tts_response import TTSResponseOverlay
 
+try:
+    import atspi_context
+    _HAS_ATSPI = True
+except ImportError:
+    _HAS_ATSPI = False
+
 @contextlib.contextmanager
 def ignore_stderr():
     devnull = os.open(os.devnull, os.O_WRONLY)
@@ -309,6 +315,10 @@ def main():
         else:
             tray.show()
 
+        # Start AT-SPI2 focus tracker (no-op when pyatspi is not installed)
+        if _HAS_ATSPI:
+            atspi_context.start()
+
         # Start threads
         recorder.start()
         inference.start()
@@ -327,6 +337,8 @@ def main():
         sys.exit(1)
     finally:
         try:
+            if _HAS_ATSPI:
+                atspi_context.stop()
             listener.stop()
             recorder.stop()
             inference.stop()

--- a/src/text_injector.py
+++ b/src/text_injector.py
@@ -11,6 +11,12 @@ try:
 except ImportError:
     _HAS_PORTAL = False
 
+try:
+    import atspi_context as _atspi
+    _HAS_ATSPI = True
+except ImportError:
+    _HAS_ATSPI = False
+
 # Word count accumulator for P0.6 (session stats)
 _session_word_count = 0
 
@@ -81,6 +87,11 @@ class TextInjector(threading.Thread):
         # Short pause so the hotkey's physical key-up events propagate to the
         # compositor before we send virtual keyboard events on top of them.
         time.sleep(0.12)
+
+        # --- AT-SPI2: direct Text.insertText (no keystrokes, no modifier issues) ---
+        if not injected and _HAS_ATSPI and self.config.get('atspi_injection', True):
+            if _atspi.is_available() and _atspi.inject_text(text):
+                injected = True
 
         # --- Wayland: release modifiers first, then type ---
         if is_wayland and shutil.which('wtype'):

--- a/tests/test_atspi_context.py
+++ b/tests/test_atspi_context.py
@@ -1,0 +1,357 @@
+"""Tests for the AT-SPI2 accessibility integration module (src/atspi_context.py).
+
+All tests use unittest.mock to simulate pyatspi so they run regardless of
+whether the library is installed on the test host.
+"""
+import os
+import sys
+import threading
+import types
+import unittest
+from unittest.mock import MagicMock, patch, PropertyMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build a minimal fake pyatspi module
+# ---------------------------------------------------------------------------
+
+def _make_pyatspi_stub():
+    """Return a minimal pyatspi stub with a controllable Registry."""
+    stub = types.ModuleType("pyatspi")
+
+    class _Registry:
+        _listeners: dict = {}
+        _started = False
+
+        @classmethod
+        def registerEventListener(cls, callback, event_type):
+            cls._listeners[event_type] = callback
+
+        @classmethod
+        def deregisterEventListener(cls, callback, event_type):
+            cls._listeners.pop(event_type, None)
+
+        @classmethod
+        def start(cls):
+            cls._started = True
+
+        @classmethod
+        def stop(cls):
+            cls._started = False
+
+    stub.Registry = _Registry
+    stub.STATE_FOCUSED = 1
+    return stub
+
+
+def _make_accessible(app_name="TestApp", role_name="entry",
+                     text_content="hello world", caret_offset=11,
+                     insert_result=True):
+    """Return a mock pyatspi Accessible with a queryText() interface."""
+    text_iface = MagicMock()
+    text_iface.caretOffset = caret_offset
+    text_iface.getText = MagicMock(return_value=text_content)
+    text_iface.insertText = MagicMock(return_value=insert_result)
+
+    app = MagicMock()
+    app.name = app_name
+
+    accessible = MagicMock()
+    accessible.getApplication = MagicMock(return_value=app)
+    accessible.getRoleName = MagicMock(return_value=role_name)
+    accessible.queryText = MagicMock(return_value=text_iface)
+    return accessible, text_iface
+
+
+# ---------------------------------------------------------------------------
+# Re-import atspi_context with a fresh module state for each test class
+# ---------------------------------------------------------------------------
+
+def _fresh_module(pyatspi_stub=None):
+    """Import atspi_context into a clean module namespace, optionally injecting pyatspi."""
+    # Remove any cached version so importlib gives us a fresh one
+    for key in list(sys.modules.keys()):
+        if 'atspi_context' in key:
+            del sys.modules[key]
+
+    if pyatspi_stub is not None:
+        sys.modules['pyatspi'] = pyatspi_stub
+    else:
+        sys.modules.pop('pyatspi', None)
+
+    import atspi_context
+    return atspi_context
+
+
+# ===========================================================================
+# Tests that run WITHOUT pyatspi installed (graceful degradation)
+# ===========================================================================
+
+class TestWithoutPyatspi:
+    """All public functions must be no-ops when pyatspi is absent."""
+
+    def setup_method(self):
+        self.mod = _fresh_module(pyatspi_stub=None)
+
+    def teardown_method(self):
+        sys.modules.pop('pyatspi', None)
+
+    def test_is_available_false(self):
+        assert self.mod.is_available() is False
+
+    def test_get_focused_context_returns_none(self):
+        assert self.mod.get_focused_context() is None
+
+    def test_inject_text_returns_false(self):
+        assert self.mod.inject_text("hello") is False
+
+    def test_start_is_noop(self):
+        self.mod.start()   # must not raise
+        assert self.mod._running is False
+
+    def test_stop_is_noop(self):
+        self.mod.stop()    # must not raise
+
+
+# ===========================================================================
+# Tests that run WITH a pyatspi stub
+# ===========================================================================
+
+class TestWithPyatspi:
+    """Behaviour when pyatspi is present."""
+
+    def setup_method(self):
+        self.stub = _make_pyatspi_stub()
+        self.stub.Registry._listeners.clear()
+        self.stub.Registry._started = False
+        self.mod = _fresh_module(pyatspi_stub=self.stub)
+
+    def teardown_method(self):
+        # Reset module state
+        self.mod._running = False
+        self.mod._focused = None
+        sys.modules.pop('pyatspi', None)
+        for key in list(sys.modules.keys()):
+            if 'atspi_context' in key:
+                del sys.modules[key]
+
+    # --- is_available -------------------------------------------------------
+
+    def test_is_available_true(self):
+        assert self.mod.is_available() is True
+
+    # --- start / stop -------------------------------------------------------
+
+    def test_start_registers_listener(self):
+        self.mod.start()
+        assert 'object:state-changed:focused' in self.stub.Registry._listeners
+
+    def test_start_sets_running(self):
+        self.mod.start()
+        assert self.mod._running is True
+
+    def test_start_is_idempotent(self):
+        self.mod.start()
+        self.mod.start()   # second call must be a no-op
+        assert self.mod._running is True
+
+    def test_stop_deregisters_listener(self):
+        self.mod.start()
+        self.mod.stop()
+        assert 'object:state-changed:focused' not in self.stub.Registry._listeners
+
+    def test_stop_clears_running(self):
+        self.mod.start()
+        self.mod.stop()
+        assert self.mod._running is False
+
+    # --- focus event handling -----------------------------------------------
+
+    def test_focus_gained_updates_focused(self):
+        accessible, _ = _make_accessible()
+        event = MagicMock()
+        event.detail1 = 1
+        event.source = accessible
+
+        self.mod._on_focus_changed(event)
+        assert self.mod._focused is accessible
+
+    def test_focus_lost_does_not_clear_focused(self):
+        accessible, _ = _make_accessible()
+        # First set a focused widget
+        gained = MagicMock()
+        gained.detail1 = 1
+        gained.source = accessible
+        self.mod._on_focus_changed(gained)
+
+        # Now send a "lost focus" event — _focused must stay the same
+        lost = MagicMock()
+        lost.detail1 = 0
+        lost.source = accessible
+        self.mod._on_focus_changed(lost)
+        assert self.mod._focused is accessible
+
+    # --- get_focused_context ------------------------------------------------
+
+    def test_returns_none_when_no_focused_widget(self):
+        self.mod._focused = None
+        assert self.mod.get_focused_context() is None
+
+    def test_returns_focus_context_fields(self):
+        accessible, text_iface = _make_accessible(
+            app_name="Firefox",
+            role_name="entry",
+            text_content="type something here",
+            caret_offset=19,
+        )
+        self.mod._focused = accessible
+
+        ctx = self.mod.get_focused_context(max_chars=500)
+
+        assert ctx is not None
+        assert ctx.app_name == "Firefox"
+        assert ctx.role_name == "entry"
+        assert ctx.surrounding_text == "type something here"
+        assert ctx.cursor_offset == 19
+
+    def test_surrounding_text_sliced_to_max_chars(self):
+        long_text = "a" * 1000
+        accessible, text_iface = _make_accessible(
+            text_content=long_text[-300:],  # getText is called with (offset-max, offset)
+            caret_offset=1000,
+        )
+        self.mod._focused = accessible
+
+        ctx = self.mod.get_focused_context(max_chars=300)
+        # getText should be called with start=max(0, 1000-300)=700, end=1000
+        text_iface.getText.assert_called_once_with(700, 1000)
+
+    def test_is_code_context_for_terminal_role(self):
+        accessible, _ = _make_accessible(role_name="terminal")
+        self.mod._focused = accessible
+        ctx = self.mod.get_focused_context()
+        assert ctx.is_code_context is True
+
+    def test_is_code_context_false_for_entry_role(self):
+        accessible, _ = _make_accessible(role_name="entry")
+        self.mod._focused = accessible
+        ctx = self.mod.get_focused_context()
+        assert ctx.is_code_context is False
+
+    def test_get_context_survives_querytext_failure(self):
+        """get_focused_context must not raise when Text interface is unavailable."""
+        accessible, _ = _make_accessible()
+        accessible.queryText = MagicMock(side_effect=NotImplementedError)
+        self.mod._focused = accessible
+
+        ctx = self.mod.get_focused_context()
+        assert ctx is not None
+        assert ctx.surrounding_text == ""
+        assert ctx.cursor_offset == 0
+
+    def test_get_context_survives_getapplication_failure(self):
+        accessible, _ = _make_accessible()
+        accessible.getApplication = MagicMock(side_effect=Exception("dbus error"))
+        self.mod._focused = accessible
+
+        ctx = self.mod.get_focused_context()
+        assert ctx is not None
+        assert ctx.app_name == ""
+
+    # --- inject_text --------------------------------------------------------
+
+    def test_inject_text_returns_false_when_no_focused(self):
+        self.mod._focused = None
+        assert self.mod.inject_text("hello") is False
+
+    def test_inject_text_calls_insert_at_caret(self):
+        accessible, text_iface = _make_accessible(caret_offset=5, insert_result=True)
+        self.mod._focused = accessible
+
+        result = self.mod.inject_text("world")
+
+        assert result is True
+        text_iface.insertText.assert_called_once_with(5, "world", 5)
+
+    def test_inject_text_returns_false_on_no_text_interface(self):
+        accessible, _ = _make_accessible()
+        accessible.queryText = MagicMock(side_effect=NotImplementedError)
+        self.mod._focused = accessible
+
+        assert self.mod.inject_text("hello") is False
+
+    def test_inject_text_returns_false_when_insert_fails(self):
+        accessible, text_iface = _make_accessible(insert_result=False)
+        self.mod._focused = accessible
+
+        assert self.mod.inject_text("hello") is False
+
+    def test_inject_empty_string_returns_false(self):
+        accessible, _ = _make_accessible()
+        self.mod._focused = accessible
+        assert self.mod.inject_text("") is False
+
+    # --- thread safety -------------------------------------------------------
+
+    def test_concurrent_focus_updates_are_safe(self):
+        """Rapid concurrent focus changes must not corrupt _focused."""
+        errors = []
+
+        def spam_focus_events(accessible):
+            for _ in range(200):
+                event = MagicMock()
+                event.detail1 = 1
+                event.source = accessible
+                try:
+                    self.mod._on_focus_changed(event)
+                except Exception as exc:
+                    errors.append(exc)
+
+        a1, _ = _make_accessible(app_name="App1")
+        a2, _ = _make_accessible(app_name="App2")
+        t1 = threading.Thread(target=spam_focus_events, args=(a1,))
+        t2 = threading.Thread(target=spam_focus_events, args=(a2,))
+        t1.start(); t2.start()
+        t1.join(); t2.join()
+
+        assert not errors
+        # _focused must be one of the two valid accessibles
+        assert self.mod._focused in (a1, a2)
+
+
+# ===========================================================================
+# FocusContext namedtuple
+# ===========================================================================
+
+class TestFocusContextNamedTuple:
+    def setup_method(self):
+        self.stub = _make_pyatspi_stub()
+        self.mod = _fresh_module(pyatspi_stub=self.stub)
+
+    def teardown_method(self):
+        sys.modules.pop('pyatspi', None)
+        for key in list(sys.modules.keys()):
+            if 'atspi_context' in key:
+                del sys.modules[key]
+
+    def test_fields(self):
+        ctx = self.mod.FocusContext(
+            app_name="Gedit",
+            role_name="text",
+            surrounding_text="some text",
+            cursor_offset=9,
+            is_code_context=False,
+        )
+        assert ctx.app_name == "Gedit"
+        assert ctx.role_name == "text"
+        assert ctx.surrounding_text == "some text"
+        assert ctx.cursor_offset == 9
+        assert ctx.is_code_context is False
+
+    def test_is_namedtuple(self):
+        ctx = self.mod.FocusContext("A", "b", "c", 0, False)
+        # NamedTuples support indexing
+        assert ctx[0] == "A"
+        assert ctx[1] == "b"


### PR DESCRIPTION
## Summary

Adds optional AT-SPI2 (Assistive Technology Service Provider Interface) integration to enable three new capabilities: direct text insertion via the AT-SPI2 Text interface, context-aware transcription using surrounding text as a Whisper initial prompt, and automatic code mode detection when focused on terminal/IDE widgets.

## Key Changes

- **New module `src/atspi_context.py`**: Provides focus tracking, context reading, and text injection via AT-SPI2
  - `is_available()`: Returns True when pyatspi is installed
  - `start()/stop()`: Manages the AT-SPI2 event listener and GLib event loop
  - `get_focused_context()`: Returns a `FocusContext` snapshot with app name, widget role, surrounding text, and cursor offset
  - `inject_text()`: Inserts text directly via the Text interface, bypassing keystroke simulation
  - `FocusContext` NamedTuple: Captures focused widget state including `is_code_context` flag for terminal/IDE detection
  - Thread-safe focus tracking with graceful degradation when pyatspi is unavailable

- **Integration in `src/inference_engine.py`**:
  - Captures AT-SPI2 context at recording start (`_atspi_context_at_start`)
  - Prepends surrounding text to the initial prompt for Whisper, improving accuracy on specialized terminology
  - Auto-switches to code dictation mode when focused on terminal/IDE widgets (configurable)

- **Integration in `src/text_injector.py`**:
  - Attempts AT-SPI2 text insertion before falling back to wtype/xdotool
  - Eliminates modifier-key conflicts from keystroke simulation

- **Integration in `src/main.py`**:
  - Starts AT-SPI2 focus tracker on app startup
  - Stops tracker on shutdown

- **Configuration in `src/config.json`**:
  - `atspi_injection`: Enable/disable direct text insertion (default: true)
  - `atspi_context_prompt`: Enable/disable surrounding text as initial prompt (default: true)
  - `atspi_auto_code_mode`: Enable/disable automatic code mode on terminal/IDE focus (default: true)

- **Comprehensive test suite in `tests/test_atspi_context.py`**:
  - 357 lines of tests covering graceful degradation when pyatspi is absent
  - Focus event handling, context reading, text injection, and thread safety
  - Mock-based testing that runs without requiring pyatspi installation

- **Documentation in `README.md`**:
  - Installation instructions for Arch Linux and Debian/Ubuntu
  - Detailed explanation of the three capabilities
  - Configuration reference table

## Implementation Details

- All public functions degrade gracefully when pyatspi is not installed; no hard dependency
- Thread-safe focus tracking using a lock to protect the `_focused` state
- Event listener only captures focus-gained events (detail1 == 1); focus-lost events are ignored to preserve context
- Text injection falls back silently to existing injection chain (wtype → portal → xdotool → clipboard)
- Context snapshot is taken at recording start to ensure consistent initial prompt throughout transcription
- Auto code mode respects user's explicit `dictation_mode` setting if overridden

https://claude.ai/code/session_01RG5eDcG2bhPYia3SB62r5G