### PR TITLE
Simplify app install: comprehensive install.sh + consistent AppRun

### DIFF
--- a/AppRun
+++ b/AppRun
@@ -1,23 +1,18 @@
 #!/bin/bash
-# AppRun entry point for VoxCtl AppImage
+# AppImage entry point for VoxCtl.
+# This file is replaced by build_appimage.sh during the build; keep it in sync.
 
 HERE="$(dirname "$(readlink -f "${0}")")"
-
-# Define bundled paths
 USR_DIR="${HERE}/usr"
-# We use a wildcard or glob to find the python version if possible, 
-# but for now we'll stick to a placeholder or detect it in the script.
-PYTHON_VERSION=$(ls "${USR_DIR}/lib" | grep -E "^python3\.[0-9]+$" | head -n 1)
+VENV_DIR="${USR_DIR}/venv"
 
-# Export library paths
+# Make PyAudio/dbus-python C extensions findable (host libs: libportaudio2, libdbus-1)
 export LD_LIBRARY_PATH="${USR_DIR}/lib:${USR_DIR}/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH}"
 
-# Setup Python environment
-export PYTHONPATH="${USR_DIR}/share/voxctl:${USR_DIR}/lib/${PYTHON_VERSION}/site-packages:${PYTHONPATH}"
-export PYTHONHOME="${USR_DIR}"
-
-# Wayland / Desktop integration
+# Wayland / XDG desktop integration
 export XDG_DATA_DIRS="${USR_DIR}/share:${XDG_DATA_DIRS}"
 
-# Launch
-exec "${USR_DIR}/bin/python3" "${USR_DIR}/share/voxctl/src/main.py" "$@"
+# Expose the src/ directory as a top-level import path
+export PYTHONPATH="${USR_DIR}/share/voxctl:${PYTHONPATH}"
+
+exec "${VENV_DIR}/bin/python3" "${USR_DIR}/share/voxctl/src/main.py" "$@"

--- a/README.md
+++ b/README.md
@@ -79,64 +79,106 @@ The backend is chosen automatically at startup using GPU detection via `nvidia-s
 
 ## Installation
 
-### Option A — AppImage (easiest)
+### Option A — AppImage (recommended)
 
-Download the latest `VoxCtl-x86_64.AppImage` from [Releases](https://github.com/jrufer/voxctr/releases), then run the installer:
+**Step 1 — Get the AppImage.** Download the latest `VoxCtl-x86_64.AppImage` from [Releases](https://github.com/jrufer/voxctr/releases), or build it from source:
 
 ```bash
-chmod +x install.sh
-./install.sh
+bash scripts/build_appimage.sh
 ```
 
-This copies the AppImage to `~/.local/bin/voxctl`, installs the desktop entry, and downloads Piper TTS automatically.
+**Step 2 — Run the installer:**
+
+```bash
+bash install.sh
+```
+
+The installer takes care of everything:
+
+- Detects your package manager (`apt`, `pacman`, `dnf`, or `zypper`) and installs all required system libraries and binaries automatically
+- Downloads and installs the Piper neural TTS engine to `/opt/piper`
+- Creates udev rules and adds you to the `input`/`uinput` groups so global hotkeys work
+- Installs the AppImage to `~/.local/bin/voxctl` with a desktop entry and icon
+- Prompts once for two optional extras: `socat` (Claude Desktop / MCP bridge) and `python3-pyatspi` (AT-SPI2 accessibility — see section below)
+- Detects your GPU and advises which transcription backend will be selected
+
+**Step 3 — Log out and back in** (required for the group permission changes to take effect), then launch:
+
+```bash
+voxctl
+```
+
+On first launch a wizard guides you through choosing a Whisper model size and configuring hotkeys. The model is downloaded automatically (~140 MB for `base`, ~2.9 GB for `large-v3`).
+
+> If `~/.local/bin` is not in your `PATH`, the installer will warn you and show the one-liner to add it to your shell rc file.
+
+---
 
 ### Option B — Run from source
 
 #### 1. System dependencies
 
+**Arch Linux:**
 ```bash
-sudo pacman -S portaudio python-pyaudio wl-clipboard dbus pkgconf python-gobject ydotool wtype
-
-# For TTS voice output (recommended)
-sudo pacman -S alsa-utils          # aplay for Piper audio output
-yay -S piper-tts                   # Neural TTS engine
-# OR minimal fallback:
-sudo pacman -S espeak-ng
-
-# For MCP server → Claude Desktop bridge
+sudo pacman -S portaudio wl-clipboard xdotool wtype xclip alsa-utils espeak-ng
+# Optional: MCP / Claude Desktop bridge
 sudo pacman -S socat
+# Optional: AT-SPI2 accessibility
+sudo pacman -S python-atspi
 ```
 
-#### 2. Clone and set up the virtual environment
+**Debian / Ubuntu:**
+```bash
+sudo apt install libportaudio2 wl-clipboard xdotool wtype xclip alsa-utils espeak-ng
+# Optional: MCP / Claude Desktop bridge
+sudo apt install socat
+# Optional: AT-SPI2 accessibility
+sudo apt install python3-pyatspi
+```
+
+Also install [Piper TTS](https://github.com/rhasspy/piper/releases) for neural voice output (optional — `espeak-ng` is the fallback):
+
+```bash
+# Arch Linux
+yay -S piper-tts
+
+# All distros — manual install to /opt/piper (same as the AppImage installer):
+curl -fsSL https://github.com/rhasspy/piper/releases/download/v0.0.2/piper_amd64.tar.gz \
+  | sudo tar -xz -C /opt/
+echo /opt/piper | sudo tee /etc/ld.so.conf.d/piper.conf && sudo ldconfig
+printf '#!/bin/sh\nexec /opt/piper/piper "$@"\n' | sudo tee /usr/local/bin/piper
+sudo chmod +x /usr/local/bin/piper
+```
+
+#### 2. Permissions (evdev hotkeys)
+
+```bash
+sudo bash scripts/setup-permissions.sh
+```
+
+Log out and back in after this step.
+
+#### 3. Clone and set up the virtual environment
 
 ```bash
 git clone https://github.com/jrufer/voxctr.git
 cd voxctr
 
-python -m venv venv
-source venv/bin/activate        # bash/zsh
-# source venv/bin/activate.fish # fish
+python3 -m venv venv
+source venv/bin/activate
 
 pip install -r requirements.txt
 ```
 
-> `requirements.txt` includes noise suppression (`noisereduce`) and DBus support (`dbus-python`) by default.
+> `requirements.txt` includes noise suppression (`noisereduce`) and D-Bus support (`dbus-python`) by default.
 
-#### 3. Optional extras
+#### 4. Optional: NVIDIA GPU acceleration
 
 ```bash
-# Optional: AT-SPI2 accessibility integration (focus tracking, context-aware
-# transcription, direct text insertion — see section below)
-# Arch Linux:
-sudo pacman -S python-atspi
-# Debian / Ubuntu:
-# sudo apt install python3-pyatspi
-
-# Optional: NVIDIA GPU acceleration
 pip install nvidia-cublas-cu12 nvidia-cudnn-cu12
 ```
 
-#### 4. Launch
+#### 5. Launch
 
 ```bash
 ./voxctl.sh
@@ -144,7 +186,7 @@ pip install nvidia-cublas-cu12 nvidia-cudnn-cu12
 
 The app starts in the system tray. If your compositor doesn't support system trays, the Settings window opens directly.
 
-**On first launch**, if global hotkeys aren't yet configured, a setup wizard appears automatically. Click **Set Up Permissions**, enter your administrator password when prompted, then log out and back in. That's it — no terminal commands, no scripts to run manually.
+**On first launch**, if global hotkeys aren't yet configured, a setup wizard appears automatically. Click **Set Up Permissions**, enter your administrator password when prompted, then log out and back in.
 
 > You can also open the wizard any time from the tray icon → **Set Up Hotkeys…**
 
@@ -223,6 +265,10 @@ GGML_VULKAN=1 pip install git+https://github.com/abdeladim-s/pywhispercpp
 AT-SPI2 (Assistive Technology Service Provider Interface) is the standard Linux accessibility bus. When the optional `pyatspi` library is installed, VoxCtl gains three capabilities that work transparently alongside the existing injection chain.
 
 ### Installation
+
+**AppImage users:** `install.sh` prompts you to install AT-SPI2 during setup — no manual steps needed.
+
+**Source users:**
 
 ```bash
 # Arch Linux
@@ -442,12 +488,15 @@ VoxCtl can speak responses aloud using [Piper](https://github.com/rhasspy/piper)
 
 ### Setup
 
-1. Install Piper: `yay -S piper-tts` (or download from the [Piper releases page](https://github.com/rhasspy/piper/releases))
-2. Open **Settings → Voice Output**
-3. Select a voice from the picker
-4. Click **⬇ Download** to fetch the model (~5–130 MB depending on quality)
-5. Click **▶ Test Voice** to preview
-6. Toggle **"Enable TTS"** on
+**AppImage users:** Piper is installed automatically by `install.sh` — skip straight to step 2.
+
+**Source users:** Install Piper first (see [Installation → Option B](#option-b--run-from-source) for distro-specific instructions), then:
+
+1. Open **Settings → Voice Output**
+2. Select a voice from the picker
+3. Click **⬇ Download** to fetch the model (~5–130 MB depending on quality)
+4. Click **▶ Test Voice** to preview
+5. Toggle **"Enable TTS"** on
 
 `espeak-ng` is used automatically if Piper is not installed — no configuration needed.
 

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
 # VoxCtl AppImage Installer
-
-set -e
+#
+# Installs the AppImage to ~/.local/bin/voxctl and handles all system-level
+# dependencies that cannot be bundled inside the AppImage:
+#   - Runtime C libraries (portaudio, dbus)
+#   - Text injection binaries (wtype, xdotool)
+#   - Clipboard tools (wl-clipboard, xclip)
+#   - Audio playback (alsa-utils)
+#   - TTS engine (piper, espeak-ng)
+#   - Optional: socat (MCP/Claude Desktop bridge)
+#   - Optional: python3-pyatspi (AT-SPI2 accessibility)
+#   - udev rules + user groups for global hotkeys
 
 APP_NAME="VoxCtl"
 APPIMAGE_FILE="VoxCtl-x86_64.AppImage"
@@ -9,35 +18,232 @@ BIN_DIR="$HOME/.local/bin"
 DESKTOP_DIR="$HOME/.local/share/applications"
 ICON_DIR="$HOME/.local/share/icons/hicolor/256x256/apps"
 
-echo "=========================================="
-echo " Installing $APP_NAME "
-echo "=========================================="
+# ── Colours ──────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+BLUE='\033[0;34m'; BOLD='\033[1m'; NC='\033[0m'
+ok()   { echo -e "  ${GREEN}[OK]${NC}   $*"; }
+warn() { echo -e "  ${YELLOW}[WARN]${NC}  $*"; }
+info() { echo -e "  ${BLUE}[*]${NC}    $*"; }
+fail() { echo -e "  ${RED}[FAIL]${NC}  $*"; }
+step() { echo -e "\n${BOLD}── $* ──────────────────────────────────────────${NC}"; }
 
-# Check if AppImage exists
+echo -e "${BOLD}==========================================${NC}"
+echo -e "${BOLD}  Installing $APP_NAME${NC}"
+echo -e "${BOLD}==========================================${NC}"
+
+# ──────────────────────────────────────────────────────
+# 0. Detect distro and package manager
+# ──────────────────────────────────────────────────────
+detect_pkg_manager() {
+    if command -v apt-get &>/dev/null; then   echo "apt"
+    elif command -v pacman &>/dev/null;       then echo "pacman"
+    elif command -v dnf &>/dev/null;          then echo "dnf"
+    elif command -v zypper &>/dev/null;       then echo "zypper"
+    else                                           echo "unknown"
+    fi
+}
+
+PKG_MGR=$(detect_pkg_manager)
+info "Detected package manager: $PKG_MGR"
+
+# Resolve a package name for the current distro.
+# Args: <apt-name> <pacman-name> [<dnf-name> [<zypper-name>]]
+_resolve_pkg() {
+    local apt="$1" pac="$2" dnf="${3:-$1}" zyp="${4:-$1}"
+    case "$PKG_MGR" in
+        apt)    echo "$apt" ;;
+        pacman) echo "$pac" ;;
+        dnf)    echo "$dnf" ;;
+        zypper) echo "$zyp" ;;
+        *)      echo "$apt" ;;
+    esac
+}
+
+# Install one package via the detected package manager. Non-fatal on failure.
+_pkg_install() {
+    local pkg="$1"
+    if [ "$PKG_MGR" = "unknown" ]; then
+        warn "Unknown package manager — please install '$pkg' manually."
+        return 1
+    fi
+    case "$PKG_MGR" in
+        apt)    sudo apt-get install -y "$pkg" ;;
+        pacman) sudo pacman -S --noconfirm "$pkg" ;;
+        dnf)    sudo dnf install -y "$pkg" ;;
+        zypper) sudo zypper install -y "$pkg" ;;
+    esac
+}
+
+# ──────────────────────────────────────────────────────
+# 1. Pre-flight: AppImage must exist
+# ──────────────────────────────────────────────────────
+step "Pre-flight check"
 if [ ! -f "$APPIMAGE_FILE" ]; then
-    echo "Error: $APPIMAGE_FILE not found in the current directory."
-    echo "Please build the AppImage first or place this script next to it."
+    fail "$APPIMAGE_FILE not found in the current directory."
+    echo "       Build it first:  bash scripts/build_appimage.sh"
     exit 1
 fi
+ok "Found $APPIMAGE_FILE"
 
-# Ensure target directories exist
-mkdir -p "$BIN_DIR"
-mkdir -p "$DESKTOP_DIR"
-mkdir -p "$ICON_DIR"
+# ──────────────────────────────────────────────────────
+# 2. Required system dependencies
+#
+# The AppImage bundles all Python packages, but it cannot bundle:
+#   • libportaudio2  — PyAudio's C extension links to this at runtime
+#   • libdbus-1      — dbus-python's C extension links to this at runtime
+#   • External binaries (wtype, xdotool, wl-copy, aplay, piper, etc.)
+# ──────────────────────────────────────────────────────
+step "Required system dependencies"
 
-# 1. Install the AppImage
-echo "[*] Copying AppImage to $BIN_DIR..."
-cp "$APPIMAGE_FILE" "$BIN_DIR/voxctl"
-chmod +x "$BIN_DIR/voxctl"
-
-# 2. Install the icon
-echo "[*] Installing icon..."
-if [ -f "assets/app_icon.png" ]; then
-    cp assets/app_icon.png "$ICON_DIR/voxctl.png"
+# portaudio — required for all audio capture (PyAudio)
+info "Checking libportaudio (required for audio capture)..."
+if ldconfig -p 2>/dev/null | grep -q "libportaudio"; then
+    ok "libportaudio found"
+else
+    pkg=$(_resolve_pkg "libportaudio2" "portaudio" "portaudio-devel" "libportaudio2")
+    info "Installing $pkg..."
+    _pkg_install "$pkg" && ok "$pkg installed" \
+        || warn "Failed to install $pkg — audio capture will not work."
 fi
 
-# 3. Create the desktop entry
-echo "[*] Creating desktop entry..."
+# alsa-utils — provides 'aplay' used by the TTS engine for audio output
+info "Checking aplay (alsa-utils, required for TTS audio playback)..."
+if command -v aplay &>/dev/null; then
+    ok "aplay available"
+else
+    pkg=$(_resolve_pkg "alsa-utils" "alsa-utils" "alsa-utils" "alsa-utils")
+    info "Installing $pkg..."
+    _pkg_install "$pkg" && ok "$pkg installed" \
+        || warn "Failed to install $pkg — TTS audio playback will not work."
+fi
+
+# Text injection — wtype (Wayland) and/or xdotool (X11).
+# The app prefers wtype on Wayland and falls back to xdotool on X11.
+info "Checking text injection tools (wtype / xdotool)..."
+HAVE_WTYPE=false; HAVE_XDOTOOL=false
+command -v wtype   &>/dev/null && HAVE_WTYPE=true   && ok "wtype available (Wayland injection)"
+command -v xdotool &>/dev/null && HAVE_XDOTOOL=true && ok "xdotool available (X11 injection)"
+
+if ! $HAVE_WTYPE; then
+    pkg=$(_resolve_pkg "wtype" "wtype" "wtype" "wtype")
+    info "Installing $pkg (Wayland text injection)..."
+    _pkg_install "$pkg" && ok "$pkg installed" || warn "wtype not available — Wayland text injection may not work."
+fi
+if ! $HAVE_XDOTOOL; then
+    pkg=$(_resolve_pkg "xdotool" "xdotool" "xdotool" "xdotool")
+    info "Installing $pkg (X11 text injection fallback)..."
+    _pkg_install "$pkg" && ok "$pkg installed" || warn "xdotool not available — X11 text injection may not work."
+fi
+
+# Clipboard — wl-clipboard (Wayland) and xclip (X11)
+info "Checking clipboard tools (wl-clipboard / xclip)..."
+if command -v wl-copy &>/dev/null; then
+    ok "wl-clipboard available (Wayland clipboard)"
+else
+    pkg=$(_resolve_pkg "wl-clipboard" "wl-clipboard" "wl-clipboard" "wl-clipboard")
+    info "Installing $pkg..."
+    _pkg_install "$pkg" && ok "$pkg installed" || warn "wl-clipboard not available — Wayland clipboard output may not work."
+fi
+
+if command -v xclip &>/dev/null; then
+    ok "xclip available (X11 clipboard)"
+else
+    pkg=$(_resolve_pkg "xclip" "xclip" "xclip" "xclip")
+    info "Installing $pkg..."
+    _pkg_install "$pkg" && ok "$pkg installed" || warn "xclip not available — X11 clipboard output may not work."
+fi
+
+# espeak-ng — TTS fallback when piper is not installed or a model hasn't loaded yet
+info "Checking espeak-ng (TTS fallback engine)..."
+if command -v espeak-ng &>/dev/null; then
+    ok "espeak-ng available"
+else
+    pkg=$(_resolve_pkg "espeak-ng" "espeak-ng" "espeak-ng" "espeak-ng")
+    info "Installing $pkg..."
+    _pkg_install "$pkg" && ok "$pkg installed" || warn "espeak-ng not available — TTS will only work if piper is installed."
+fi
+
+# ──────────────────────────────────────────────────────
+# 3. Optional system dependencies (prompt user)
+# ──────────────────────────────────────────────────────
+step "Optional system dependencies"
+
+# socat — bridges the MCP Unix socket to Claude Desktop's stdio transport
+if command -v socat &>/dev/null; then
+    ok "socat available (MCP / Claude Desktop bridge enabled)"
+else
+    echo ""
+    echo "    socat enables the MCP server that lets Claude Desktop call VoxCtl tools"
+    echo "    (transcribe_voice, speak_text, get_status) directly from Claude Desktop."
+    read -rp "  Install socat for Claude Desktop / MCP integration? [y/N] " yn
+    if [[ "$yn" =~ ^[Yy]$ ]]; then
+        pkg=$(_resolve_pkg "socat" "socat" "socat" "socat")
+        _pkg_install "$pkg" && ok "socat installed" \
+            || warn "socat install failed — MCP bridge will not work."
+    else
+        warn "socat skipped — MCP server / Claude Desktop integration will be disabled."
+    fi
+fi
+
+# pyatspi — AT-SPI2 Python bindings for direct text insertion and context-aware transcription.
+# This is a system package; it cannot be bundled in the AppImage because it depends on
+# session-level AT-SPI dbus services that must run on the host.
+PYATSPI_PKG=$(_resolve_pkg "python3-pyatspi" "python-atspi" "python3-pyatspi" "python3-pyatspi")
+if python3 -c "import pyatspi" 2>/dev/null; then
+    ok "pyatspi available (AT-SPI2 context-aware transcription enabled)"
+else
+    echo ""
+    echo "    pyatspi enables:"
+    echo "      • Direct text insertion (no keystrokes needed — works in most apps)"
+    echo "      • Context-aware transcription (reads the focused field to adapt output)"
+    echo "      • Code/prose mode auto-switching"
+    read -rp "  Install $PYATSPI_PKG for AT-SPI2 accessibility? [y/N] " yn
+    if [[ "$yn" =~ ^[Yy]$ ]]; then
+        _pkg_install "$PYATSPI_PKG" && ok "$PYATSPI_PKG installed" \
+            || warn "$PYATSPI_PKG install failed — AT-SPI2 features will be disabled."
+    else
+        warn "$PYATSPI_PKG skipped — AT-SPI2 context-aware transcription will be disabled."
+    fi
+fi
+
+# ──────────────────────────────────────────────────────
+# 4. GPU detection and transcription backend guidance
+# ──────────────────────────────────────────────────────
+step "GPU / transcription backend"
+if command -v nvidia-smi &>/dev/null && nvidia-smi &>/dev/null 2>&1; then
+    ok "NVIDIA GPU detected — faster-whisper (CUDA) backend active automatically."
+    info "Ensure NVIDIA drivers are current for best performance."
+elif command -v vulkaninfo &>/dev/null && vulkaninfo 2>/dev/null | grep -qi "GPU id"; then
+    warn "AMD/Intel GPU with Vulkan detected."
+    info "For GPU-accelerated transcription install whisper-cpp with Vulkan support:"
+    echo "         Arch:  yay -S whisper-cpp-vulkan"
+    echo "         Other: build from source with -DGGML_VULKAN=ON"
+    info "The app will use CPU transcription until whisper-cpp is available."
+else
+    info "No discrete GPU detected — CPU transcription will be used."
+    info "Recommended model size for CPU: 'base' or 'small' (good balance of speed/accuracy)."
+fi
+
+# ──────────────────────────────────────────────────────
+# 5. Install the AppImage
+# ──────────────────────────────────────────────────────
+step "Installing AppImage"
+mkdir -p "$BIN_DIR" "$DESKTOP_DIR" "$ICON_DIR"
+
+info "Copying AppImage to $BIN_DIR/voxctl..."
+cp "$APPIMAGE_FILE" "$BIN_DIR/voxctl"
+chmod +x "$BIN_DIR/voxctl"
+ok "AppImage installed at $BIN_DIR/voxctl"
+
+# ──────────────────────────────────────────────────────
+# 6. Icon + desktop entry
+# ──────────────────────────────────────────────────────
+step "Desktop integration"
+if [ -f "assets/app_icon.png" ]; then
+    cp assets/app_icon.png "$ICON_DIR/voxctl.png"
+    ok "Icon installed"
+fi
+
 cat > "$DESKTOP_DIR/voxctl.desktop" <<EOF
 [Desktop Entry]
 Name=VoxCtl
@@ -46,67 +252,115 @@ Exec=$BIN_DIR/voxctl
 Icon=voxctl
 Terminal=false
 Type=Application
-Categories=Utility;Audio;
+Categories=Utility;AudioVideo;
+StartupNotify=false
+Keywords=whisper;voice;dictation;wayland;
 EOF
+ok "Desktop entry created"
 
-# 4. Install piper TTS (binary + bundled shared libraries)
-echo ""
-echo "[*] Installing piper TTS engine..."
+command -v update-desktop-database &>/dev/null && update-desktop-database "$DESKTOP_DIR" || true
+
+# ──────────────────────────────────────────────────────
+# 7. Piper TTS engine
+# ──────────────────────────────────────────────────────
+step "Piper TTS engine"
 _install_piper() {
-    local tmp_dir
+    local tmp_dir tarball
     tmp_dir=$(mktemp -d)
-    local tarball="$tmp_dir/piper_amd64.tar.gz"
+    tarball="$tmp_dir/piper_amd64.tar.gz"
 
-    echo "    Downloading piper v0.0.2..."
+    info "Downloading piper v0.0.2..."
     if ! curl -fsSL -o "$tarball" \
         "https://github.com/rhasspy/piper/releases/download/v0.0.2/piper_amd64.tar.gz"; then
-        echo "    Warning: piper download failed. TTS will fall back to espeak-ng."
+        warn "piper download failed — TTS will fall back to espeak-ng."
         rm -rf "$tmp_dir"
         return 1
     fi
 
     tar -xzf "$tarball" -C "$tmp_dir"
-
     sudo mkdir -p /opt/piper
     sudo cp -r "$tmp_dir/piper/." /opt/piper/
 
-    # Wrapper keeps the binary next to its bundled .so files
-    printf '#!/bin/sh\nexec /opt/piper/piper "$@"\n' | sudo tee /usr/local/bin/piper > /dev/null
+    # Wrapper script keeps the binary next to its bundled .so files
+    printf '#!/bin/sh\nexec /opt/piper/piper "$@"\n' \
+        | sudo tee /usr/local/bin/piper > /dev/null
     sudo chmod +x /usr/local/bin/piper
 
-    # Register bundled libs with the dynamic linker
+    # Register piper's bundled shared libraries with the dynamic linker
     echo /opt/piper | sudo tee /etc/ld.so.conf.d/piper.conf > /dev/null
     sudo ldconfig
 
     rm -rf "$tmp_dir"
-    echo "    piper installed to /opt/piper"
+    ok "piper installed to /opt/piper"
 }
 
 if command -v piper &>/dev/null; then
-    echo "    piper already installed at $(command -v piper) — skipping."
+    ok "piper already installed at $(command -v piper) — skipping."
 else
-    _install_piper
+    _install_piper || true
 fi
 
-# 5. Set up permissions (evdev)
-echo ""
-echo "[*] Setting up hardware permissions (evdev) for global hotkeys..."
-echo "This step requires root privileges to create udev rules."
+# ──────────────────────────────────────────────────────
+# 8. Hardware permissions (evdev / uinput)
+# ──────────────────────────────────────────────────────
+step "Hardware permissions (evdev / uinput)"
+info "Creating udev rules for global hotkeys (requires sudo)..."
 if [ -f "scripts/setup-permissions.sh" ]; then
     sudo bash scripts/setup-permissions.sh
 else
-    echo "Warning: scripts/setup-permissions.sh not found. Hotkeys may not work globally."
+    warn "scripts/setup-permissions.sh not found — global hotkeys may not work."
 fi
 
-# 6. Update desktop database
-echo "[*] Updating desktop database..."
-if command -v update-desktop-database &> /dev/null; then
-    update-desktop-database "$DESKTOP_DIR"
+# ──────────────────────────────────────────────────────
+# 9. PATH check
+# ──────────────────────────────────────────────────────
+if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+    echo ""
+    warn "\$HOME/.local/bin is not in your PATH."
+    echo "       Add this line to ~/.bashrc or ~/.zshrc:"
+    echo ""
+    echo "         export PATH=\"\$HOME/.local/bin:\$PATH\""
+    echo ""
+    echo "       Then reload your shell:  source ~/.bashrc"
 fi
 
-echo "=========================================="
-echo " Installation Complete!"
-echo " "
-echo " Note: Make sure '$BIN_DIR' is in your PATH."
-echo " You may need to log out and log back in for the permission changes to take effect."
-echo "=========================================="
+# ──────────────────────────────────────────────────────
+# Summary
+# ──────────────────────────────────────────────────────
+echo ""
+echo -e "${BOLD}==========================================${NC}"
+echo -e "${BOLD}  Installation Complete!${NC}"
+echo -e "${BOLD}==========================================${NC}"
+echo ""
+echo "  Installed:"
+echo "    AppImage   →  $BIN_DIR/voxctl"
+echo "    Desktop    →  $DESKTOP_DIR/voxctl.desktop"
+echo "    Icon       →  $ICON_DIR/voxctl.png"
+command -v piper &>/dev/null && echo "    TTS        →  piper (neural) + espeak-ng (fallback)"
+echo ""
+echo "  What the AppImage bundles (no extra pip install needed):"
+echo "    • All Python packages: PyQt6, faster-whisper, onnxruntime, PyAudio,"
+echo "      dbus-python, evdev, noisereduce, scipy, numpy, and 50+ more"
+echo ""
+echo "  What must be on the host (installed above):"
+echo "    • libportaudio2  — audio capture C library"
+echo "    • alsa-utils     — aplay for TTS audio output"
+echo "    • wtype          — Wayland text injection"
+echo "    • xdotool        — X11 text injection fallback"
+echo "    • wl-clipboard   — Wayland clipboard"
+echo "    • xclip          — X11 clipboard fallback"
+echo "    • espeak-ng      — TTS fallback engine"
+echo "    • piper          — neural TTS engine (installed to /opt/piper)"
+echo ""
+echo "  Next steps:"
+echo "    1. LOG OUT and LOG BACK IN (required for hotkey group permissions)"
+echo "    2. Run: voxctl"
+echo "       (or launch from your application menu)"
+echo ""
+echo "  On first launch VoxCtl will:"
+echo "    • Let you choose a Whisper model size"
+echo "    • Download the model (~140 MB for 'base', ~2.9 GB for 'large-v3')"
+echo "    • Let you configure hotkeys, output targets, and TTS voice"
+echo ""
+echo "  TTS voice models are downloaded on demand from Settings → TTS."
+echo ""

--- a/scripts/build_appimage.sh
+++ b/scripts/build_appimage.sh
@@ -1,8 +1,25 @@
 #!/bin/bash
 # VoxCtl AppImage Build Script
-# This script creates a portable AppImage bundling Python and dependencies.
+#
+# Bundles the Python application and all pip dependencies into a portable AppImage.
+#
+# What IS bundled:
+#   All packages from requirements.txt (PyQt6, faster-whisper, onnxruntime, PyAudio
+#   Python wrapper, dbus-python, evdev, noisereduce, scipy, numpy, and 50+ more).
+#
+# What is NOT bundled (must be present on the host — installed by install.sh):
+#   • libportaudio2  — PyAudio's C extension links to this at runtime
+#   • libdbus-1      — dbus-python's C extension links to this at runtime
+#   • wtype          — Wayland text injection binary
+#   • xdotool        — X11 text injection binary
+#   • wl-clipboard   — Wayland clipboard tools (wl-copy / wl-paste)
+#   • xclip          — X11 clipboard tool
+#   • alsa-utils     — provides aplay for TTS audio output
+#   • piper          — neural TTS binary (installed to /opt/piper by install.sh)
+#   • espeak-ng      — TTS fallback binary
+#   • socat          — optional MCP/Claude Desktop bridge
+#   • python3-pyatspi / python-atspi  — optional AT-SPI2 system package
 
-# Exit on error
 set -e
 
 APP_NAME="VoxCtl"
@@ -11,72 +28,75 @@ PYTHON_VERSION=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.v
 
 echo "Building AppImage for ${APP_NAME} (Python ${PYTHON_VERSION})..."
 
-# 1. Clean and Setup Structure
-rm -rf ${APP_DIR} *.AppImage
-mkdir -p ${APP_DIR}/usr/bin
-mkdir -p ${APP_DIR}/usr/share/voxctl
-mkdir -p ${APP_DIR}/usr/share/metainfo
-mkdir -p ${APP_DIR}/usr/share/applications
-mkdir -p ${APP_DIR}/usr/share/icons/hicolor/256x256/apps
+# 1. Clean and set up AppDir structure
+rm -rf "${APP_DIR}" ./*.AppImage
+mkdir -p "${APP_DIR}/usr/bin"
+mkdir -p "${APP_DIR}/usr/share/voxctl"
+mkdir -p "${APP_DIR}/usr/share/metainfo"
+mkdir -p "${APP_DIR}/usr/share/applications"
+mkdir -p "${APP_DIR}/usr/share/icons/hicolor/256x256/apps"
 
-# 2. Copy Application Files
+# 2. Copy application files
 echo "[*] Copying application source and assets..."
-cp -r src/ ${APP_DIR}/usr/share/voxctl/
-cp -r assets/ ${APP_DIR}/usr/share/voxctl/
-cp voxctl.desktop ${APP_DIR}/usr/share/applications/
+cp -r src/    "${APP_DIR}/usr/share/voxctl/"
+cp -r assets/ "${APP_DIR}/usr/share/voxctl/"
 
-# Update desktop file for AppImage
-sed -i "s|^Exec=.*|Exec=voxctl|" ${APP_DIR}/usr/share/applications/voxctl.desktop
-sed -i "s|^Icon=.*|Icon=voxctl|" ${APP_DIR}/usr/share/applications/voxctl.desktop
+cp voxctl.desktop "${APP_DIR}/usr/share/applications/"
+sed -i "s|^Exec=.*|Exec=voxctl|"   "${APP_DIR}/usr/share/applications/voxctl.desktop"
+sed -i "s|^Icon=.*|Icon=voxctl|"   "${APP_DIR}/usr/share/applications/voxctl.desktop"
 
-# Icons
-cp assets/app_icon.png ${APP_DIR}/usr/share/icons/hicolor/256x256/apps/voxctl.png
-cp assets/app_icon.png ${APP_DIR}/voxctl.png
-ln -sf usr/share/applications/voxctl.desktop ${APP_DIR}/voxctl.desktop
+cp assets/app_icon.png "${APP_DIR}/usr/share/icons/hicolor/256x256/apps/voxctl.png"
+cp assets/app_icon.png "${APP_DIR}/voxctl.png"
+ln -sf usr/share/applications/voxctl.desktop "${APP_DIR}/voxctl.desktop"
 
-# 3. Install Dependencies using a virtualenv
+# 3. Install all pip dependencies into a self-contained venv
 echo "[*] Creating virtual environment inside AppDir..."
-python3 -m venv ${APP_DIR}/usr/venv
+python3 -m venv "${APP_DIR}/usr/venv"
 
 echo "[*] Installing dependencies into AppDir venv..."
-${APP_DIR}/usr/venv/bin/pip install --upgrade pip
-${APP_DIR}/usr/venv/bin/pip install -r requirements.txt
+"${APP_DIR}/usr/venv/bin/pip" install --upgrade pip --quiet
+"${APP_DIR}/usr/venv/bin/pip" install -r requirements.txt
 
-# 4. Set up AppRun
-echo "[*] Setting up AppRun..."
-cat > ${APP_DIR}/AppRun <<EOF
+# 4. Write AppRun (keep in sync with repo-root AppRun)
+echo "[*] Writing AppRun..."
+cat > "${APP_DIR}/AppRun" <<'EOF'
 #!/bin/bash
-HERE="\$(dirname "\$(readlink -f "\${0}")")"
-USR_DIR="\${HERE}/usr"
-VENV_DIR="\${USR_DIR}/venv"
+HERE="$(dirname "$(readlink -f "${0}")")"
+USR_DIR="${HERE}/usr"
+VENV_DIR="${USR_DIR}/venv"
 
-# Export library paths
-export LD_LIBRARY_PATH="\${USR_DIR}/lib:\${USR_DIR}/lib/x86_64-linux-gnu:\${LD_LIBRARY_PATH}"
+# Make PyAudio/dbus-python C extensions findable (host libs: libportaudio2, libdbus-1)
+export LD_LIBRARY_PATH="${USR_DIR}/lib:${USR_DIR}/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH}"
 
-# Wayland / Desktop integration
-export XDG_DATA_DIRS="\${USR_DIR}/share:\${XDG_DATA_DIRS}"
+# Wayland / XDG desktop integration
+export XDG_DATA_DIRS="${USR_DIR}/share:${XDG_DATA_DIRS}"
 
-# Launch using the bundled venv's python
-export PYTHONPATH="\${USR_DIR}/share/voxctl:\${PYTHONPATH}"
-exec "\${VENV_DIR}/bin/python3" "\${USR_DIR}/share/voxctl/src/main.py" "\$@"
+# Expose the src/ directory as a top-level import path
+export PYTHONPATH="${USR_DIR}/share/voxctl:${PYTHONPATH}"
+
+exec "${VENV_DIR}/bin/python3" "${USR_DIR}/share/voxctl/src/main.py" "$@"
 EOF
-chmod +x ${APP_DIR}/AppRun
+chmod +x "${APP_DIR}/AppRun"
 
-# 5. AppImage Creation Tool
-if ! command -v appimagetool &> /dev/null; then
-    if [ ! -f "appimagetool" ]; then
-        echo "[*] appimagetool not found, downloading..."
-        wget -c https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage -O appimagetool
-        chmod +x appimagetool
-    fi
+# 5. Locate or download appimagetool
+if command -v appimagetool &>/dev/null; then
+    TOOL="appimagetool"
+elif [ -f "./appimagetool" ]; then
     TOOL="./appimagetool"
 else
-    TOOL="appimagetool"
+    echo "[*] appimagetool not found — downloading..."
+    wget -c "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage" \
+         -O appimagetool
+    chmod +x appimagetool
+    TOOL="./appimagetool"
 fi
 
-# 6. Build
+# 6. Package the AppImage
 echo "[*] Packaging AppImage..."
 export ARCH=x86_64
-$TOOL ${APP_DIR} ${APP_NAME}-x86_64.AppImage
+$TOOL "${APP_DIR}" "${APP_NAME}-x86_64.AppImage"
 
-echo "Success! ${APP_NAME}-x86_64.AppImage created."
+echo ""
+echo "Success!  ${APP_NAME}-x86_64.AppImage created."
+echo ""
+echo "To install:  bash install.sh"

--- a/voxctl.desktop
+++ b/voxctl.desktop
@@ -1,8 +1,8 @@
 [Desktop Entry]
 Name=VoxCtl
 Comment=Global Voice-to-Text for Wayland
-Exec=/run/media/jrufer/NVME/Development/VoxCtl/venv/bin/python3 /run/media/jrufer/NVME/Development/VoxCtl/src/main.py
-Icon=/run/media/jrufer/NVME/Development/VoxCtl/assets/app_icon.png
+Exec=voxctl
+Icon=voxctl
 Terminal=false
 Type=Application
 Categories=Utility;AudioVideo;


### PR DESCRIPTION
install.sh now handles all host-level dependencies that cannot be
bundled inside the AppImage:
  - Detects distro/package manager (apt, pacman, dnf, zypper)
  - Installs required: libportaudio2, alsa-utils, wtype, xdotool,
    wl-clipboard, xclip, espeak-ng
  - Prompts for optional: socat (MCP/Claude Desktop bridge),
    python3-pyatspi (AT-SPI2 accessibility)
  - Detects GPU (NVIDIA CUDA / AMD-Intel Vulkan / CPU) and gives
    backend guidance
  - Checks PATH for ~/.local/bin
  - Prints a clear post-install summary of what's bundled vs. host

voxctl.desktop: remove hardcoded developer machine paths; use bare
"voxctl" command name so it works after install regardless of machine.

AppRun (repo root): sync with the venv-based approach actually written
by build_appimage.sh (was using ${USR_DIR}/bin/python3 which doesn't
exist in the built AppDir structure).

scripts/build_appimage.sh: add host-dependency comment block, sync the
generated AppRun template with the repo-root AppRun, minor cleanup.

https://claude.ai/code/session_01MdaRMMHRkwU7dnDqjQygrB