### PR TITLE
Fix build failure: remove pyatspi from pip requirements

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -185,14 +185,22 @@ else
     fi
 fi
 
-# pyatspi — bundled inside the AppImage venv. AT-SPI2 features (direct text insertion,
-# context-aware transcription) work automatically as long as the host AT-SPI registry
-# daemon is running (it is started automatically by most desktop environments).
+# pyatspi — system package (python3-pyatspi); NOT pip-installable on Python 3.11+.
+# The AppImage's AppRun adds the host site-packages to PYTHONPATH so the app finds it.
 if python3 -c "import pyatspi" 2>/dev/null; then
-    ok "pyatspi available on system Python (AT-SPI2 context-aware transcription enabled)"
+    ok "python3-pyatspi available — AT-SPI2 context-aware transcription enabled"
 else
-    info "pyatspi not found on system Python — that's OK, it's bundled inside the AppImage."
-    info "AT-SPI2 features will work as long as your desktop session runs the AT-SPI registry."
+    echo ""
+    echo "    python3-pyatspi enables AT-SPI2 context-aware transcription (direct text"
+    echo "    insertion into focused applications without using the clipboard)."
+    read -rp "  Install python3-pyatspi for AT-SPI2 features? [y/N] " yn
+    if [[ "$yn" =~ ^[Yy]$ ]]; then
+        pkg=$(_resolve_pkg "python3-pyatspi" "python-pyatspi" "python3-pyatspi" "python3-pyatspi")
+        _pkg_install "$pkg" && ok "$pkg installed — AT-SPI2 features enabled" \
+            || warn "$pkg install failed — AT-SPI2 context-aware transcription will be unavailable."
+    else
+        warn "python3-pyatspi skipped — AT-SPI2 context-aware transcription will be unavailable."
+    fi
 fi
 
 # ──────────────────────────────────────────────────────
@@ -330,7 +338,9 @@ echo ""
 echo "  What the AppImage bundles (no extra pip install needed):"
 echo "    • All Python packages: PyQt6, faster-whisper, onnxruntime, PyAudio,"
 echo "      dbus-python, evdev, noisereduce, scipy, numpy, websockets, mcp,"
-echo "      pyatspi, and 50+ more"
+echo "      and 50+ more"
+echo "  Note: python3-pyatspi is a system package (installed above if selected);"
+echo "        the AppImage reads it from the host site-packages at runtime."
 echo ""
 echo "  What must be on the host (installed above):"
 echo "    • libportaudio2  — audio capture C library"

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,6 +56,7 @@ typer==0.24.1
 typing_extensions==4.15.0
 websockets>=14.0
 mcp>=1.0.0
-pyatspi
+# pyatspi is a system package (python3-pyatspi) — not available on PyPI for Python 3.11+.
+# Install via: sudo apt install python3-pyatspi  (or distro equivalent)
 # Optional: install for in-process whisper.cpp (lower latency than subprocess)
 # pywhispercpp>=1.2.0

--- a/scripts/build_appimage.sh
+++ b/scripts/build_appimage.sh
@@ -6,7 +6,11 @@
 # What IS bundled:
 #   All packages from requirements.txt (PyQt6, faster-whisper, onnxruntime, PyAudio
 #   Python wrapper, dbus-python, evdev, noisereduce, scipy, numpy, websockets, mcp,
-#   pyatspi, and 50+ more).
+#   and 50+ more).
+#
+# Note: pyatspi is NOT bundled — it is a system package (python3-pyatspi) not
+#   available on PyPI for Python 3.11+. AppRun adds the host site-packages to
+#   PYTHONPATH so the app finds it if the user installed python3-pyatspi.
 #
 # What is NOT bundled (must be present on the host — installed by install.sh):
 #   • libportaudio2  — PyAudio's C extension links to this at runtime
@@ -72,8 +76,10 @@ export LD_LIBRARY_PATH="${USR_DIR}/lib:${USR_DIR}/lib/x86_64-linux-gnu:${LD_LIBR
 # Wayland / XDG desktop integration
 export XDG_DATA_DIRS="${USR_DIR}/share:${XDG_DATA_DIRS}"
 
-# Expose the src/ directory as a top-level import path
-export PYTHONPATH="${USR_DIR}/share/voxctl:${PYTHONPATH}"
+# pyatspi is a system package (python3-pyatspi) that cannot be bundled via pip.
+# Add the host system site-packages so pyatspi is found if installed on the host.
+SYS_SITE=$(python3 -c "import site; print(site.getsitepackages()[0])" 2>/dev/null || true)
+export PYTHONPATH="${USR_DIR}/share/voxctl:${SYS_SITE}:${PYTHONPATH}"
 
 exec "${VENV_DIR}/bin/python3" "${USR_DIR}/share/voxctl/src/main.py" "$@"
 EOF


### PR DESCRIPTION
## Summary

- `pyatspi` has no PyPI distribution for Python 3.11+ — it is a system package (`python3-pyatspi`) that cannot be installed via pip, causing `build_appimage.sh` to fail with `No matching distribution found for pyatspi`
- Removed `pyatspi` from `requirements.txt` and added a comment explaining it must be installed via the OS package manager
- Updated `AppRun` in the build script to inject the host system site-packages into `PYTHONPATH` so the app finds `pyatspi` at runtime if the user has `python3-pyatspi` installed
- Updated `install.sh` to interactively offer installing `python3-pyatspi` via the system package manager (replacing the incorrect "it's bundled" message)

## Test plan

- [ ] Run `bash scripts/build_appimage.sh` — should complete without the `pyatspi` pip error
- [ ] Verify AT-SPI2 features work after running `install.sh` and choosing to install `python3-pyatspi`
- [ ] Verify AT-SPI2 gracefully degrades (no crash) when `python3-pyatspi` is not installed

https://claude.ai/code/session_013oEKe9Yh9GvT1ati51SB2D

---
_Generated by [Claude Code](https://claude.ai/code/session_013oEKe9Yh9GvT1ati51SB2D)_