### PR TITLE
Add install-deps.sh script for dependency management

### DIFF
--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Install Python dependencies for VoxCtl.
+#
+# On modern distros (Ubuntu 23.04+, Debian 12+, Arch, etc.) the system Python is
+# "externally managed" and plain `pip install` is blocked. This script handles
+# that by preferring a virtual environment. Pass --system to force a system-wide
+# install instead (requires --break-system-packages).
+#
+# Usage:
+#   ./scripts/install-deps.sh            # install into .venv/
+#   ./scripts/install-deps.sh --system   # install system-wide (not recommended)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REQUIREMENTS="$REPO_ROOT/requirements.txt"
+VENV_DIR="$REPO_ROOT/.venv"
+USE_SYSTEM=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --system) USE_SYSTEM=true ;;
+        *) echo "Unknown argument: $arg" >&2; exit 1 ;;
+    esac
+done
+
+if [ ! -f "$REQUIREMENTS" ]; then
+    echo "Error: requirements.txt not found at $REQUIREMENTS" >&2
+    exit 1
+fi
+
+if $USE_SYSTEM; then
+    echo "Installing system-wide (--break-system-packages)..."
+    pip install --break-system-packages -r "$REQUIREMENTS"
+    echo "Done."
+    exit 0
+fi
+
+# --- Virtual environment path ---
+
+# If we're already inside a venv, install there directly.
+if [ -n "${VIRTUAL_ENV:-}" ]; then
+    echo "Active venv detected: $VIRTUAL_ENV"
+    echo "Installing into active venv..."
+    pip install -r "$REQUIREMENTS"
+    echo "Done."
+    exit 0
+fi
+
+# Create the venv if it doesn't exist.
+if [ ! -d "$VENV_DIR" ]; then
+    echo "Creating virtual environment at $VENV_DIR ..."
+    python3 -m venv "$VENV_DIR"
+fi
+
+echo "Installing dependencies into $VENV_DIR ..."
+"$VENV_DIR/bin/pip" install --upgrade pip --quiet
+"$VENV_DIR/bin/pip" install -r "$REQUIREMENTS"
+
+echo ""
+echo "Done. Activate the environment with:"
+echo "  source $VENV_DIR/bin/activate"


### PR DESCRIPTION
## Summary
Add a new installation script that handles Python dependency setup for VoxCtl with support for both virtual environments and system-wide installations.

## Key Changes
- **New script**: `scripts/install-deps.sh` provides a convenient way to install project dependencies
- **Virtual environment support**: Automatically creates and uses `.venv/` directory when not in an active virtual environment
- **Active venv detection**: Installs directly into an already-activated virtual environment if one is detected
- **System-wide fallback**: Supports `--system` flag for system-wide installation using `--break-system-packages` (not recommended)
- **User guidance**: Provides clear instructions on how to activate the virtual environment after installation

## Implementation Details
- Script validates that `requirements.txt` exists before attempting installation
- Uses `python3 -m venv` for virtual environment creation
- Automatically upgrades pip within the virtual environment before installing dependencies
- Handles the "externally managed" Python restriction on modern distros (Ubuntu 23.04+, Debian 12+, Arch, etc.)
- Includes comprehensive documentation and usage examples in script comments

https://claude.ai/code/session_01MxM6RQuSZpmEAaBFr6XDLJ