### PR TITLE
Bundle pyatspi, mcp, and websockets in AppImage

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,7 +7,10 @@ arch=('any')
 url="https://github.com/jrufer/voxctl"
 license=('MIT')
 depends=('python' 'python-pyqt6' 'python-evdev' 'portaudio' 'wl-clipboard')
-optdepends=('python-faster-whisper: for the transcription engine')
+optdepends=('python-faster-whisper: for the transcription engine'
+            'python-websockets: for WebSocket delivery support'
+            'python-mcp: for MCP server feature'
+            'python-atspi: for AT-SPI2 focus tracking and direct text insertion')
 source=("voxctl.desktop" "99-voxctl.rules")
 sha256sums=('SKIP' 'SKIP')
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ The installer takes care of everything:
 - Downloads and installs the Piper neural TTS engine to `/opt/piper`
 - Creates udev rules and adds you to the `input`/`uinput` groups so global hotkeys work
 - Installs the AppImage to `~/.local/bin/voxctl` with a desktop entry and icon
-- Prompts once for two optional extras: `socat` (Claude Desktop / MCP bridge) and `python3-pyatspi` (AT-SPI2 accessibility — see section below)
+- Prompts once for one optional extra: `socat` (Claude Desktop / MCP bridge stdio transport)
+- `pyatspi`, `mcp`, and `websockets` are bundled inside the AppImage — no manual install needed
 - Detects your GPU and advises which transcription backend will be selected
 
 **Step 3 — Log out and back in** (required for the group permission changes to take effect), then launch:
@@ -170,7 +171,7 @@ source venv/bin/activate
 pip install -r requirements.txt
 ```
 
-> `requirements.txt` includes noise suppression (`noisereduce`) and D-Bus support (`dbus-python`) by default.
+> `requirements.txt` includes noise suppression (`noisereduce`), D-Bus support (`dbus-python`), WebSocket delivery (`websockets`), MCP server support (`mcp`), and AT-SPI2 accessibility (`pyatspi`) by default.
 
 #### 4. Optional: NVIDIA GPU acceleration
 
@@ -266,9 +267,9 @@ AT-SPI2 (Assistive Technology Service Provider Interface) is the standard Linux 
 
 ### Installation
 
-**AppImage users:** `install.sh` prompts you to install AT-SPI2 during setup — no manual steps needed.
+**AppImage users:** `pyatspi` is bundled inside the AppImage — no manual steps needed. AT-SPI2 features are available automatically as long as your desktop session runs the AT-SPI registry daemon (started automatically by GNOME, KDE, and most other environments).
 
-**Source users:**
+**Source users:** `pyatspi` is included in `requirements.txt` and installed automatically with `pip install -r requirements.txt`. If you prefer the system package:
 
 ```bash
 # Arch Linux

--- a/install.sh
+++ b/install.sh
@@ -185,25 +185,14 @@ else
     fi
 fi
 
-# pyatspi — AT-SPI2 Python bindings for direct text insertion and context-aware transcription.
-# This is a system package; it cannot be bundled in the AppImage because it depends on
-# session-level AT-SPI dbus services that must run on the host.
-PYATSPI_PKG=$(_resolve_pkg "python3-pyatspi" "python-atspi" "python3-pyatspi" "python3-pyatspi")
+# pyatspi — bundled inside the AppImage venv. AT-SPI2 features (direct text insertion,
+# context-aware transcription) work automatically as long as the host AT-SPI registry
+# daemon is running (it is started automatically by most desktop environments).
 if python3 -c "import pyatspi" 2>/dev/null; then
-    ok "pyatspi available (AT-SPI2 context-aware transcription enabled)"
+    ok "pyatspi available on system Python (AT-SPI2 context-aware transcription enabled)"
 else
-    echo ""
-    echo "    pyatspi enables:"
-    echo "      • Direct text insertion (no keystrokes needed — works in most apps)"
-    echo "      • Context-aware transcription (reads the focused field to adapt output)"
-    echo "      • Code/prose mode auto-switching"
-    read -rp "  Install $PYATSPI_PKG for AT-SPI2 accessibility? [y/N] " yn
-    if [[ "$yn" =~ ^[Yy]$ ]]; then
-        _pkg_install "$PYATSPI_PKG" && ok "$PYATSPI_PKG installed" \
-            || warn "$PYATSPI_PKG install failed — AT-SPI2 features will be disabled."
-    else
-        warn "$PYATSPI_PKG skipped — AT-SPI2 context-aware transcription will be disabled."
-    fi
+    info "pyatspi not found on system Python — that's OK, it's bundled inside the AppImage."
+    info "AT-SPI2 features will work as long as your desktop session runs the AT-SPI registry."
 fi
 
 # ──────────────────────────────────────────────────────
@@ -340,7 +329,8 @@ command -v piper &>/dev/null && echo "    TTS        →  piper (neural) + espea
 echo ""
 echo "  What the AppImage bundles (no extra pip install needed):"
 echo "    • All Python packages: PyQt6, faster-whisper, onnxruntime, PyAudio,"
-echo "      dbus-python, evdev, noisereduce, scipy, numpy, and 50+ more"
+echo "      dbus-python, evdev, noisereduce, scipy, numpy, websockets, mcp,"
+echo "      pyatspi, and 50+ more"
 echo ""
 echo "  What must be on the host (installed above):"
 echo "    • libportaudio2  — audio capture C library"

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,8 +54,8 @@ tokenizers==0.22.2
 tqdm==4.67.3
 typer==0.24.1
 typing_extensions==4.15.0
+websockets
+mcp
+pyatspi
 # Optional: install for in-process whisper.cpp (lower latency than subprocess)
 # pywhispercpp>=1.2.0
-# Optional: install for AT-SPI2 accessibility integration (focus tracking, context-aware
-# transcription, direct text insertion). Arch: python-atspi; Debian/Ubuntu: python3-pyatspi
-# pyatspi

--- a/scripts/build_appimage.sh
+++ b/scripts/build_appimage.sh
@@ -5,7 +5,8 @@
 #
 # What IS bundled:
 #   All packages from requirements.txt (PyQt6, faster-whisper, onnxruntime, PyAudio
-#   Python wrapper, dbus-python, evdev, noisereduce, scipy, numpy, and 50+ more).
+#   Python wrapper, dbus-python, evdev, noisereduce, scipy, numpy, websockets, mcp,
+#   pyatspi, and 50+ more).
 #
 # What is NOT bundled (must be present on the host — installed by install.sh):
 #   • libportaudio2  — PyAudio's C extension links to this at runtime
@@ -17,8 +18,8 @@
 #   • alsa-utils     — provides aplay for TTS audio output
 #   • piper          — neural TTS binary (installed to /opt/piper by install.sh)
 #   • espeak-ng      — TTS fallback binary
-#   • socat          — optional MCP/Claude Desktop bridge
-#   • python3-pyatspi / python-atspi  — optional AT-SPI2 system package
+#   • socat          — optional MCP/Claude Desktop bridge (stdio transport)
+#   • AT-SPI2 daemon — pyatspi is bundled, but the host AT-SPI registry must be running
 
 set -e
 


### PR DESCRIPTION
## Summary
This PR moves `pyatspi`, `mcp`, and `websockets` from optional/system packages to bundled dependencies within the AppImage, simplifying the installation experience and ensuring AT-SPI2 accessibility features are available by default.

## Key Changes

- **Removed interactive pyatspi installation prompt** from `install.sh`: The installer no longer asks users to install `python3-pyatspi` as a system package. Instead, it checks if pyatspi is available on the system Python and informs users it's bundled in the AppImage.

- **Updated requirements.txt**: Moved `pyatspi`, `mcp`, and `websockets` from commented-out optional dependencies to active bundled dependencies.

- **Updated documentation**:
  - `README.md`: Clarified that `pyatspi`, `mcp`, and `websockets` are bundled in the AppImage with no manual install needed
  - Updated AT-SPI2 installation section to reflect that the feature is automatically available as long as the host AT-SPI registry daemon is running
  - Updated source installation instructions to note these packages are included in `requirements.txt`

- **Updated build and packaging metadata**:
  - `scripts/build_appimage.sh`: Updated comments to reflect that `pyatspi`, `mcp`, and `websockets` are now bundled
  - `PKGBUILD`: Added `python-websockets`, `python-mcp`, and `python-atspi` as optional dependencies for source installations

## Implementation Details

- The change maintains backward compatibility: if pyatspi is available on the system Python, it's used; otherwise, the bundled version in the AppImage provides the functionality
- AT-SPI2 features now work automatically without requiring users to install additional system packages during setup
- The installer is simplified by removing one interactive prompt while maintaining all functionality

https://claude.ai/code/session_013xd3cZJgqGnBz6ZCCvHHs6