### PR TITLE
Add technical documentation wiki and fix pre-existing docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,45 @@
+# VoxCtr Documentation
+
+VoxCtr is a high-performance, privacy-first voice-to-text dictation application and programmable voice input broker. All processing happens 100% on-device with zero telemetry or cloud dependencies.
+
+---
+
+## Wiki Index
+
+| Document | Description |
+|---|---|
+| [Overview](./overview.md) | What VoxCtr does, key features, and design principles |
+| [Architecture](./architecture.md) | System design, crate layout, data flow, concurrency model |
+| [Audio Pipeline](./audio.md) | Audio capture, device management, VAD, resampling |
+| [Speech Recognition](./speech-recognition.md) | Whisper engine, models, inference pipeline, post-processing |
+| [Routing](./routing.md) | Output targets, hotkey bindings, delivery types |
+| [Hotkeys](./hotkeys.md) | Global hotkey listener, gestures, platform support |
+| [Text-to-Speech](./tts.md) | TTS engines, voice packs, playback |
+| [Integrations](./integrations.md) | MCP server, DBus service, Ollama, webhooks |
+| [UI & Windows](./ui.md) | Svelte frontend, overlay, history viewer, settings |
+| [API Reference](./api.md) | Tauri IPC commands and frontend events |
+| [Configuration](./configuration.md) | All config files, schemas, and options |
+| [Installation & Setup](./installation.md) | Dependencies, building, running |
+| [Development Guide](./development.md) | Dev environment, build system, crate structure |
+
+---
+
+## Quick Summary
+
+```
+Microphone → Audio Capture → Whisper Inference → Post-Processing → Output Router
+                                                                         │
+                                               ┌────────────────────────┤
+                                               │                        │
+                                          Inject text            Clipboard/File/
+                                          to window              HTTP/Webhook/Socket/
+                                                                 DBus/MCP/Exec/Pipe
+```
+
+**Tech Stack:**
+- **Frontend:** Svelte 5 + Tailwind CSS 4 + Vite 5
+- **Desktop Shell:** Tauri 2 (Rust + WebView)
+- **Backend:** Rust (Tokio async), ~10 specialized crates
+- **Speech:** whisper.cpp (GGUF models, CPU/CUDA/Vulkan)
+- **TTS:** Piper (ONNX neural voices) + Espeak-ng fallback
+- **Config:** TOML + JSON, hot-reloadable

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,421 @@
+# API Reference
+
+## Tauri IPC Commands
+
+These are the commands the Svelte frontend (or any Tauri WebView) can call via `invoke()`.
+
+**Source:** `src-tauri/src/commands.rs`
+
+```typescript
+import { invoke } from '@tauri-apps/api/core';
+```
+
+---
+
+### Status & Recording
+
+#### `get_status() → AppStatus`
+Returns the current application state.
+
+```typescript
+const status = await invoke<AppStatus>('get_status');
+```
+
+```typescript
+interface AppStatus {
+  recording: boolean;
+  processing: boolean;
+  speaking: boolean;
+  word_count: number;
+  active_target: string;
+}
+```
+
+---
+
+#### `start_recording(targetId?: string) → void`
+Begins audio capture. Optionally specifies which target to route output to.
+
+```typescript
+await invoke('start_recording', { targetId: 'default' });
+```
+
+---
+
+#### `stop_recording() → void`
+Stops audio capture and triggers the inference pipeline.
+
+```typescript
+await invoke('stop_recording');
+```
+
+---
+
+#### `toggle_recording(targetId?: string) → void`
+Starts recording if idle, stops if recording.
+
+```typescript
+await invoke('toggle_recording');
+```
+
+---
+
+### Configuration
+
+#### `get_config() → AppConfig`
+Returns the full application configuration.
+
+```typescript
+const config = await invoke<AppConfig>('get_config');
+```
+
+---
+
+#### `save_config(config: AppConfig) → void`
+Persists the configuration to `~/.config/voxctl/config.json`.
+
+```typescript
+await invoke('save_config', { config: myConfig });
+```
+
+---
+
+### Routing
+
+#### `get_targets() → OutputTarget[]`
+Returns all output targets from `targets.toml`.
+
+```typescript
+const targets = await invoke<OutputTarget[]>('get_targets');
+```
+
+---
+
+#### `save_targets(targets: OutputTarget[]) → void`
+Writes updated targets to `targets.toml` and hot-reloads the router.
+
+```typescript
+await invoke('save_targets', { targets: myTargets });
+```
+
+---
+
+#### `get_bindings() → HotkeyBinding[]`
+Returns all hotkey bindings from `bindings.toml`.
+
+```typescript
+const bindings = await invoke<HotkeyBinding[]>('get_bindings');
+```
+
+---
+
+#### `save_bindings(bindings: HotkeyBinding[]) → void`
+Writes updated bindings to `bindings.toml` and hot-reloads the hotkey listener.
+
+```typescript
+await invoke('save_bindings', { bindings: myBindings });
+```
+
+---
+
+### History
+
+#### `get_history() → HistoryEntry[]`
+Returns the transcription history (in-memory, current session only).
+
+```typescript
+const history = await invoke<HistoryEntry[]>('get_history');
+```
+
+```typescript
+interface HistoryEntry {
+  id: number;
+  text: string;
+  raw_text: string;
+  target_id: string;
+  timestamp: string;    // ISO 8601
+  word_count: number;
+  inference_ms: number;
+  language: string;
+}
+```
+
+---
+
+#### `clear_history() → void`
+Clears the in-memory history log.
+
+```typescript
+await invoke('clear_history');
+```
+
+---
+
+### Text-to-Speech
+
+#### `speak_text(text: string, voice?: string) → void`
+Queues text for TTS playback.
+
+```typescript
+await invoke('speak_text', { text: 'Hello world', voice: 'en_US-lessac-medium' });
+```
+
+---
+
+#### `check_voice_downloaded(name: string) → boolean`
+Returns whether a Piper voice pack is available locally.
+
+```typescript
+const downloaded = await invoke<boolean>('check_voice_downloaded', {
+  name: 'en_US-lessac-medium'
+});
+```
+
+---
+
+#### `download_voice(name: string) → void`
+Downloads a Piper voice pack from GitHub. Progress is emitted via Tauri events.
+
+```typescript
+await invoke('download_voice', { name: 'en_US-ryan-high' });
+```
+
+---
+
+### Speech Recognition Models
+
+#### `check_model_downloaded(size: string) → boolean`
+Returns whether a Whisper model file is present locally.
+
+```typescript
+const downloaded = await invoke<boolean>('check_model_downloaded', { size: 'base' });
+```
+
+---
+
+#### `download_model(size: string) → void`
+Downloads a Whisper GGUF model. Size: `"tiny"` | `"base"` | `"small"` | `"medium"` | `"large-v3"`.
+
+```typescript
+await invoke('download_model', { size: 'small' });
+```
+
+---
+
+### Audio Monitoring
+
+#### `start_monitoring_audio() → void`
+Starts streaming `audio-level` events to the frontend (for VU meter display).
+
+```typescript
+await invoke('start_monitoring_audio');
+```
+
+---
+
+#### `stop_monitoring_audio() → void`
+Stops `audio-level` event streaming.
+
+```typescript
+await invoke('stop_monitoring_audio');
+```
+
+---
+
+#### `list_audio_devices() → AudioDevice[]`
+Returns all available input devices.
+
+```typescript
+const devices = await invoke<AudioDevice[]>('list_audio_devices');
+```
+
+```typescript
+interface AudioDevice {
+  index: number;
+  name: string;
+}
+```
+
+---
+
+### Ollama
+
+#### `test_ollama(endpoint: string, timeoutSecs: number) → OllamaTestResult`
+Pings an Ollama endpoint and lists available models.
+
+```typescript
+const result = await invoke<OllamaTestResult>('test_ollama', {
+  endpoint: 'http://localhost:11434',
+  timeoutSecs: 5
+});
+```
+
+```typescript
+interface OllamaTestResult {
+  success: boolean;
+  message: string;
+  models: string[];
+}
+```
+
+---
+
+### Overlay
+
+#### `show_overlay() → void`
+Makes the overlay window visible.
+
+```typescript
+await invoke('show_overlay');
+```
+
+---
+
+#### `hide_overlay() → void`
+Hides the overlay window.
+
+```typescript
+await invoke('hide_overlay');
+```
+
+---
+
+## Tauri Events (Backend → Frontend)
+
+Subscribe with `listen()` from `@tauri-apps/api/event`.
+
+```typescript
+import { listen } from '@tauri-apps/api/event';
+```
+
+---
+
+### `status-tick`
+Emitted every 250ms with the current application state.
+
+```typescript
+await listen<AppStatus>('status-tick', (event) => {
+  console.log(event.payload.recording); // boolean
+});
+```
+
+---
+
+### `config-changed`
+Emitted when the config file is modified externally (file watcher) or by another window.
+
+```typescript
+await listen<AppConfig>('config-changed', (event) => {
+  config.set(event.payload);
+});
+```
+
+---
+
+### `audio-level`
+Emitted during audio monitoring with the current RMS energy level (0.0 – 1.0).
+
+```typescript
+await listen<number>('audio-level', (event) => {
+  updateVuMeter(event.payload);
+});
+```
+
+---
+
+## TypeScript Types
+
+```typescript
+interface AppConfig {
+  engine: EngineConfig;
+  audio: AudioConfig;
+  ui: UiConfig;
+  features: FeaturesConfig;
+  ollama: OllamaConfig;
+  tts: TtsConfig;
+  mcp: McpConfig;
+  atspi: AtspiConfig;
+}
+
+interface EngineConfig {
+  backend: 'whisper' | 'moonshine';
+  model_size: 'tiny' | 'base' | 'small' | 'medium' | 'large-v3';
+  device: 'auto' | 'cpu' | 'cuda' | 'vulkan';
+  language: string;
+}
+
+interface AudioConfig {
+  device_index: number;
+  gain: number;
+  vad_threshold: number;
+  dynamic_stream: boolean;
+}
+
+interface UiConfig {
+  overlay_style: 'ocean_wave' | 'voice_card' | 'waveform' | 'pulse';
+  auto_show_overlay: boolean;
+  show_notification: boolean;
+  history_enabled: boolean;
+}
+
+interface FeaturesConfig {
+  remove_fillers: boolean;
+  snippets: Record<string, string>;
+  vocabulary: string[];
+}
+
+interface OllamaConfig {
+  enabled: boolean;
+  endpoint: string;
+  model: string;
+  mode: 'clean' | 'formal' | 'casual' | 'bullet' | 'concise' | 'custom';
+  custom_prompt: string;
+}
+
+interface TtsConfig {
+  enabled: boolean;
+  engine: 'piper' | 'espeak';
+  voice: string;
+  stop_keys: string[];
+}
+
+interface McpConfig {
+  enabled: boolean;
+  record_timeout: number;
+}
+
+interface AtspiConfig {
+  enabled: boolean;
+  context_prompt: boolean;
+  auto_code_mode: boolean;
+}
+
+interface OutputTarget {
+  id: string;
+  label: string;
+  delivery: 'inject' | 'clipboard' | 'exec' | 'pipe' | 'socket' | 'file' | 'dbus' | 'http' | 'webhook' | 'mcp';
+  file_path?: string;
+  file_prefix: string;
+  file_timestamp: boolean;
+  http_url?: string;
+  webhook_secret?: string;
+  exec_command?: string;
+  socket_path?: string;
+  pipe_path?: string;
+  send_on_release: boolean;
+  append_newline: boolean;
+  initial_prompt?: string;
+  tts_engine: string;
+  processing?: TargetProcessingConfig;
+}
+
+interface HotkeyBinding {
+  id: string;
+  label: string;
+  keys: string[];
+  gesture: 'hold' | 'toggle' | 'double';
+  target_id?: string;
+  target_ids: string[];
+  disabled: boolean;
+}
+```

--- a/docs/api.md
+++ b/docs/api.md
@@ -14,36 +14,38 @@ import { invoke } from '@tauri-apps/api/core';
 
 ### Status & Recording
 
-#### `get_status() → AppStatus`
+#### `get_status() → StatusPayload`
 Returns the current application state.
 
 ```typescript
-const status = await invoke<AppStatus>('get_status');
+const status = await invoke<StatusPayload>('get_status');
 ```
 
 ```typescript
-interface AppStatus {
+interface StatusPayload {
   recording: boolean;
   processing: boolean;
   speaking: boolean;
+  audio_ready: boolean;
   word_count: number;
-  active_target: string;
+  active_target_id: string;
+  active_target_label: string;
 }
 ```
 
 ---
 
-#### `start_recording(targetId?: string) → void`
-Begins audio capture. Optionally specifies which target to route output to.
+#### `start_recording() → void`
+Sets the recording flag to true. The audio pipeline will start capturing.
 
 ```typescript
-await invoke('start_recording', { targetId: 'default' });
+await invoke('start_recording');
 ```
 
 ---
 
 #### `stop_recording() → void`
-Stops audio capture and triggers the inference pipeline.
+Sets the recording flag to false, signaling the audio pipeline to stop.
 
 ```typescript
 await invoke('stop_recording');
@@ -51,11 +53,11 @@ await invoke('stop_recording');
 
 ---
 
-#### `toggle_recording(targetId?: string) → void`
-Starts recording if idle, stops if recording.
+#### `toggle_recording() → boolean`
+Toggles recording state. Returns the **new** recording state.
 
 ```typescript
-await invoke('toggle_recording');
+const nowRecording = await invoke<boolean>('toggle_recording');
 ```
 
 ---
@@ -71,12 +73,14 @@ const config = await invoke<AppConfig>('get_config');
 
 ---
 
-#### `save_config(config: AppConfig) → void`
-Persists the configuration to `~/.config/voxctl/config.json`.
+#### `save_config(newConfig: AppConfig) → void`
+Persists configuration to `~/.config/voxctl/config.json` and emits a `config-changed` event to all windows.
 
 ```typescript
-await invoke('save_config', { config: myConfig });
+await invoke('save_config', { newConfig: myConfig });
 ```
+
+Note the parameter name is `newConfig` (camelCase), not `config`.
 
 ---
 
@@ -92,7 +96,7 @@ const targets = await invoke<OutputTarget[]>('get_targets');
 ---
 
 #### `save_targets(targets: OutputTarget[]) → void`
-Writes updated targets to `targets.toml` and hot-reloads the router.
+Writes updated targets to `targets.toml`, updates the in-memory cache, hot-reloads the router, and spawns any new FIFO response pipe listeners.
 
 ```typescript
 await invoke('save_targets', { targets: myTargets });
@@ -110,7 +114,7 @@ const bindings = await invoke<HotkeyBinding[]>('get_bindings');
 ---
 
 #### `save_bindings(bindings: HotkeyBinding[]) → void`
-Writes updated bindings to `bindings.toml` and hot-reloads the hotkey listener.
+Writes updated bindings to `bindings.toml` and sends a hot-reload signal to the hotkey listener thread.
 
 ```typescript
 await invoke('save_bindings', { bindings: myBindings });
@@ -129,21 +133,17 @@ const history = await invoke<HistoryEntry[]>('get_history');
 
 ```typescript
 interface HistoryEntry {
-  id: number;
   text: string;
-  raw_text: string;
   target_id: string;
   timestamp: string;    // ISO 8601
-  word_count: number;
   inference_ms: number;
-  language: string;
 }
 ```
 
 ---
 
 #### `clear_history() → void`
-Clears the in-memory history log.
+Clears the in-memory history log and resets the word count.
 
 ```typescript
 await invoke('clear_history');
@@ -157,55 +157,59 @@ await invoke('clear_history');
 Queues text for TTS playback.
 
 ```typescript
-await invoke('speak_text', { text: 'Hello world', voice: 'en_US-lessac-medium' });
+await invoke('speak_text', { text: 'Hello world', voice: 'en-us-lessac-medium' });
 ```
+
+`voice` is optional — omit to use the configured default.
 
 ---
 
-#### `check_voice_downloaded(name: string) → boolean`
+#### `check_voice_downloaded(voiceName: string) → boolean`
 Returns whether a Piper voice pack is available locally.
 
 ```typescript
 const downloaded = await invoke<boolean>('check_voice_downloaded', {
-  name: 'en_US-lessac-medium'
+  voiceName: 'en-us-lessac-medium'
 });
 ```
 
 ---
 
-#### `download_voice(name: string) → void`
-Downloads a Piper voice pack from GitHub. Progress is emitted via Tauri events.
+#### `download_voice(voiceName: string) → void`
+Downloads a Piper voice pack from GitHub.
 
 ```typescript
-await invoke('download_voice', { name: 'en_US-ryan-high' });
+await invoke('download_voice', { voiceName: 'en-us-ryan-high' });
 ```
 
 ---
 
 ### Speech Recognition Models
 
-#### `check_model_downloaded(size: string) → boolean`
-Returns whether a Whisper model file is present locally.
+#### `check_model_downloaded(modelSize: string) → boolean`
+Returns whether a Whisper model GGUF file is present locally.
 
 ```typescript
-const downloaded = await invoke<boolean>('check_model_downloaded', { size: 'base' });
+const downloaded = await invoke<boolean>('check_model_downloaded', { modelSize: 'base' });
 ```
 
 ---
 
-#### `download_model(size: string) → void`
-Downloads a Whisper GGUF model. Size: `"tiny"` | `"base"` | `"small"` | `"medium"` | `"large-v3"`.
+#### `download_model(modelSize: string) → void`
+Downloads a Whisper GGUF model.
 
 ```typescript
-await invoke('download_model', { size: 'small' });
+await invoke('download_model', { modelSize: 'small' });
 ```
+
+Valid sizes: `"tiny"`, `"tiny.en"`, `"base"`, `"base.en"`, `"small"`, `"small.en"`, `"medium"`, `"medium.en"`, `"large-v2"`, `"large-v3"`, `"large-v3-turbo"`
 
 ---
 
 ### Audio Monitoring
 
 #### `start_monitoring_audio() → void`
-Starts streaming `audio-level` events to the frontend (for VU meter display).
+Enables the monitoring flag so `audio-level` events are emitted for the VU meter.
 
 ```typescript
 await invoke('start_monitoring_audio');
@@ -214,7 +218,7 @@ await invoke('start_monitoring_audio');
 ---
 
 #### `stop_monitoring_audio() → void`
-Stops `audio-level` event streaming.
+Disables monitoring and stops `audio-level` event streaming.
 
 ```typescript
 await invoke('stop_monitoring_audio');
@@ -222,15 +226,15 @@ await invoke('stop_monitoring_audio');
 
 ---
 
-#### `list_audio_devices() → AudioDevice[]`
+#### `list_audio_devices() → AudioDeviceInfo[]`
 Returns all available input devices.
 
 ```typescript
-const devices = await invoke<AudioDevice[]>('list_audio_devices');
+const devices = await invoke<AudioDeviceInfo[]>('list_audio_devices');
 ```
 
 ```typescript
-interface AudioDevice {
+interface AudioDeviceInfo {
   index: number;
   name: string;
 }
@@ -263,13 +267,11 @@ interface OllamaTestResult {
 ### Overlay
 
 #### `show_overlay() → void`
-Makes the overlay window visible.
+Makes the overlay window visible and sets always-on-top.
 
 ```typescript
 await invoke('show_overlay');
 ```
-
----
 
 #### `hide_overlay() → void`
 Hides the overlay window.
@@ -288,21 +290,17 @@ Subscribe with `listen()` from `@tauri-apps/api/event`.
 import { listen } from '@tauri-apps/api/event';
 ```
 
----
-
 ### `status-tick`
-Emitted every 250ms with the current application state.
+Emitted every ~250ms with the current application state.
 
 ```typescript
 await listen<AppStatus>('status-tick', (event) => {
-  console.log(event.payload.recording); // boolean
+  console.log(event.payload.recording);
 });
 ```
 
----
-
 ### `config-changed`
-Emitted when the config file is modified externally (file watcher) or by another window.
+Emitted when the config is saved (from any window or external change).
 
 ```typescript
 await listen<AppConfig>('config-changed', (event) => {
@@ -310,10 +308,8 @@ await listen<AppConfig>('config-changed', (event) => {
 });
 ```
 
----
-
 ### `audio-level`
-Emitted during audio monitoring with the current RMS energy level (0.0 – 1.0).
+Emitted during monitoring with the current RMS energy level (0.0–1.0+).
 
 ```typescript
 await listen<number>('audio-level', (event) => {
@@ -324,6 +320,8 @@ await listen<number>('audio-level', (event) => {
 ---
 
 ## TypeScript Types
+
+These types are defined in `src/stores/config.ts`:
 
 ```typescript
 interface AppConfig {
@@ -338,54 +336,75 @@ interface AppConfig {
 }
 
 interface EngineConfig {
-  backend: 'whisper' | 'moonshine';
-  model_size: 'tiny' | 'base' | 'small' | 'medium' | 'large-v3';
-  device: 'auto' | 'cpu' | 'cuda' | 'vulkan';
+  backend: "auto" | "whisper-cpp" | "moonshine";
+  inference_mode: "Balanced" | "Aggressive";
+  whisper_cpp: WhisperCppConfig;
+  moonshine: MoonshineConfig;
+}
+
+interface WhisperCppConfig {
+  model_dir: string;
+  model_size: string;
+  device: string;
+  threads: number;
+}
+
+interface MoonshineConfig {
+  model_size: string;
   language: string;
 }
 
 interface AudioConfig {
-  device_index: number;
-  gain: number;
   vad_threshold: number;
+  min_silence_duration_ms: number;
+  input_device_index: number | null;
+  evdev_device: string | null;
+  noise_suppression: boolean;
+  gain: number;
   dynamic_stream: boolean;
 }
 
 interface UiConfig {
-  overlay_style: 'ocean_wave' | 'voice_card' | 'waveform' | 'pulse';
-  auto_show_overlay: boolean;
+  show_overlay: boolean;
+  overlay_style: "voice_card" | "waveform" | "pulse" | "blue_wave" | "none";
+  auto_show_settings: boolean;
   show_notification: boolean;
   history_enabled: boolean;
 }
 
 interface FeaturesConfig {
   remove_fillers: boolean;
+  custom_vocabulary: string[];
+  spoken_punctuation: boolean;
+  auto_format_lists: boolean;
+  quiet_mode: boolean;
   snippets: Record<string, string>;
-  vocabulary: string[];
 }
 
 interface OllamaConfig {
   enabled: boolean;
-  endpoint: string;
   model: string;
-  mode: 'clean' | 'formal' | 'casual' | 'bullet' | 'concise' | 'custom';
-  custom_prompt: string;
+  mode: "clean" | "formal" | "casual" | "bullet" | "concise" | "custom";
+  custom_prompt: string | null;
+  endpoint: string;
+  timeout_secs: number;
 }
 
 interface TtsConfig {
   enabled: boolean;
-  engine: 'piper' | 'espeak';
+  engine: "piper" | "espeak";
   voice: string;
-  stop_keys: string[];
+  stop_key: string[];       // singular field name, plural value
+  response_overlay: boolean;
 }
 
 interface McpConfig {
-  enabled: boolean;
+  server_enabled: boolean;  // not "enabled"
   record_timeout: number;
 }
 
 interface AtspiConfig {
-  enabled: boolean;
+  injection: boolean;       // not "enabled"
   context_prompt: boolean;
   auto_code_mode: boolean;
 }
@@ -393,29 +412,92 @@ interface AtspiConfig {
 interface OutputTarget {
   id: string;
   label: string;
-  delivery: 'inject' | 'clipboard' | 'exec' | 'pipe' | 'socket' | 'file' | 'dbus' | 'http' | 'webhook' | 'mcp';
+  delivery: "inject" | "clipboard" | "exec" | "pipe" | "socket" | "file" | "dbus" | "http" | "webhook" | "mcp";
+
+  // exec
+  command?: string;
+
+  // pipe
+  pipe_path?: string;
+
+  // socket (unix or TCP)
+  socket_unix?: string;
+  socket_host?: string;
+  socket_port?: number;
+
+  // file
   file_path?: string;
   file_prefix: string;
   file_timestamp: boolean;
+  file_mode: string;        // "append" or "write"
+
+  // dbus
+  dbus_signal?: string;
+
+  // http
   http_url?: string;
+  http_method: string;
+
+  // webhook (note: webhook_url, not http_url)
+  webhook_url?: string;
   webhook_secret?: string;
-  exec_command?: string;
-  socket_path?: string;
-  pipe_path?: string;
-  send_on_release: boolean;
-  append_newline: boolean;
+
+  // mcp
+  mcp_path?: string;
+  mcp_tool?: string;
+
+  send_on_release: boolean;   // default: true
+  append_newline: boolean;    // default: true
   initial_prompt?: string;
+
+  processing: TargetProcessingConfig;
+
   tts_engine: string;
-  processing?: TargetProcessingConfig;
+  tts_voice?: string;
+  response_pipe?: string;
+}
+
+interface TargetProcessingConfig {
+  noise_suppression?: boolean;
+  quiet_mode?: boolean;
+  atspi_context?: boolean;
+  remove_fillers?: boolean;
+  spoken_punctuation?: boolean;
+  auto_format_lists?: boolean;
+  apply_snippets?: boolean;
+  code_mode?: boolean;
+  ollama_enabled?: boolean;
+  ollama_model?: string;
+  ollama_mode?: string;
+  ollama_prompt?: string;
 }
 
 interface HotkeyBinding {
   id: string;
   label: string;
   keys: string[];
-  gesture: 'hold' | 'toggle' | 'double';
-  target_id?: string;
+  gesture: "hold" | "toggle" | "double_tap" | "chord";
+  target_id: string;
   target_ids: string[];
+  tap_ms: number;           // default: 250
+  hold_threshold_ms: number;// default: 200
   disabled: boolean;
+}
+
+interface AppStatus {
+  recording: boolean;
+  processing: boolean;
+  speaking: boolean;
+  audio_ready?: boolean;
+  word_count: number;
+  active_target_id?: string;
+  active_target_label?: string;
+}
+
+interface HistoryEntry {
+  text: string;
+  target_id: string;
+  timestamp: string;
+  inference_ms: number;
 }
 ```

--- a/docs/appimage_build_process.md
+++ b/docs/appimage_build_process.md
@@ -28,7 +28,7 @@ graph TD
 
     subgraph Output Bundles [4. Standalone Packages]
         H -->|Assembles| I[target/release/bundle/appimage/VoxCtr_*.AppImage]
-        I -->|Exposed by build_appimage.sh| J[Root: VoxCtl-x86_64.AppImage]
+        I -->|Exposed by build_appimage.sh| J[Root: VoxCtl-x86_64.AppImage *]
     end
 
     classDef primary fill:#0f172a,stroke:#38bdf8,stroke-width:2px,color:#fff;
@@ -51,18 +51,18 @@ Before executing a build, ensure the host machine has the core compilation packa
 | **Rust Toolchain** | Rust compiler and Cargo bundle tools. | `rustup` / `rust` | `rustc` / `cargo` |
 | **Node.js Environment** | Package manager and Vite bundling. | `nodejs` `npm` | `nodejs` `npm` |
 | **System Webview** | Tauri interface runtime dependency. | `webkit2gtk-4.1` | `libwebkit2gtk-4.1-dev` |
-| **Audio Library** | Low-latency audio capture stream backend. | `portaudio` | `portaudio19-dev` |
+| **Audio Library** | Low-latency audio capture via CPAL/ALSA. | `alsa-lib` | `libasound2-dev` |
 | **Desktop Integrations**| System tray application icons support. | `libayatana-appindicator` | `libayatana-appindicator3-dev` |
 
 ### Rapid Prerequisites Install
 * **Arch Linux / CachyOS**:
   ```bash
-  sudo pacman -S --needed base-devel rustup nodejs npm webkit2gtk-4.1 portaudio libayatana-appindicator squashfs-tools
+  sudo pacman -S --needed base-devel rustup nodejs npm webkit2gtk-4.1 alsa-lib libayatana-appindicator squashfs-tools
   ```
 * **Ubuntu / Debian**:
   ```bash
   sudo apt-get update
-  sudo apt-get install -y build-essential curl nodejs npm pkg-config libwebkit2gtk-4.1-dev libssl-dev libayatana-appindicator3-dev portaudio19-dev squashfs-tools
+  sudo apt-get install -y build-essential curl nodejs npm pkg-config libwebkit2gtk-4.1-dev libssl-dev libayatana-appindicator3-dev libasound2-dev squashfs-tools
   ```
 
 ---
@@ -81,7 +81,7 @@ chmod +x build_appimage.sh
 2. **Frontend Compiles**: Compiles all visual assets and generates the optimized production build (`/dist`).
 3. **Environment Setup**: Prepends the workspace root to the shell `$PATH` and exports `APPIMAGE_EXTRACT_AND_RUN=1` and `QT_QPA_PLATFORM=offscreen` to allow FUSE-less head-free compilation.
 4. **Tauri Releases**: Runs `npx tauri build` to compile the optimized release binary and bundles it using the FUSE-bypass tools.
-5. **Relocation**: Exposes the completed executable as `VoxCtl-x86_64.AppImage` directly in the project root.
+5. **Relocation**: Copies the completed executable as `VoxCtl-x86_64.AppImage` directly in the project root. Note: the output filename uses `VoxCtl` (with a lowercase `l`) — this is the legacy artifact name produced by `build_appimage.sh` and has not yet been renamed to match the current `VoxCtr` branding.
 
 ---
 
@@ -105,13 +105,18 @@ To resolve this, we bypass the platform's editor hooks by writing the correct ba
 
 ```bash
 # 1. Re-write the correct wrapper script directly via the shell
+# NOTE: If your IDE/container injects a custom PATH entry that is being
+#       written into the shebang, adjust the sed pattern below to match
+#       your environment's injected bin path.
 cat << 'EOF' > ~/.cache/tauri/linuxdeploy-x86_64.AppImage
 #!/bin/bash
 export APPIMAGE_EXTRACT_AND_RUN=1
 export NO_STRIP=1
 export QT_QPA_PLATFORM=offscreen
-export PATH=$(echo $PATH | sed 's|/home/jrufer/.gemini/antigravity-ide/bin:||g')
-exec /home/jrufer/.cache/tauri/linuxdeploy-x86_64.AppImage.real "$@" --exclude-library=libselinux* --exclude-library=libgio* --exclude-library=*gdk_pixbuf*
+# Remove any IDE-injected PATH entries that corrupt the linuxdeploy wrapper.
+# Adjust the pattern below to match your environment if needed.
+export PATH=$(echo $PATH | sed 's|<YOUR_IDE_BIN_PATH>:||g')
+exec "$HOME/.cache/tauri/linuxdeploy-x86_64.AppImage.real" "$@" --exclude-library=libselinux* --exclude-library=libgio* --exclude-library=*gdk_pixbuf*
 EOF
 
 # 2. REVOKE write permissions to make the file immutable to the broken platform hook
@@ -149,7 +154,7 @@ Because `install.sh` adds your account to the low-level `input` group for global
 
 ## 📋 Build Flags & Config Reference
 
-* **Tauri Config ([tauri.conf.json](file:///home/jrufer/Development/VoxCtr/src-tauri/tauri.conf.json))**:
+* **Tauri Config (`src-tauri/tauri.conf.json`)**:
   * `"targets": ["appimage"]`: Isolated to bundle exclusively the AppImage target. Can be set back to `"all"` to compile `.deb` and `.rpm` files if production repositories require standard package formats.
 * **Environment Variables**:
   * `APPIMAGE_EXTRACT_AND_RUN=1`: Directs packaging and runtime binaries to extract themselves into `/tmp` rather than attempting FUSE mounts.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,10 +75,16 @@ voxctr-hotkeys ──gesture_tx──► lib.rs coordinator
                          ▼
                   InferenceEngine.process()
                   (voxctr-inference)
+                    │  Noise gate (VAD)
                     │  Whisper transcription
                     │  Filler removal
+                    │  Spoken punctuation
+                    │  Auto-format lists
                     │  Snippet expansion
-                    │  Ollama rewrite (optional)
+                    │  Custom vocab fuzzy correction
+                    │  Code mode
+                    │  Silence hallucination filter
+                    │  Ollama rewrite (optional, per-target)
                          │
                     text_tx (InferenceOutput)
                          │
@@ -126,7 +132,7 @@ VoxCtr uses Tokio for async I/O plus dedicated OS threads for latency-sensitive 
 - `text_tx` / `text_rx` — `InferenceOutput`
 - `audio_level_tx` / `level_rx` — `f32` RMS
 - `gesture_tx` / `gesture_rx` — `GestureEvent`
-- `binding_reload_tx` — updated bindings list (hot-reload)
+- `hotkey_reloader` — updated bindings list sent to listener thread (hot-reload)
 
 ---
 
@@ -136,19 +142,19 @@ The Svelte frontend is a single-page app with three logical "pages" rendered as 
 
 ```
 App.svelte  (route switcher)
-  ├── /settings  → Settings component
+  ├── /settings  → Settings component (sidebar with 9 tabs)
   │     ├── GeneralTab
-  │     ├── AudioTab
-  │     ├── VisualTab
-  │     ├── RoutingTab
-  │     ├── HotkeysTab
   │     ├── EngineTab
-  │     ├── OllamaTab
+  │     ├── RoutingTab     (targets + bindings editor)
+  │     ├── VisualTab
+  │     ├── AudioTab
   │     ├── TtsTab
+  │     ├── FeaturesTab
+  │     ├── OllamaTab
   │     └── AboutTab
   │
   ├── /overlay   → Overlay component
-  │     ├── OceanWave
+  │     ├── BlueWave       (default)
   │     ├── VoiceCard
   │     ├── Waveform
   │     └── Pulse
@@ -157,8 +163,8 @@ App.svelte  (route switcher)
 ```
 
 **State management:**
-- `src/stores/config.ts` — reactive `AppConfig` with 400ms debounced auto-save via `save_config` IPC
-- `src/stores/status.ts` — live recording/processing/speaking state from `status-tick` events
+- `src/stores/config.ts` — reactive `AppConfig` with 400ms debounced auto-save via `save_config` IPC; also listens for `config-changed` events
+- `src/stores/status.ts` — live state from `status-tick` events + derived stores (`recording`, `speaking`, `wordCount`, `activeTargetLabel`)
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,175 @@
+# Architecture
+
+## High-Level Design
+
+VoxCtr is a **Tauri 2** application: a compiled Rust backend that spawns a WebView window running a Svelte SPA. The two halves communicate via Tauri's IPC bridge (invoke commands + event emitters).
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    Tauri Desktop App                     │
+│                                                          │
+│  ┌───────────────────┐      ┌──────────────────────────┐ │
+│  │   Svelte Frontend │◄────►│    Rust Backend (lib.rs) │ │
+│  │   (WebView)       │ IPC  │    + crates workspace     │ │
+│  └───────────────────┘      └──────────────────────────┘ │
+└─────────────────────────────────────────────────────────┘
+         │                              │
+   Settings/Overlay/             Audio devices,
+   History windows               Filesystem, DBus,
+                                 Network (Ollama/HTTP)
+```
+
+---
+
+## Crate Workspace
+
+The backend is organized as a Cargo workspace of focused, single-responsibility crates:
+
+```
+VoxCtr/
+├── src-tauri/         # Tauri app entry + IPC command handlers
+│   └── src/
+│       ├── main.rs    # App bootstrap
+│       ├── lib.rs     # Pipeline coordinator (~2000 LOC)
+│       ├── commands.rs# Tauri #[command] handlers (~330 LOC)
+│       └── state.rs   # Shared AppState
+│
+└── crates/
+    ├── voxctr-config/     # AppConfig struct, TOML/JSON persistence
+    ├── voxctr-audio/      # Microphone capture, resampling, VU meter
+    ├── voxctr-hotkeys/    # Global key listener (evdev / Win32)
+    ├── voxctr-inference/  # Whisper transcription + post-processing
+    ├── voxctr-routing/    # OutputTarget + HotkeyBinding data models, router
+    ├── voxctr-inject/     # Text injection via wtype/xdotool/clipboard
+    ├── voxctr-tts/        # Piper/Espeak TTS engine
+    ├── voxctr-mcp/        # MCP JSON-RPC server (Unix socket / named pipe)
+    ├── voxctr-dbus/       # DBus service (Linux session bus)
+    └── voxctr-llm/        # Ollama HTTP client
+```
+
+---
+
+## Data Flow
+
+```
+Hotkey press
+     │
+     ▼
+voxctr-hotkeys ──gesture_tx──► lib.rs coordinator
+                                      │
+                         ┌────────────┤
+                         │            │
+                  Start AudioRecorder  Determine target from binding
+                  (voxctr-audio)
+                         │
+                    audio_tx chunks
+                         │
+                         ▼
+                  Audio Accumulator
+                  (lib.rs buffer)
+                         │
+                  Hotkey release / VAD stop
+                         │
+                    inference_tx
+                         │
+                         ▼
+                  InferenceEngine.process()
+                  (voxctr-inference)
+                    │  Whisper transcription
+                    │  Filler removal
+                    │  Snippet expansion
+                    │  Ollama rewrite (optional)
+                         │
+                    text_tx (InferenceOutput)
+                         │
+                         ▼
+                  OutputTargetRouter.route()
+                  (voxctr-routing)
+                    ├── inject → voxctr-inject
+                    ├── clipboard → arboard
+                    ├── file → tokio::fs
+                    ├── http/webhook → reqwest
+                    ├── exec → std::process
+                    ├── socket → UnixStream
+                    ├── dbus → voxctr-dbus
+                    ├── mcp → voxctr-mcp response queue
+                    └── pipe → named FIFO
+                         │
+                    Tauri event → frontend
+                    (status-tick, history update)
+```
+
+---
+
+## Concurrency Model
+
+VoxCtr uses Tokio for async I/O plus dedicated OS threads for latency-sensitive work:
+
+| Thread / Task | Type | Purpose |
+|---|---|---|
+| Main Tauri thread | OS thread | Window management, IPC dispatch |
+| Audio capture | OS thread (cpal) | Microphone streaming at hardware rate |
+| Audio level emitter | Tokio task | Forwards RMS levels to UI every ~50ms |
+| Hotkey listener | OS thread | evdev/Win32 event loop |
+| Inference worker | OS thread | Blocking Whisper computation |
+| Status ticker | Tokio task | Emits `status-tick` events every 250ms |
+| Config watcher | Tokio task | `inotify`/`kqueue` on config files |
+| MCP server | Tokio task | Unix socket accept loop |
+| DBus service | Tokio task | Session bus method handler |
+| TTS FIFO watcher | Tokio task | Named pipe reader for TTS input |
+
+**Shared state** is an `Arc<AppState>` with `AtomicBool`/`AtomicU32` for hot-path flags and `Mutex` for heavier data (targets, history, TTS handle).
+
+**Channels** (crossbeam/tokio):
+- `audio_tx` / `audio_rx` — `Vec<f32>` chunks
+- `inference_tx` / `inference_rx` — `InferenceRequest`
+- `text_tx` / `text_rx` — `InferenceOutput`
+- `audio_level_tx` / `level_rx` — `f32` RMS
+- `gesture_tx` / `gesture_rx` — `GestureEvent`
+- `binding_reload_tx` — updated bindings list (hot-reload)
+
+---
+
+## Frontend Architecture
+
+The Svelte frontend is a single-page app with three logical "pages" rendered as separate Tauri windows:
+
+```
+App.svelte  (route switcher)
+  ├── /settings  → Settings component
+  │     ├── GeneralTab
+  │     ├── AudioTab
+  │     ├── VisualTab
+  │     ├── RoutingTab
+  │     ├── HotkeysTab
+  │     ├── EngineTab
+  │     ├── OllamaTab
+  │     ├── TtsTab
+  │     └── AboutTab
+  │
+  ├── /overlay   → Overlay component
+  │     ├── OceanWave
+  │     ├── VoiceCard
+  │     ├── Waveform
+  │     └── Pulse
+  │
+  └── /history   → History component
+```
+
+**State management:**
+- `src/stores/config.ts` — reactive `AppConfig` with 400ms debounced auto-save via `save_config` IPC
+- `src/stores/status.ts` — live recording/processing/speaking state from `status-tick` events
+
+---
+
+## File Locations
+
+| Path | Contents |
+|---|---|
+| `~/.config/voxctl/config.json` | Main application config |
+| `~/.config/voxctl/targets.toml` | Output target definitions |
+| `~/.config/voxctl/bindings.toml` | Hotkey binding definitions |
+| `~/.local/share/voxctl/models/` | Downloaded Whisper GGUF models |
+| `~/.local/share/voxctl/piper-voices/` | Downloaded Piper voice packs |
+| `/tmp/voxctl-mcp.sock` | MCP Unix domain socket (Linux) |
+| `\\.\pipe\voxctl-mcp` | MCP named pipe (Windows) |

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -7,7 +7,7 @@
 - Enumerate and select audio input devices
 - Stream raw PCM from the microphone via CPAL
 - Resample from the hardware rate to 16 kHz (Whisper's required input rate)
-- Compute RMS levels for the VU meter and noise gate
+- Compute RMS levels for the VU meter and VAD noise gate
 - Support two streaming modes: dynamic (on-demand) and always-on
 
 ---
@@ -16,82 +16,83 @@
 
 On startup, `test_and_detect_active_device()` probes devices in priority order:
 
-1. **Configured device** — `audio.device_index` from config
+1. **Configured device** — `audio.input_device_index` from config (if non-null)
 2. **Default input device** — CPAL's `default_input_device()`
-3. **First enumerable device** — iterates all hosts/devices
+3. **First enumerable device** — iterates all input devices, picks first that builds a stream
 
-A "test capture" of ~200ms is performed to confirm the device actually produces audio before committing to it. The result is stored atomically so the inference and UI layers can query it.
+A test stream is opened on each candidate to confirm it is functional before committing. If none succeed, CPAL's default device is used as a last resort.
 
-Devices are listed with `list_audio_devices()` which returns `(index, name)` pairs for the Settings → Audio tab.
+Devices are enumerated with `list_input_devices()`, which returns `(index: u32, name: String)` pairs for the Settings → Audio tab.
+
+The device can be **hot-reloaded** at runtime: if `audio.input_device_index` changes (via the UI), the capture loop detects the change and re-opens the stream on the new device without restarting.
 
 ---
 
 ## Streaming Modes
 
-### Dynamic Streaming (default)
-The microphone stream is opened when recording starts and closed when it stops. This is the default mode.
+### Dynamic Streaming (default, `dynamic_stream: true`)
+The microphone stream is opened when recording starts and closed when it stops.
 
 - Lower CPU/battery usage when idle
-- A small startup latency (~10–50ms) when a hotkey is pressed
+- A small startup latency (~30ms polling interval) on hotkey press
 - Suitable for most users
 
-### Always-On Streaming
-The stream stays open permanently. Chunks are buffered and discarded when not recording.
+### Always-On Streaming (`dynamic_stream: false`)
+The stream stays open permanently. Chunks are forwarded to the recording buffer only while recording is active; they are discarded otherwise.
 
 - Zero startup latency
 - Higher idle CPU usage
-- Required for VAD-triggered recording (future feature)
+- The stream also runs during VU meter monitoring (Settings → Audio tab)
 
-Toggle via `audio.dynamic_stream` in config.
+Both modes also serve the live audio monitoring flag used by the VU meter in the Settings → Audio tab.
 
 ---
 
 ## Audio Processing Chain
 
 ```
-Hardware Input (e.g. 48000 Hz, f32 or i16 samples)
+Hardware input (e.g. 48000 Hz, f32 samples)
         │
         ▼
-   normalize_samples()     — convert i16/i32/u16 to f32 [-1.0, 1.0]
+   apply_gain()         — multiply each sample by gain (atomic f32, live-updated)
         │
         ▼
-   apply_gain()             — multiply by gain factor (default 1.0)
+   rms() → level_tx     — f32 RMS forwarded to UI every ~30ms for VU meter
         │
         ▼
-   resample_chunk()         — linear interpolation to 16000 Hz
+   resample_chunk()      — linear interpolation to 16000 Hz (if hardware rate differs)
         │
         ▼
-   audio_tx.send(chunk)     — Vec<f32> forwarded to lib.rs accumulator
-        │
-        ▼
-   rms() → audio_level_tx   — f32 RMS forwarded to UI for visualization
+   audio_tx.send(chunk)  — Vec<f32> forwarded to lib.rs accumulator (only if recording=true)
 ```
 
 ### Resampling
 
-`resample_chunk(input, from_rate, to_rate)` uses linear interpolation via the **Rubato** library. This is fast and introduces minimal latency, which is more important than perfect audio quality for speech recognition.
+`resample_chunk(input, from_hz, to_hz)` uses simple linear interpolation to convert from the hardware sample rate to 16 kHz. This is fast and low-latency, which is more important than perfect fidelity for speech recognition.
 
 ### Gain Control
 
-`audio.gain` (0.0–4.0) is stored as an `AtomicU32` (bit-cast from f32) so it can be updated from the UI without locking the audio thread.
+`audio.gain` is stored as an `AtomicU32` (bit-cast from f32) in `AppState`, allowing live updates from the UI without locking the audio thread.
 
 ---
 
 ## Noise Gate / VAD
 
-A simple energy-based Voice Activity Detection gate is applied during inference, not capture:
+Voice Activity Detection is applied in the inference layer (not capture), after the full recording is accumulated:
 
 ```
-RMS energy of captured audio
-        │
-        ▼
-    < audio.vad_threshold?   →  Drop (return empty string)
-        │
-        ▼
-    Send to Whisper
+rms_threshold = (1.0 - audio.vad_threshold) * 0.006
+
+IF rms(audio) < rms_threshold
+THEN discard — return empty string
 ```
 
-The threshold is configurable (default ~0.02). Setting it too high causes missed speech; too low causes Whisper to transcribe silence as hallucinated text (a known Whisper behavior).
+**VAD threshold interpretation:**
+- `0.5` (default) → rms_threshold = 0.003 (comfortable speech easily passes)
+- `1.0` (maximum sensitivity) → rms_threshold = 0.0 (no gate; all audio processed)
+- `0.0` (minimum sensitivity) → rms_threshold = 0.006 (only loud audio passes)
+
+Setting it too low (high sensitivity) can cause Whisper to transcribe silence as hallucinated text. The default 0.5 is well-calibrated for typical microphone setups.
 
 ---
 
@@ -101,28 +102,29 @@ All under `audio` in `config.json`:
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `device_index` | `i32` | `-1` (auto) | CPAL device index; -1 = auto-detect |
-| `gain` | `f32` | `1.0` | Microphone gain multiplier (0.0–4.0) |
-| `vad_threshold` | `f32` | `0.02` | RMS threshold below which audio is discarded |
-| `dynamic_stream` | `bool` | `true` | Open/close mic stream on demand |
+| `input_device_index` | integer or null | `null` | CPAL device index; null = auto-detect |
+| `evdev_device` | string or null | `null` | Linux evdev keyboard path, e.g. `"/dev/input/event4"` |
+| `gain` | float | `1.0` | Microphone amplification multiplier |
+| `vad_threshold` | float | `0.5` | Sensitivity 0.0–1.0; higher = more sensitive (0.0 RMS gate at 1.0) |
+| `min_silence_duration_ms` | integer | `500` | Milliseconds of silence to trigger recording stop |
+| `noise_suppression` | bool | `false` | Enable basic noise suppression |
+| `dynamic_stream` | bool | `true` | Open/close mic on demand vs. always-on |
 
 ---
 
-## AudioRecorder API
+## AudioRecorder
+
+`AudioRecorder` is constructed with shared atomics from `AppState` so it reacts to live config changes without restarts:
 
 ```rust
-// Create recorder with a channel for audio chunks and RMS levels
-let recorder = AudioRecorder::new(audio_tx, level_tx, config);
-
-// Start capturing (dynamic mode: opens stream)
-recorder.start()?;
-
-// Stop capturing (dynamic mode: closes stream)
-recorder.stop()?;
-
-// Update gain at runtime (atomic, no restart needed)
-recorder.set_gain(1.5);
-
-// Switch device at runtime (triggers stream restart)
-recorder.set_device_index(2);
+pub struct AudioRecorder {
+    config: AudioConfig,
+    recording: Arc<AtomicBool>,
+    monitoring: Arc<AtomicBool>,
+    dynamic_stream: Arc<AtomicBool>,
+    input_device_index: Arc<AtomicU32>,
+    gain: Arc<AtomicU32>,
+}
 ```
+
+It is started via `.run(audio_tx, level_tx, audio_ready)` which spawns the `capture_loop` on a dedicated OS thread. The loop polls every 30ms to check for device index changes, dynamic stream preference changes, and recording/monitoring state transitions.

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -1,0 +1,128 @@
+# Audio Pipeline
+
+**Crate:** `crates/voxctr-audio/`
+
+## Responsibilities
+
+- Enumerate and select audio input devices
+- Stream raw PCM from the microphone via CPAL
+- Resample from the hardware rate to 16 kHz (Whisper's required input rate)
+- Compute RMS levels for the VU meter and noise gate
+- Support two streaming modes: dynamic (on-demand) and always-on
+
+---
+
+## Device Selection
+
+On startup, `test_and_detect_active_device()` probes devices in priority order:
+
+1. **Configured device** — `audio.device_index` from config
+2. **Default input device** — CPAL's `default_input_device()`
+3. **First enumerable device** — iterates all hosts/devices
+
+A "test capture" of ~200ms is performed to confirm the device actually produces audio before committing to it. The result is stored atomically so the inference and UI layers can query it.
+
+Devices are listed with `list_audio_devices()` which returns `(index, name)` pairs for the Settings → Audio tab.
+
+---
+
+## Streaming Modes
+
+### Dynamic Streaming (default)
+The microphone stream is opened when recording starts and closed when it stops. This is the default mode.
+
+- Lower CPU/battery usage when idle
+- A small startup latency (~10–50ms) when a hotkey is pressed
+- Suitable for most users
+
+### Always-On Streaming
+The stream stays open permanently. Chunks are buffered and discarded when not recording.
+
+- Zero startup latency
+- Higher idle CPU usage
+- Required for VAD-triggered recording (future feature)
+
+Toggle via `audio.dynamic_stream` in config.
+
+---
+
+## Audio Processing Chain
+
+```
+Hardware Input (e.g. 48000 Hz, f32 or i16 samples)
+        │
+        ▼
+   normalize_samples()     — convert i16/i32/u16 to f32 [-1.0, 1.0]
+        │
+        ▼
+   apply_gain()             — multiply by gain factor (default 1.0)
+        │
+        ▼
+   resample_chunk()         — linear interpolation to 16000 Hz
+        │
+        ▼
+   audio_tx.send(chunk)     — Vec<f32> forwarded to lib.rs accumulator
+        │
+        ▼
+   rms() → audio_level_tx   — f32 RMS forwarded to UI for visualization
+```
+
+### Resampling
+
+`resample_chunk(input, from_rate, to_rate)` uses linear interpolation via the **Rubato** library. This is fast and introduces minimal latency, which is more important than perfect audio quality for speech recognition.
+
+### Gain Control
+
+`audio.gain` (0.0–4.0) is stored as an `AtomicU32` (bit-cast from f32) so it can be updated from the UI without locking the audio thread.
+
+---
+
+## Noise Gate / VAD
+
+A simple energy-based Voice Activity Detection gate is applied during inference, not capture:
+
+```
+RMS energy of captured audio
+        │
+        ▼
+    < audio.vad_threshold?   →  Drop (return empty string)
+        │
+        ▼
+    Send to Whisper
+```
+
+The threshold is configurable (default ~0.02). Setting it too high causes missed speech; too low causes Whisper to transcribe silence as hallucinated text (a known Whisper behavior).
+
+---
+
+## Configuration Options
+
+All under `audio` in `config.json`:
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `device_index` | `i32` | `-1` (auto) | CPAL device index; -1 = auto-detect |
+| `gain` | `f32` | `1.0` | Microphone gain multiplier (0.0–4.0) |
+| `vad_threshold` | `f32` | `0.02` | RMS threshold below which audio is discarded |
+| `dynamic_stream` | `bool` | `true` | Open/close mic stream on demand |
+
+---
+
+## AudioRecorder API
+
+```rust
+// Create recorder with a channel for audio chunks and RMS levels
+let recorder = AudioRecorder::new(audio_tx, level_tx, config);
+
+// Start capturing (dynamic mode: opens stream)
+recorder.start()?;
+
+// Stop capturing (dynamic mode: closes stream)
+recorder.stop()?;
+
+// Update gain at runtime (atomic, no restart needed)
+recorder.set_gain(1.5);
+
+// Switch device at runtime (triggers stream restart)
+recorder.set_device_index(2);
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,133 +19,183 @@ Full schema with defaults:
 ```json
 {
   "engine": {
-    "backend": "whisper",
-    "model_size": "base",
-    "device": "auto",
-    "language": "en"
+    "backend": "auto",
+    "inference_mode": "Balanced",
+    "whisper_cpp": {
+      "model_dir": "",
+      "model_size": "large-v3",
+      "device": "auto",
+      "threads": 0
+    },
+    "moonshine": {
+      "model_size": "base",
+      "language": "en"
+    }
   },
   "audio": {
-    "device_index": -1,
+    "vad_threshold": 0.5,
+    "min_silence_duration_ms": 500,
+    "input_device_index": null,
+    "evdev_device": null,
+    "noise_suppression": false,
     "gain": 1.0,
-    "vad_threshold": 0.02,
     "dynamic_stream": true
   },
   "ui": {
-    "overlay_style": "ocean_wave",
-    "auto_show_overlay": true,
+    "show_overlay": true,
+    "overlay_style": "blue_wave",
+    "auto_show_settings": true,
     "show_notification": false,
-    "history_enabled": true
+    "history_enabled": false
   },
   "features": {
     "remove_fillers": true,
-    "snippets": {},
-    "vocabulary": []
+    "custom_vocabulary": [],
+    "spoken_punctuation": true,
+    "auto_format_lists": true,
+    "quiet_mode": false,
+    "snippets": {}
   },
   "ollama": {
     "enabled": false,
     "endpoint": "http://localhost:11434",
-    "model": "llama3.2",
+    "model": "llama3.2:1b",
     "mode": "clean",
-    "custom_prompt": ""
+    "custom_prompt": null,
+    "timeout_secs": 8
   },
   "tts": {
     "enabled": false,
     "engine": "piper",
-    "voice": "en_US-lessac-medium",
-    "stop_keys": ["KEY_ESC"]
+    "voice": "en-us-lessac-medium",
+    "stop_key": ["KEY_ESCAPE"],
+    "response_overlay": true
   },
   "mcp": {
-    "enabled": false,
-    "record_timeout": 30
+    "server_enabled": false,
+    "record_timeout": 15.0
   },
   "atspi": {
-    "enabled": false,
-    "context_prompt": false,
-    "auto_code_mode": false
+    "injection": true,
+    "context_prompt": true,
+    "auto_code_mode": true
   }
 }
 ```
 
 ### `engine` section
 
+The engine config is nested into two backend sub-objects.
+
+**Top-level fields:**
+
 | Key | Type | Values | Description |
 |---|---|---|---|
-| `backend` | string | `"whisper"`, `"moonshine"` | Recognition engine |
-| `model_size` | string | `"tiny"` `"base"` `"small"` `"medium"` `"large-v3"` | Whisper model to load |
-| `device` | string | `"auto"` `"cpu"` `"cuda"` `"vulkan"` | Compute backend |
-| `language` | string | ISO 639-1 code or `"auto"` | Transcription language |
+| `backend` | string | `"auto"`, `"whisper-cpp"`, `"moonshine"` | Which backend to use; `auto` selects based on GPU availability |
+| `inference_mode` | string | `"Balanced"`, `"Aggressive"` | Inference aggressiveness; `Balanced` is recommended |
+
+**`whisper_cpp` sub-object:**
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `model_size` | string | `"large-v3"` | Whisper model to load (see valid values below) |
+| `device` | string | `"auto"` | Compute device: `auto`/`cpu`/`cuda`/`vulkan` |
+| `threads` | integer | `0` | CPU thread count; 0 = half of logical cores |
+| `model_dir` | string | `""` | Custom model directory; empty = platform default |
+
+Valid `model_size` values: `tiny`, `tiny.en`, `base`, `base.en`, `small`, `small.en`, `medium`, `medium.en`, `large-v2`, `large-v3`, `large-v3-turbo`
+
+The `.en` variants are English-only but slightly faster. `large-v3-turbo` is a distilled model balancing quality and speed.
+
+**`moonshine` sub-object** (only used when `backend = "moonshine"`):
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `model_size` | string | `"base"` | `"base"` or `"tiny"` |
+| `language` | string | `"en"` | BCP-47 language code |
 
 ### `audio` section
 
-| Key | Type | Range | Description |
+| Key | Type | Default | Description |
 |---|---|---|---|
-| `device_index` | integer | `-1` = auto | CPAL device index |
-| `gain` | float | `0.0` – `4.0` | Microphone amplification |
-| `vad_threshold` | float | `0.0` – `1.0` | RMS energy cutoff for silence detection |
-| `dynamic_stream` | bool | | Open mic on-demand vs. always-on |
+| `vad_threshold` | float | `0.5` | Voice Activity Detection sensitivity (0.0–1.0); **higher = more sensitive** (lower RMS gate) |
+| `min_silence_duration_ms` | integer | `500` | Milliseconds of silence before stopping a recording session |
+| `input_device_index` | integer or null | `null` | CPAL device index; null = auto-detect |
+| `evdev_device` | string or null | `null` | Linux evdev keyboard device path for hotkeys, e.g. `"/dev/input/event4"` |
+| `noise_suppression` | bool | `false` | Enable basic noise suppression pre-processing |
+| `gain` | float | `1.0` | Microphone amplification multiplier |
+| `dynamic_stream` | bool | `true` | Open mic on-demand (true) vs. always-on (false) |
+
+**VAD threshold note:** The threshold maps as `rms_gate = (1.0 - vad_threshold) * 0.006`. At 0.5 (default), the gate threshold is 0.003 RMS. At 1.0 (maximum sensitivity), there is no gate (0.0 RMS). At 0.0 (minimum sensitivity), the gate is 0.006 RMS.
 
 ### `ui` section
 
-| Key | Type | Values | Description |
-|---|---|---|---|
-| `overlay_style` | string | `"ocean_wave"` `"voice_card"` `"waveform"` `"pulse"` | HUD visualization |
-| `auto_show_overlay` | bool | | Show overlay automatically when recording |
-| `show_notification` | bool | | Desktop toast notification on text delivery |
-| `history_enabled` | bool | | Enable transcription history tracking |
+| Key | Type | Values | Default | Description |
+|---|---|---|---|---|
+| `show_overlay` | bool | | `true` | Whether the overlay window is currently visible |
+| `overlay_style` | string | `"voice_card"`, `"waveform"`, `"pulse"`, `"blue_wave"`, `"none"` | `"blue_wave"` | HUD visualization style |
+| `auto_show_settings` | bool | | `true` | Auto-show Settings window on startup |
+| `show_notification` | bool | | `false` | Desktop toast notification after text delivery |
+| `history_enabled` | bool | | `false` | Enable transcription history tracking |
 
 ### `features` section
 
-| Key | Type | Description |
-|---|---|---|
-| `remove_fillers` | bool | Strip "um", "uh", "hmm" from output |
-| `snippets` | object | Short code → expansion map |
-| `vocabulary` | string[] | Custom words to improve Whisper accuracy |
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `remove_fillers` | bool | `true` | Strip filler words (`uh`, `um`, `hmm`, `er`, `ah`, etc.) |
+| `spoken_punctuation` | bool | `true` | Convert spoken punctuation words to symbols (e.g. "period" → ".") |
+| `auto_format_lists` | bool | `true` | Detect "first/second/third" patterns and reformat as a numbered list |
+| `quiet_mode` | bool | `false` | Suppress overlay notifications during transcription |
+| `custom_vocabulary` | string[] | `[]` | Custom words; VoxCtr uses fuzzy Levenshtein matching to correct near-matches post-transcription |
+| `snippets` | object | `{}` | Short code → expansion map |
 
 Example with snippets:
 ```json
 "features": {
   "remove_fillers": true,
+  "spoken_punctuation": true,
   "snippets": {
     "addr": "742 Evergreen Terrace, Springfield",
-    "sig": "Best regards,\nAlice",
-    "mtg": "meeting"
+    "sig": "Best regards,\nAlice"
   }
 }
 ```
 
 ### `ollama` section
 
-| Key | Type | Values | Description |
+| Key | Type | Default | Description |
 |---|---|---|---|
-| `enabled` | bool | | Enable Ollama post-processing |
-| `endpoint` | string | URL | Ollama API base URL |
-| `model` | string | | Model name (e.g. `"llama3.2"`, `"phi3"`) |
-| `mode` | string | `"clean"` `"formal"` `"casual"` `"bullet"` `"concise"` `"custom"` | Rewrite style |
-| `custom_prompt` | string | | Instruction when mode is `"custom"` |
+| `enabled` | bool | `false` | Enable Ollama post-processing |
+| `endpoint` | string | `"http://localhost:11434"` | Ollama API base URL |
+| `model` | string | `"llama3.2:1b"` | Model name |
+| `mode` | string | `"clean"` | Rewrite style: `clean`/`formal`/`casual`/`bullet`/`concise`/`custom` |
+| `custom_prompt` | string or null | `null` | Instruction when mode is `custom`; use `{text}` as placeholder, or text is appended after the prompt |
+| `timeout_secs` | integer | `8` | HTTP request timeout in seconds |
 
 ### `tts` section
 
-| Key | Type | Values | Description |
+| Key | Type | Default | Description |
 |---|---|---|---|
-| `enabled` | bool | | Enable TTS subsystem |
-| `engine` | string | `"piper"`, `"espeak"` | Synthesis engine |
-| `voice` | string | Voice name | Active Piper voice |
-| `stop_keys` | string[] | evdev key names | Keys that cancel playback |
+| `enabled` | bool | `false` | Enable TTS subsystem |
+| `engine` | string | `"piper"` | Synthesis engine: `"piper"` or `"espeak"` |
+| `voice` | string | `"en-us-lessac-medium"` | Active Piper voice name (hyphen-delimited, e.g. `"en-us-ryan-high"`) |
+| `stop_key` | string[] | `["KEY_ESCAPE"]` | Keys that cancel current TTS playback |
+| `response_overlay` | bool | `true` | Show overlay indicator while TTS is speaking |
 
 ### `mcp` section
 
-| Key | Type | Description |
-|---|---|---|
-| `enabled` | bool | Start the MCP socket server |
-| `record_timeout` | integer | Max seconds for `transcribe_voice` to wait |
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `server_enabled` | bool | `false` | Start the MCP socket server on launch |
+| `record_timeout` | float | `15.0` | Max seconds for `transcribe_voice` to wait for speech |
 
 ### `atspi` section
 
-| Key | Type | Description |
-|---|---|---|
-| `enabled` | bool | Enable AT-SPI2 integration |
-| `context_prompt` | bool | Read focused widget text for Whisper context |
-| `auto_code_mode` | bool | Detect code editors and enable code-mode automatically |
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `injection` | bool | `true` | Use AT-SPI2 for text insertion when available |
+| `context_prompt` | bool | `true` | Read focused widget text to use as Whisper context prompt |
+| `auto_code_mode` | bool | `true` | Detect code editors/terminals and enable code-mode processing automatically |
 
 ---
 
@@ -161,20 +211,32 @@ label = "Focused Window"
 delivery = "inject"
 ```
 
-### Full example with all common fields
+### All common fields
 ```toml
 [[target]]
 id = "my_target"
 label = "My Target"
-delivery = "inject"          # See delivery types below
-append_newline = false        # Append \n after text
-send_on_release = false       # Wait for hotkey release
-initial_prompt = ""           # Whisper context prompt override
+delivery = "inject"
 
+# Text formatting
+append_newline = true         # Default: true
+send_on_release = true        # Default: true
+initial_prompt = ""           # Whisper context prompt override for this target
+
+# Per-target post-processing overrides (all optional; null = inherit global)
 [my_target.processing]
-code_mode = false
 remove_fillers = true
+spoken_punctuation = true
+auto_format_lists = true
+apply_snippets = true
+code_mode = false
+quiet_mode = false
 ollama_enabled = false
+ollama_model = ""
+ollama_mode = ""
+ollama_prompt = ""
+atspi_context = true
+noise_suppression = false
 ```
 
 ### Delivery-specific fields
@@ -184,32 +246,53 @@ ollama_enabled = false
 delivery = "file"
 file_path = "~/Documents/notes.md"
 file_prefix = "- "
-file_timestamp = true
+file_timestamp = true          # Default: true
+file_mode = "append"           # "append" or "write"
 ```
 
-**`http` / `webhook`:**
+**`http`:**
+```toml
+delivery = "http"
+http_url = "http://localhost:8080/voice"
+http_method = "POST"           # Default: "POST"
+# Optional: custom headers and JSON template
+```
+
+**`webhook`:**
 ```toml
 delivery = "webhook"
-http_url = "https://example.com/hook"
+webhook_url = "https://example.com/hook"
 webhook_secret = "my-hmac-secret"
 ```
+
+Note: `webhook` uses `webhook_url`, while `http` uses `http_url`.
 
 **`exec`:**
 ```toml
 delivery = "exec"
-exec_command = "/usr/local/bin/handle-voice.sh"
+command = "/usr/local/bin/handle-voice.sh"
 ```
 
-**`socket`:**
+**`socket`** (supports Unix and TCP):
 ```toml
 delivery = "socket"
-socket_path = "/tmp/myapp.sock"
+socket_unix = "/tmp/myapp.sock"    # Unix domain socket
+# OR:
+socket_host = "127.0.0.1"
+socket_port = 9000
 ```
 
 **`pipe`:**
 ```toml
 delivery = "pipe"
 pipe_path = "/tmp/voice.fifo"
+```
+
+**TTS per-target response:**
+```toml
+tts_engine = "piper"          # Default: "piper"
+tts_voice = "en-us-ryan-high" # Optional voice override
+response_pipe = "/tmp/tts-response.fifo"  # Optional FIFO for TTS output
 ```
 
 ---
@@ -226,6 +309,7 @@ label = "Dictate (Hold)"
 keys = ["KEY_LEFTMETA", "KEY_SPACE"]
 gesture = "hold"
 target_ids = ["default"]
+hold_threshold_ms = 200        # Default: 200ms min hold to register
 disabled = false
 
 [[binding]]
@@ -239,28 +323,31 @@ target_ids = ["notes", "clipboard"]
 id = "quick_code"
 label = "Code Dictation (Double-tap)"
 keys = ["KEY_F12"]
-gesture = "double"
+gesture = "double_tap"
+tap_ms = 250                   # Default: 250ms inter-tap window
 target_ids = ["code_editor"]
-disabled = false
 ```
 
 ### Field reference
 
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `id` | string | Yes | Unique identifier |
-| `label` | string | Yes | Display name |
-| `keys` | string[] | Yes | Key names (evdev format) |
-| `gesture` | string | Yes | `"hold"` / `"toggle"` / `"double"` |
-| `target_ids` | string[] | Yes | Ordered list of target IDs |
-| `disabled` | bool | No | Disable without deleting |
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `id` | string | Yes | | Unique identifier |
+| `label` | string | Yes | `""` | Display name |
+| `keys` | string[] | Yes | | Key names (evdev format) |
+| `gesture` | string | Yes | | `"hold"`, `"toggle"`, `"double_tap"`, or `"chord"` |
+| `target_ids` | string[] | Yes | | Ordered list of target IDs to route to |
+| `target_id` | string | No | | Single target (legacy; use `target_ids`) |
+| `hold_threshold_ms` | integer | No | `200` | Min hold duration in ms for hold gesture |
+| `tap_ms` | integer | No | `250` | Double-tap inter-press window in ms |
+| `disabled` | bool | No | `false` | Disable without deleting |
 
 ---
 
 ## Config Migration
 
-VoxCtr auto-migrates older config formats. Known migrations:
+VoxCtr auto-migrates older config formats on load. Known migrations:
 
-- `features.show_notification` → `ui.show_notification` (moved in an early release)
+- `features.show_notification` → `ui.show_notification` (moved in an early release; the migrated config is immediately re-saved to disk to clean up the old key)
 
-If a field is unrecognized, it is ignored. Missing fields use their defaults. This ensures forward and backward compatibility when upgrading.
+Unrecognized fields are silently ignored. Missing fields use their defaults. This ensures compatibility when upgrading or downgrading.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,266 @@
+# Configuration Reference
+
+VoxCtr uses three configuration files, all stored under `~/.config/voxctl/`.
+
+| File | Format | Purpose |
+|---|---|---|
+| `config.json` | JSON | Application settings |
+| `targets.toml` | TOML | Output target definitions |
+| `bindings.toml` | TOML | Hotkey binding definitions |
+
+All files are **hot-reloaded** — the app watches for external changes and applies them without restart.
+
+---
+
+## config.json
+
+Full schema with defaults:
+
+```json
+{
+  "engine": {
+    "backend": "whisper",
+    "model_size": "base",
+    "device": "auto",
+    "language": "en"
+  },
+  "audio": {
+    "device_index": -1,
+    "gain": 1.0,
+    "vad_threshold": 0.02,
+    "dynamic_stream": true
+  },
+  "ui": {
+    "overlay_style": "ocean_wave",
+    "auto_show_overlay": true,
+    "show_notification": false,
+    "history_enabled": true
+  },
+  "features": {
+    "remove_fillers": true,
+    "snippets": {},
+    "vocabulary": []
+  },
+  "ollama": {
+    "enabled": false,
+    "endpoint": "http://localhost:11434",
+    "model": "llama3.2",
+    "mode": "clean",
+    "custom_prompt": ""
+  },
+  "tts": {
+    "enabled": false,
+    "engine": "piper",
+    "voice": "en_US-lessac-medium",
+    "stop_keys": ["KEY_ESC"]
+  },
+  "mcp": {
+    "enabled": false,
+    "record_timeout": 30
+  },
+  "atspi": {
+    "enabled": false,
+    "context_prompt": false,
+    "auto_code_mode": false
+  }
+}
+```
+
+### `engine` section
+
+| Key | Type | Values | Description |
+|---|---|---|---|
+| `backend` | string | `"whisper"`, `"moonshine"` | Recognition engine |
+| `model_size` | string | `"tiny"` `"base"` `"small"` `"medium"` `"large-v3"` | Whisper model to load |
+| `device` | string | `"auto"` `"cpu"` `"cuda"` `"vulkan"` | Compute backend |
+| `language` | string | ISO 639-1 code or `"auto"` | Transcription language |
+
+### `audio` section
+
+| Key | Type | Range | Description |
+|---|---|---|---|
+| `device_index` | integer | `-1` = auto | CPAL device index |
+| `gain` | float | `0.0` – `4.0` | Microphone amplification |
+| `vad_threshold` | float | `0.0` – `1.0` | RMS energy cutoff for silence detection |
+| `dynamic_stream` | bool | | Open mic on-demand vs. always-on |
+
+### `ui` section
+
+| Key | Type | Values | Description |
+|---|---|---|---|
+| `overlay_style` | string | `"ocean_wave"` `"voice_card"` `"waveform"` `"pulse"` | HUD visualization |
+| `auto_show_overlay` | bool | | Show overlay automatically when recording |
+| `show_notification` | bool | | Desktop toast notification on text delivery |
+| `history_enabled` | bool | | Enable transcription history tracking |
+
+### `features` section
+
+| Key | Type | Description |
+|---|---|---|
+| `remove_fillers` | bool | Strip "um", "uh", "hmm" from output |
+| `snippets` | object | Short code → expansion map |
+| `vocabulary` | string[] | Custom words to improve Whisper accuracy |
+
+Example with snippets:
+```json
+"features": {
+  "remove_fillers": true,
+  "snippets": {
+    "addr": "742 Evergreen Terrace, Springfield",
+    "sig": "Best regards,\nAlice",
+    "mtg": "meeting"
+  }
+}
+```
+
+### `ollama` section
+
+| Key | Type | Values | Description |
+|---|---|---|---|
+| `enabled` | bool | | Enable Ollama post-processing |
+| `endpoint` | string | URL | Ollama API base URL |
+| `model` | string | | Model name (e.g. `"llama3.2"`, `"phi3"`) |
+| `mode` | string | `"clean"` `"formal"` `"casual"` `"bullet"` `"concise"` `"custom"` | Rewrite style |
+| `custom_prompt` | string | | Instruction when mode is `"custom"` |
+
+### `tts` section
+
+| Key | Type | Values | Description |
+|---|---|---|---|
+| `enabled` | bool | | Enable TTS subsystem |
+| `engine` | string | `"piper"`, `"espeak"` | Synthesis engine |
+| `voice` | string | Voice name | Active Piper voice |
+| `stop_keys` | string[] | evdev key names | Keys that cancel playback |
+
+### `mcp` section
+
+| Key | Type | Description |
+|---|---|---|
+| `enabled` | bool | Start the MCP socket server |
+| `record_timeout` | integer | Max seconds for `transcribe_voice` to wait |
+
+### `atspi` section
+
+| Key | Type | Description |
+|---|---|---|
+| `enabled` | bool | Enable AT-SPI2 integration |
+| `context_prompt` | bool | Read focused widget text for Whisper context |
+| `auto_code_mode` | bool | Detect code editors and enable code-mode automatically |
+
+---
+
+## targets.toml
+
+Each output destination is a `[[target]]` block.
+
+### Minimal example
+```toml
+[[target]]
+id = "default"
+label = "Focused Window"
+delivery = "inject"
+```
+
+### Full example with all common fields
+```toml
+[[target]]
+id = "my_target"
+label = "My Target"
+delivery = "inject"          # See delivery types below
+append_newline = false        # Append \n after text
+send_on_release = false       # Wait for hotkey release
+initial_prompt = ""           # Whisper context prompt override
+
+[my_target.processing]
+code_mode = false
+remove_fillers = true
+ollama_enabled = false
+```
+
+### Delivery-specific fields
+
+**`file`:**
+```toml
+delivery = "file"
+file_path = "~/Documents/notes.md"
+file_prefix = "- "
+file_timestamp = true
+```
+
+**`http` / `webhook`:**
+```toml
+delivery = "webhook"
+http_url = "https://example.com/hook"
+webhook_secret = "my-hmac-secret"
+```
+
+**`exec`:**
+```toml
+delivery = "exec"
+exec_command = "/usr/local/bin/handle-voice.sh"
+```
+
+**`socket`:**
+```toml
+delivery = "socket"
+socket_path = "/tmp/myapp.sock"
+```
+
+**`pipe`:**
+```toml
+delivery = "pipe"
+pipe_path = "/tmp/voice.fifo"
+```
+
+---
+
+## bindings.toml
+
+Each hotkey is a `[[binding]]` block.
+
+### Full example
+```toml
+[[binding]]
+id = "dictate_hold"
+label = "Dictate (Hold)"
+keys = ["KEY_LEFTMETA", "KEY_SPACE"]
+gesture = "hold"
+target_ids = ["default"]
+disabled = false
+
+[[binding]]
+id = "dictate_notes"
+label = "Dictate to Notes + Clipboard"
+keys = ["KEY_LEFTCTRL", "KEY_LEFTSHIFT", "KEY_N"]
+gesture = "toggle"
+target_ids = ["notes", "clipboard"]
+
+[[binding]]
+id = "quick_code"
+label = "Code Dictation (Double-tap)"
+keys = ["KEY_F12"]
+gesture = "double"
+target_ids = ["code_editor"]
+disabled = false
+```
+
+### Field reference
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | string | Yes | Unique identifier |
+| `label` | string | Yes | Display name |
+| `keys` | string[] | Yes | Key names (evdev format) |
+| `gesture` | string | Yes | `"hold"` / `"toggle"` / `"double"` |
+| `target_ids` | string[] | Yes | Ordered list of target IDs |
+| `disabled` | bool | No | Disable without deleting |
+
+---
+
+## Config Migration
+
+VoxCtr auto-migrates older config formats. Known migrations:
+
+- `features.show_notification` → `ui.show_notification` (moved in an early release)
+
+If a field is unrecognized, it is ignored. Missing fields use their defaults. This ensures forward and backward compatibility when upgrading.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,240 @@
+# Development Guide
+
+## Prerequisites
+
+### Required Tools
+- **Rust** 1.75+ with `cargo` — [rustup.rs](https://rustup.rs/)
+- **Node.js** 18+ with `npm`
+- **Tauri CLI** 2.x — `cargo install tauri-cli`
+
+### Linux System Dependencies
+```bash
+# Ubuntu / Debian
+sudo apt install \
+  libwebkit2gtk-4.1-dev \
+  libayatana-appindicator3-dev \
+  librsvg2-dev \
+  libssl-dev \
+  libasound2-dev \
+  libspeechd-dev \
+  pkg-config \
+  build-essential
+
+# Fedora
+sudo dnf install \
+  webkit2gtk4.1-devel \
+  libayatana-appindicator-devel \
+  openssl-devel \
+  alsa-lib-devel \
+  speech-dispatcher-devel
+```
+
+### Windows
+- Visual Studio Build Tools 2019+
+- WebView2 SDK (usually pre-installed)
+
+---
+
+## Repository Layout
+
+```
+VoxCtr/
+├── src/                    # Svelte frontend
+│   ├── main.ts
+│   ├── App.svelte
+│   ├── stores/
+│   │   ├── config.ts
+│   │   └── status.ts
+│   └── lib/
+│       ├── Settings/
+│       ├── Overlay/
+│       └── History/
+│
+├── src-tauri/              # Tauri application shell
+│   ├── Cargo.toml
+│   ├── tauri.conf.json
+│   └── src/
+│       ├── main.rs
+│       ├── lib.rs          # Main coordinator
+│       ├── commands.rs     # IPC command handlers
+│       └── state.rs        # AppState definition
+│
+├── crates/                 # Backend library crates
+│   ├── voxctr-config/
+│   ├── voxctr-audio/
+│   ├── voxctr-hotkeys/
+│   ├── voxctr-inference/
+│   ├── voxctr-routing/
+│   ├── voxctr-inject/
+│   ├── voxctr-tts/
+│   ├── voxctr-mcp/
+│   ├── voxctr-dbus/
+│   └── voxctr-llm/
+│
+├── Cargo.toml              # Workspace definition
+├── package.json            # Frontend deps
+├── vite.config.ts
+└── svelte.config.js
+```
+
+---
+
+## Development Workflow
+
+### Start Dev Server
+```bash
+npm install          # Install frontend deps (first time only)
+npm run tauri dev    # Start Tauri + Vite in development mode
+```
+
+This:
+1. Starts Vite dev server on `http://localhost:5173` with HMR
+2. Compiles the Rust backend
+3. Launches the app with the WebView pointed at Vite
+
+Svelte changes hot-reload instantly. Rust changes trigger a backend recompile (typically 5–30s).
+
+### Frontend Only
+If you only need to work on the UI:
+```bash
+npm run dev
+# Opens http://localhost:5173 in browser
+# Note: Tauri commands won't work in browser — mock them if needed
+```
+
+### Backend Only
+```bash
+cargo build -p voxctr-inference  # Build a specific crate
+cargo test -p voxctr-config      # Test a specific crate
+cargo check --workspace          # Type-check all crates
+```
+
+---
+
+## Building for Production
+
+### AppImage (Linux)
+```bash
+bash build_appimage.sh
+# Output: VoxCtr.AppImage in project root
+```
+
+The build script:
+1. Runs `npm run tauri build` to produce a `.deb` bundle
+2. Extracts the contents into an AppDir
+3. Runs `appimagetool` to create the AppImage
+
+### Standard Tauri Build
+```bash
+npm run tauri build
+# Output: src-tauri/target/release/bundle/
+#   Linux:   .deb, .AppImage
+#   Windows: .msi, .exe (NSIS)
+```
+
+---
+
+## Crate Development Guide
+
+Each crate under `crates/` is self-contained. They are included in the workspace `Cargo.toml` and referenced by `src-tauri` as path dependencies.
+
+### Adding a new crate
+```bash
+cargo new --lib crates/voxctr-myfeature
+
+# Add to Cargo.toml workspace members:
+[workspace]
+members = [
+  ...
+  "crates/voxctr-myfeature",
+]
+
+# Reference from src-tauri/Cargo.toml:
+voxctr-myfeature = { path = "../crates/voxctr-myfeature" }
+```
+
+### Crate Conventions
+- Keep each crate focused on one domain
+- Expose a minimal public API (`pub` on types/functions needed by callers)
+- Use `tokio` for async where I/O is needed; keep CPU-heavy work on dedicated OS threads
+- Pass channels rather than `Arc<Mutex<_>>` for data pipelines where possible
+
+---
+
+## Key Files to Understand
+
+### `src-tauri/src/lib.rs`
+The main coordinator. This is where the audio pipeline is assembled:
+- Creates all channels
+- Spawns the hotkey listener
+- Spawns the audio recorder
+- Spawns the inference worker
+- Starts the MCP server
+- Starts the DBus service
+- Runs the Tauri event loop with the status ticker
+
+When adding a new integration, this is typically where you wire it in.
+
+### `src-tauri/src/commands.rs`
+All `#[tauri::command]` handlers. Each command is a thin wrapper that reads/writes `AppState` or calls into a crate. Keep commands small — business logic belongs in crates.
+
+### `crates/voxctr-config/src/lib.rs`
+The `AppConfig` struct is the source of truth for all settings. If you add a config option, add it here first, then expose it in the Settings UI.
+
+### `crates/voxctr-routing/src/targets.rs`
+Defines `OutputTarget`, `DeliveryType`, and the routing dispatch logic. Add new delivery types here.
+
+---
+
+## Adding a New Output Target Type
+
+1. Add a variant to `DeliveryType` enum in `crates/voxctr-routing/src/targets.rs`
+2. Add a match arm in `OutputTargetRouter::route()` with the delivery logic
+3. Add any target-specific config fields to `OutputTarget` struct (all optional with defaults)
+4. Update the TypeScript `OutputTarget` interface in `src/`
+5. Add the new type to the delivery type selector in `src/lib/Settings/RoutingTab.svelte`
+6. Document in `docs/routing.md`
+
+---
+
+## Testing
+
+```bash
+# Run all tests
+cargo test --workspace
+
+# Run tests for a specific crate
+cargo test -p voxctr-config
+cargo test -p voxctr-routing
+
+# Frontend type checking
+npm run check    # svelte-check + tsc
+```
+
+There are currently no end-to-end tests. The audio pipeline is tested manually via the dev server.
+
+---
+
+## Debugging
+
+### Rust Logging
+VoxCtr uses the `log` crate with `env_logger`. Enable verbose output:
+```bash
+RUST_LOG=debug npm run tauri dev
+RUST_LOG=voxctr_inference=trace npm run tauri dev
+```
+
+### Frontend DevTools
+In dev mode, right-click the Tauri window → Inspect Element to open WebKit DevTools.
+
+### IPC Tracing
+Add `console.log` around `invoke()` calls in Svelte, or add `println!` in command handlers in Rust.
+
+### Audio Issues
+```bash
+# Check CPAL devices
+RUST_LOG=cpal=debug npm run tauri dev
+
+# Check PulseAudio
+pactl list sources short
+```

--- a/docs/development.md
+++ b/docs/development.md
@@ -181,17 +181,17 @@ All `#[tauri::command]` handlers. Each command is a thin wrapper that reads/writ
 ### `crates/voxctr-config/src/lib.rs`
 The `AppConfig` struct is the source of truth for all settings. If you add a config option, add it here first, then expose it in the Settings UI.
 
-### `crates/voxctr-routing/src/targets.rs`
-Defines `OutputTarget`, `DeliveryType`, and the routing dispatch logic. Add new delivery types here.
+### `crates/voxctr-routing/src/models.rs`
+Defines `OutputTarget`, `HotkeyBinding`, `DeliveryType`, `TargetProcessingConfig`, and `GestureType`. Add new delivery types or target fields here.
 
 ---
 
 ## Adding a New Output Target Type
 
-1. Add a variant to `DeliveryType` enum in `crates/voxctr-routing/src/targets.rs`
-2. Add a match arm in `OutputTargetRouter::route()` with the delivery logic
-3. Add any target-specific config fields to `OutputTarget` struct (all optional with defaults)
-4. Update the TypeScript `OutputTarget` interface in `src/`
+1. Add a variant to `DeliveryType` enum in `crates/voxctr-routing/src/models.rs`
+2. Add any target-specific fields to `OutputTarget` in `crates/voxctr-routing/src/models.rs`
+3. Add a match arm in the router dispatch logic in `crates/voxctr-routing/src/router.rs`
+4. Update the TypeScript `OutputTarget` interface in `src/stores/config.ts`
 5. Add the new type to the delivery type selector in `src/lib/Settings/RoutingTab.svelte`
 6. Document in `docs/routing.md`
 

--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -1,0 +1,160 @@
+# Hotkey System
+
+**Crate:** `crates/voxctr-hotkeys/`
+
+## Overview
+
+VoxCtr listens for global keyboard shortcuts that work regardless of which application has focus. The implementation is platform-specific: **evdev** on Linux and **Win32 hooks** on Windows.
+
+---
+
+## Platform Implementations
+
+### Linux (evdev)
+
+Uses `/dev/input/event*` devices directly, bypassing the desktop environment entirely. This means hotkeys work in:
+- X11 sessions
+- Wayland sessions
+- TTY / no-DE environments
+- Over SSH with an active session
+
+**Requirement:** The user must be in the `input` group (or have read access to `/dev/input/event*`):
+
+```bash
+sudo usermod -aG input $USER
+# Log out and back in
+```
+
+The listener opens all event devices that expose keyboard events, watches for key press/release events, and matches against registered bindings.
+
+### Windows
+
+Uses Win32 `SetWindowsHookEx` with `WH_KEYBOARD_LL` to intercept global keyboard events.
+
+No special permissions are required for standard user accounts.
+
+---
+
+## Gesture Recognition
+
+Each binding specifies a `gesture` that controls when recording starts and stops.
+
+### Hold
+```
+Key Down ──► START RECORDING
+Key Up   ──► STOP RECORDING
+```
+Most natural for short dictations. Recording is exactly as long as the key is held.
+
+### Toggle
+```
+Key Down (1st) ──► START RECORDING
+Key Down (2nd) ──► STOP RECORDING
+```
+Useful for longer dictations where holding a key would be tiring. Press once to start, press again to stop.
+
+### Double
+```
+Key Down + Up (rapidly) ──► (ignored)
+Key Down + Up (again within threshold) ──► START/STOP TOGGLE
+```
+Two rapid presses act as a toggle trigger. Distinguishes from accidental single presses.
+
+---
+
+## Key Names
+
+Keys are identified by their **evdev event code name** on Linux. Common keys:
+
+### Modifier Keys
+| Name | Key |
+|---|---|
+| `KEY_LEFTCTRL` | Left Ctrl |
+| `KEY_RIGHTCTRL` | Right Ctrl |
+| `KEY_LEFTSHIFT` | Left Shift |
+| `KEY_RIGHTSHIFT` | Right Shift |
+| `KEY_LEFTALT` | Left Alt |
+| `KEY_RIGHTALT` | Right Alt / AltGr |
+| `KEY_LEFTMETA` | Left Super / Windows key |
+| `KEY_RIGHTMETA` | Right Super / Windows key |
+| `KEY_CAPSLOCK` | Caps Lock |
+
+### Common Keys
+| Name | Key |
+|---|---|
+| `KEY_SPACE` | Space |
+| `KEY_ENTER` | Enter |
+| `KEY_TAB` | Tab |
+| `KEY_ESC` | Escape |
+| `KEY_BACKSPACE` | Backspace |
+| `KEY_F1`–`KEY_F12` | Function keys |
+| `KEY_A`–`KEY_Z` | Letter keys |
+| `KEY_0`–`KEY_9` | Number row |
+
+### Finding Key Names
+
+To find the evdev name for any key:
+```bash
+# Install evtest if not present
+sudo apt install evtest
+
+# Run (pick your keyboard device)
+sudo evtest /dev/input/event2
+
+# Press the key you want — look for "EV_KEY" lines
+# e.g.: Event: type 1 (EV_KEY), code 125 (KEY_LEFTMETA), value 1
+```
+
+---
+
+## Hot-Reload
+
+Hotkey bindings can be updated without restarting the listener. When `bindings.toml` changes on disk or bindings are saved via the UI:
+
+1. New bindings are parsed
+2. Sent through `binding_reload_tx` channel
+3. The listener thread receives them and swaps its internal binding table atomically
+
+This means you can add, modify, or remove hotkeys at runtime.
+
+---
+
+## Multi-Key Combos
+
+`keys` in a binding is an array. VoxCtr tracks which keys from the combo are currently held and only fires the gesture when **all** keys in the combo are pressed:
+
+```toml
+keys = ["KEY_LEFTMETA", "KEY_SPACE"]
+# Fires only when both Left-Super AND Space are held
+```
+
+Order does not matter — holding Meta then Space, or Space then Meta, both trigger.
+
+---
+
+## Conflict Handling
+
+If two bindings share the same key combo, the first matching binding wins. Disable bindings you don't want rather than leaving conflicting ones active:
+
+```toml
+[[binding]]
+id = "old_binding"
+disabled = true
+keys = ["KEY_LEFTMETA", "KEY_SPACE"]
+# ...
+```
+
+---
+
+## GestureEvent
+
+The output of the hotkey system is a stream of `GestureEvent` values sent on `gesture_tx`:
+
+```rust
+pub enum GestureEvent {
+    StartRecording { binding_id: String, target_ids: Vec<String> },
+    StopRecording  { binding_id: String },
+}
+```
+
+`lib.rs` receives these and coordinates the audio recorder and inference pipeline accordingly.

--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -16,7 +16,8 @@ Uses `/dev/input/event*` devices directly, bypassing the desktop environment ent
 - X11 sessions
 - Wayland sessions
 - TTY / no-DE environments
-- Over SSH with an active session
+
+The evdev keyboard device can be specified via `audio.evdev_device` in config (e.g. `"/dev/input/event4"`). If not set, the listener discovers keyboard devices automatically.
 
 **Requirement:** The user must be in the `input` group (or have read access to `/dev/input/event*`):
 
@@ -25,13 +26,9 @@ sudo usermod -aG input $USER
 # Log out and back in
 ```
 
-The listener opens all event devices that expose keyboard events, watches for key press/release events, and matches against registered bindings.
-
 ### Windows
 
-Uses Win32 `SetWindowsHookEx` with `WH_KEYBOARD_LL` to intercept global keyboard events.
-
-No special permissions are required for standard user accounts.
+Uses Win32 `SetWindowsHookEx` with `WH_KEYBOARD_LL` to intercept global keyboard events. No special permissions are required.
 
 ---
 
@@ -39,32 +36,37 @@ No special permissions are required for standard user accounts.
 
 Each binding specifies a `gesture` that controls when recording starts and stops.
 
-### Hold
+### `hold`
 ```
-Key Down ──► START RECORDING
-Key Up   ──► STOP RECORDING
+Key Down ──► START RECORDING (GestureKind::Start)
+Key Up   ──► STOP RECORDING  (GestureKind::Stop)
 ```
 Most natural for short dictations. Recording is exactly as long as the key is held.
 
-### Toggle
-```
-Key Down (1st) ──► START RECORDING
-Key Down (2nd) ──► STOP RECORDING
-```
-Useful for longer dictations where holding a key would be tiring. Press once to start, press again to stop.
+The `hold_threshold_ms` field (default 200ms) sets the minimum hold duration before a recording start is registered, preventing accidental triggers.
 
-### Double
+### `toggle`
 ```
-Key Down + Up (rapidly) ──► (ignored)
-Key Down + Up (again within threshold) ──► START/STOP TOGGLE
+Key Down (1st press) ──► START RECORDING
+Key Down (2nd press) ──► STOP RECORDING
 ```
-Two rapid presses act as a toggle trigger. Distinguishes from accidental single presses.
+For longer dictations where holding a key would be tiring. Press once to start, press again to stop.
+
+### `double_tap`
+```
+Rapid press+release twice within tap_ms ──► START RECORDING
+(then behaves as toggle for stop)
+```
+Two rapid presses trigger recording. The `tap_ms` field (default 250ms) sets the inter-press window. Distinguishes from accidental single presses.
+
+### `chord`
+All keys in `keys` must be simultaneously held. Uses the same hold-start / release-stop behavior. Superset-shadowing applies: if another binding's key set is a superset of this one and all its keys are also held, only the longer binding fires.
 
 ---
 
 ## Key Names
 
-Keys are identified by their **evdev event code name** on Linux. Common keys:
+Keys use **evdev event code names** on Linux. On Windows, the same names are mapped to Virtual Key codes internally.
 
 ### Modifier Keys
 | Name | Key |
@@ -85,7 +87,7 @@ Keys are identified by their **evdev event code name** on Linux. Common keys:
 | `KEY_SPACE` | Space |
 | `KEY_ENTER` | Enter |
 | `KEY_TAB` | Tab |
-| `KEY_ESC` | Escape |
+| `KEY_ESCAPE` | Escape |
 | `KEY_BACKSPACE` | Backspace |
 | `KEY_F1`–`KEY_F12` | Function keys |
 | `KEY_A`–`KEY_Z` | Letter keys |
@@ -93,7 +95,7 @@ Keys are identified by their **evdev event code name** on Linux. Common keys:
 
 ### Finding Key Names
 
-To find the evdev name for any key:
+To discover the evdev name for any key:
 ```bash
 # Install evtest if not present
 sudo apt install evtest
@@ -101,40 +103,58 @@ sudo apt install evtest
 # Run (pick your keyboard device)
 sudo evtest /dev/input/event2
 
-# Press the key you want — look for "EV_KEY" lines
-# e.g.: Event: type 1 (EV_KEY), code 125 (KEY_LEFTMETA), value 1
+# Press the key — look for "EV_KEY" lines:
+# Event: type 1 (EV_KEY), code 125 (KEY_LEFTMETA), value 1
 ```
 
 ---
 
 ## Hot-Reload
 
-Hotkey bindings can be updated without restarting the listener. When `bindings.toml` changes on disk or bindings are saved via the UI:
+Hotkey bindings update at runtime without restarting the listener. When bindings are saved via the UI or `save_bindings` IPC command:
 
-1. New bindings are parsed
-2. Sent through `binding_reload_tx` channel
-3. The listener thread receives them and swaps its internal binding table atomically
-
-This means you can add, modify, or remove hotkeys at runtime.
+1. New bindings are written to `bindings.toml`
+2. Sent through the `hotkey_reloader` crossbeam channel
+3. The listener thread receives them and swaps its binding state table
 
 ---
 
 ## Multi-Key Combos
 
-`keys` in a binding is an array. VoxCtr tracks which keys from the combo are currently held and only fires the gesture when **all** keys in the combo are pressed:
+`keys` is an array. All keys must be pressed for the gesture to activate. Order doesn't matter:
 
 ```toml
 keys = ["KEY_LEFTMETA", "KEY_SPACE"]
-# Fires only when both Left-Super AND Space are held
+# Fires when both Left-Super AND Space are held, in any order
 ```
 
-Order does not matter — holding Meta then Space, or Space then Meta, both trigger.
+---
+
+## GestureEvent
+
+The output of the hotkey system is a stream of `GestureEvent` values sent on the `gesture_tx` channel:
+
+```rust
+pub struct GestureEvent {
+    pub binding_id: String,
+    pub binding_label: String,
+    pub target_id: String,  // comma-joined for multi-target
+    pub kind: GestureKind,
+}
+
+pub enum GestureKind {
+    Start,  // Begin recording
+    Stop,   // End recording
+}
+```
+
+`lib.rs` receives these and coordinates the audio recorder and inference pipeline.
 
 ---
 
 ## Conflict Handling
 
-If two bindings share the same key combo, the first matching binding wins. Disable bindings you don't want rather than leaving conflicting ones active:
+If two bindings share the same key combo, the first matching binding wins (the one listed first in `bindings.toml`). Disable unused bindings rather than leaving conflicts active:
 
 ```toml
 [[binding]]
@@ -143,18 +163,3 @@ disabled = true
 keys = ["KEY_LEFTMETA", "KEY_SPACE"]
 # ...
 ```
-
----
-
-## GestureEvent
-
-The output of the hotkey system is a stream of `GestureEvent` values sent on `gesture_tx`:
-
-```rust
-pub enum GestureEvent {
-    StartRecording { binding_id: String, target_ids: Vec<String> },
-    StopRecording  { binding_id: String },
-}
-```
-
-`lib.rs` receives these and coordinates the audio recorder and inference pipeline accordingly.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -95,8 +95,8 @@ On first launch, VoxCtr will:
 ### Download a Whisper Model
 Before you can dictate, you need a speech recognition model:
 1. Go to Settings → Engine
-2. Choose a model size (recommendation: `base` for speed, `small` for better accuracy)
-3. Click "Download" and wait for completion (~100 MB for `base`)
+2. Choose a model size (recommendation: `small` for a good speed/accuracy balance; the default is `large-v3` for maximum accuracy)
+3. Click "Download" and wait for completion (~142 MB for `base`, ~466 MB for `small`, ~3 GB for `large-v3`)
 
 ### Configure a Hotkey
 A default binding (`Super + Space`, hold gesture → inject to focused window) is created automatically. Verify it in Settings → Hotkeys, or change the key combo if it conflicts with your desktop environment.
@@ -151,7 +151,7 @@ See [Development Guide](./development.md).
 ### No audio devices found
 - Run `arecord -l` to verify your mic is recognized by ALSA
 - Check if PulseAudio/PipeWire is running: `pactl info`
-- Try setting `audio.device_index` manually to a specific device index
+- Try setting `audio.input_device_index` manually to a specific device index (integer, not null)
 
 ### Text not injecting on Wayland
 - Verify `wtype` is installed: `which wtype`

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,167 @@
+# Installation & Setup
+
+## System Requirements
+
+### Linux
+- **OS:** Any modern Linux distro (Ubuntu 20.04+, Fedora 36+, Arch, etc.)
+- **Display:** X11 or Wayland
+- **Audio:** PulseAudio or PipeWire (ALSA fallback supported)
+- **Required packages:** `libwebkit2gtk-4.1`, `libayatana-appindicator3` or `libappindicator3`
+- **Optional:** `wtype` (Wayland injection), `xdotool` (X11 injection), `espeak-ng` (TTS fallback)
+
+### Windows
+- **OS:** Windows 10 (1903+) or Windows 11
+- **Runtime:** WebView2 (pre-installed on Win11; auto-downloadable on Win10)
+
+---
+
+## Installing the AppImage (Linux)
+
+The recommended distribution format is an AppImage — a single portable executable with all dependencies bundled.
+
+```bash
+# Download the latest AppImage
+curl -LO https://github.com/jrufer/voxctr/releases/latest/download/VoxCtr.AppImage
+
+# Make executable
+chmod +x VoxCtr.AppImage
+
+# Run
+./VoxCtr.AppImage
+```
+
+Or use the install script for system integration (desktop entry, udev rules):
+```bash
+bash install.sh
+```
+
+The install script:
+1. Copies the AppImage to `~/.local/bin/voxctr`
+2. Installs a `.desktop` file for application launchers
+3. Creates udev rules for `/dev/input` access (required for global hotkeys)
+4. Adds the current user to the `input` group
+
+> **Note:** After running `install.sh`, you must log out and back in for the `input` group membership to take effect. Until then, global hotkeys will not work.
+
+---
+
+## Permissions Setup (Linux)
+
+### Global Hotkeys
+VoxCtr uses evdev to listen for global keyboard events. Your user must be in the `input` group:
+
+```bash
+sudo usermod -aG input $USER
+# Log out and back in
+```
+
+Verify:
+```bash
+groups $USER | grep input
+```
+
+### Wayland Text Injection
+For Wayland sessions, install `wtype`:
+```bash
+# Ubuntu/Debian
+sudo apt install wtype
+
+# Arch
+sudo pacman -S wtype
+
+# Fedora
+sudo dnf install wtype
+```
+
+### X11 Text Injection
+For X11 sessions, install `xdotool`:
+```bash
+# Ubuntu/Debian
+sudo apt install xdotool
+
+# Arch
+sudo pacman -S xdotool
+```
+
+---
+
+## First Run
+
+On first launch, VoxCtr will:
+1. Create `~/.config/voxctl/` with default `config.json`, `targets.toml`, and `bindings.toml`
+2. Create `~/.local/share/voxctl/` for model and voice storage
+3. Open the Settings window
+
+### Download a Whisper Model
+Before you can dictate, you need a speech recognition model:
+1. Go to Settings → Engine
+2. Choose a model size (recommendation: `base` for speed, `small` for better accuracy)
+3. Click "Download" and wait for completion (~100 MB for `base`)
+
+### Configure a Hotkey
+A default binding (`Super + Space`, hold gesture → inject to focused window) is created automatically. Verify it in Settings → Hotkeys, or change the key combo if it conflicts with your desktop environment.
+
+### Test Dictation
+1. Open any text editor
+2. Click into the text area
+3. Hold `Super + Space` and speak
+4. Release to transcribe
+
+---
+
+## Optional Setup
+
+### GPU Acceleration
+If you have an NVIDIA GPU, install the CUDA toolkit and set `engine.device = "cuda"` in config. VoxCtr will auto-detect it with `"auto"`.
+
+For AMD/Intel GPUs, Vulkan support (`engine.device = "vulkan"`) requires:
+```bash
+# Ubuntu
+sudo apt install vulkan-tools libvulkan1
+
+# Arch
+sudo pacman -S vulkan-icd-loader
+```
+
+### Ollama Post-Processing
+If you want LLM grammar correction:
+1. Install [Ollama](https://ollama.ai/)
+2. Pull a model: `ollama pull llama3.2`
+3. Enable in Settings → Ollama
+
+### MCP Server (Claude Desktop / Cursor)
+1. Enable in Settings → Engine → MCP Server
+2. Configure your MCP client to connect to `/tmp/voxctl-mcp.sock`
+
+---
+
+## Building from Source
+
+See [Development Guide](./development.md).
+
+---
+
+## Troubleshooting
+
+### Hotkeys not working
+- Check you are in the `input` group: `groups | grep input`
+- Log out and back in after adding to group
+- On some distros, the udev rule path differs — check `install.sh` for details
+
+### No audio devices found
+- Run `arecord -l` to verify your mic is recognized by ALSA
+- Check if PulseAudio/PipeWire is running: `pactl info`
+- Try setting `audio.device_index` manually to a specific device index
+
+### Text not injecting on Wayland
+- Verify `wtype` is installed: `which wtype`
+- Some applications block synthetic input (e.g. terminals with certain settings)
+- Clipboard fallback always works — use `delivery = "clipboard"` as a workaround
+
+### Whisper outputs wrong language
+- Set `engine.language` to your language code (e.g. `"de"`, `"fr"`, `"es"`)
+- Use a larger model for better non-English accuracy
+
+### AppImage won't launch
+- Install FUSE: `sudo apt install fuse libfuse2`
+- Or extract and run directly: `./VoxCtr.AppImage --appimage-extract && squashfs-root/AppRun`

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -19,8 +19,6 @@ The [Model Context Protocol](https://modelcontextprotocol.io/) is an open standa
 | Linux | `/tmp/voxctl-mcp.sock` (Unix domain socket) |
 | Windows | `\\.\pipe\voxctl-mcp` (named pipe) |
 
-The socket is owned by the current user with mode `0600` (no other user can connect).
-
 ### Protocol
 
 JSON-RPC 2.0 over the socket. Follows MCP spec v2024-11-05.
@@ -31,54 +29,48 @@ JSON-RPC 2.0 over the socket. Follows MCP spec v2024-11-05.
 {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","clientInfo":{"name":"claude-desktop"}}}
 
 // Server responds:
-{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"serverInfo":{"name":"voxctr","version":"..."}}}
+{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"serverInfo":{"name":"voxctl","version":"1.0.0"}}}
 
-// Client sends:
+// Client sends (notification, no id):
 {"jsonrpc":"2.0","method":"notifications/initialized"}
 ```
 
 ### Available Tools
 
 #### `transcribe_voice`
-Records audio and returns the transcription as text.
+Records audio and returns the transcription. Blocks until recording ends or timeout is reached.
 
 ```json
 {
   "method": "tools/call",
   "params": {
     "name": "transcribe_voice",
-    "arguments": {
-      "timeout_seconds": 30
-    }
+    "arguments": { "timeout_seconds": 15 }
   }
 }
 ```
+
+`timeout_seconds` defaults to `mcp.record_timeout` (15.0 seconds). Returns `"(no speech detected)"` if no audio was captured.
 
 Response:
 ```json
-{
-  "result": {
-    "content": [{"type": "text", "text": "the transcribed text here"}]
-  }
-}
+{"content": [{"type": "text", "text": "the transcribed text here"}]}
 ```
 
-The call blocks until recording completes (hotkey released) or the timeout is reached.
-
 #### `speak_text`
-Queues text for TTS playback.
+Queues text for TTS playback. Returns immediately while audio plays asynchronously.
 
 ```json
 {
   "method": "tools/call",
   "params": {
     "name": "speak_text",
-    "arguments": {
-      "text": "Recording started. Please speak now."
-    }
+    "arguments": { "text": "Recording started. Please speak now." }
   }
 }
 ```
+
+Returns: `{"content": [{"type": "text", "text": "spoken"}]}`
 
 #### `get_status`
 Returns current recording/speaking state.
@@ -92,9 +84,24 @@ Response:
 {"content": [{"type": "text", "text": "{\"recording\": false, \"speaking\": false}"}]}
 ```
 
+**Recommended pattern — speak then record safely:**
+1. Call `speak_text` with your question
+2. Poll `get_status` until `speaking = false`
+3. Call `transcribe_voice`
+
+### Enabling the MCP Server
+
+In `config.json`:
+```json
+"mcp": {
+  "server_enabled": true,
+  "record_timeout": 15.0
+}
+```
+
 ### Configuring Claude Desktop
 
-Add to your Claude Desktop `claude_desktop_config.json`:
+Add to `claude_desktop_config.json`:
 ```json
 {
   "mcpServers": {
@@ -103,18 +110,6 @@ Add to your Claude Desktop `claude_desktop_config.json`:
       "args": ["-U", "/tmp/voxctl-mcp.sock"]
     }
   }
-}
-```
-
-Or use a proxy script that connects to the socket.
-
-### Enabling the MCP Server
-
-In `config.json`:
-```json
-"mcp": {
-  "enabled": true,
-  "record_timeout": 30
 }
 ```
 
@@ -138,7 +133,7 @@ VoxCtr registers on the session bus as:
 | `start_recording()` | `() → ()` | Begin recording |
 | `stop_recording()` | `() → ()` | Stop recording and process audio |
 | `toggle_recording()` | `() → ()` | Toggle recording state |
-| `get_status()` | `() → s` | Returns `"recording"`, `"processing"`, or `"idle"` |
+| `get_status()` | `() → s` | Returns `"idle"`, `"recording"`, or `"transcribing"` |
 | `get_word_count()` | `() → u` | Total words dictated this session |
 
 ### Signals
@@ -159,17 +154,14 @@ dbus-send --session --dest=ai.voxctl.Dictation \
 # Watch for injected text
 dbus-monitor --session "type='signal',interface='ai.voxctl.Dictation'"
 
-# Get current status
+# Get current status ("idle", "recording", or "transcribing")
 dbus-send --session --print-reply \
   --dest=ai.voxctl.Dictation \
   /ai/voxctl/Dictation \
   ai.voxctl.Dictation.get_status
 ```
 
-### Use Cases
-- Desktop environment macros
-- i3/Sway workspace scripts
-- System-wide voice command pipeline
+The DBus service is a stub on non-Linux platforms (compiles but does nothing).
 
 ---
 
@@ -179,42 +171,45 @@ dbus-send --session --print-reply \
 
 ### Purpose
 
-After Whisper transcribes your speech, the raw text can optionally be rewritten by a local LLM running in [Ollama](https://ollama.ai/). This is useful for correcting grammar, adjusting tone, or reformatting content.
+After Whisper transcribes speech, text can optionally be rewritten by a local LLM running in [Ollama](https://ollama.ai/). Enabled per-target via `processing.ollama_enabled = true` in `targets.toml`.
 
 ### Configuration
 
 ```json
 "ollama": {
-  "enabled": true,
+  "enabled": false,
   "endpoint": "http://localhost:11434",
-  "model": "llama3.2",
+  "model": "llama3.2:1b",
   "mode": "clean",
-  "custom_prompt": ""
+  "custom_prompt": null,
+  "timeout_secs": 8
 }
 ```
 
 ### Modes
 
-| Mode | Behavior |
+| Mode | Prompt sent to LLM |
 |---|---|
-| `clean` | Fix grammar, punctuation, and capitalization |
-| `formal` | Rewrite in formal/professional language |
-| `casual` | Rewrite in conversational language |
-| `bullet` | Convert to a bullet-point list |
-| `concise` | Shorten and summarize |
-| `custom` | Use `custom_prompt` as the instruction |
+| `clean` | "Fix grammar and punctuation only. Return only the corrected text, no commentary." |
+| `formal` | "Rewrite in formal professional language. Return only the result." |
+| `casual` | "Rewrite in casual conversational language. Return only the result." |
+| `bullet` | "Convert to a bullet-point list. Return only the list." |
+| `concise` | "Summarize concisely in 1-2 sentences. Return only the summary." |
+| `custom` | Uses `custom_prompt` field |
 
-### Custom Prompt Template
+### Custom Prompt
 
-With `mode = "custom"`, the `custom_prompt` field is used as the LLM instruction. The transcribed text is appended:
+With `mode = "custom"`, the `custom_prompt` field is used as the LLM instruction:
+- If `custom_prompt` contains `{text}`, that placeholder is replaced with the transcribed text
+- Otherwise, the transcribed text is appended after the prompt on a new line
 
-```json
-"custom_prompt": "Rewrite the following as a professional email reply:"
-```
+### Availability Caching
+
+`OllamaClient.is_available()` probes `GET /api/tags` on first call and **caches the result**. If Ollama was unreachable at startup, it will appear unreachable until the availability cache is reset (e.g. by changing the endpoint in settings).
 
 ### Graceful Fallback
 
-If Ollama is unreachable or returns an error, VoxCtr logs the failure and delivers the **original** Whisper transcription unchanged. It never blocks or drops text.
+If Ollama is unreachable, the HTTP request times out, or the response cannot be parsed, VoxCtr logs the failure and delivers the **original** Whisper transcription unchanged. Text is never dropped.
 
 ### Testing the Connection
 
@@ -232,7 +227,7 @@ const result = await invoke('test_ollama', {
 ## HTTP Webhooks
 
 ### Endpoint Delivery (`http` type)
-POST with JSON body:
+POST with JSON body to `http_url`:
 ```
 POST https://your-endpoint.com/voice
 Content-Type: application/json
@@ -240,30 +235,22 @@ Content-Type: application/json
 {"text": "transcribed text"}
 ```
 
+Configurable: `http_method`, `http_headers`, `http_json_template`.
+
 ### Signed Webhooks (`webhook` type)
-Same POST but with additional HMAC-SHA256 signature:
+Same POST (to `webhook_url`) but with HMAC-SHA256 signature:
 ```
 X-VoxCtr-Signature: sha256=abc123...
-```
-
-Verify on your server:
-```python
-import hmac, hashlib
-
-def verify(payload: bytes, secret: str, signature: str) -> bool:
-    expected = 'sha256=' + hmac.new(
-        secret.encode(), payload, hashlib.sha256
-    ).hexdigest()
-    return hmac.compare_digest(expected, signature)
 ```
 
 ---
 
 ## AT-SPI2 Context Integration (Linux)
 
-When `atspi.enabled = true`, VoxCtr uses the Linux Accessibility API (AT-SPI2) to:
+When `atspi.context_prompt = true`, VoxCtr uses the Linux Accessibility API (AT-SPI2) to read the surrounding text from the focused text field. This text is included in the Whisper initial prompt to improve transcription continuity and vocabulary consistency.
 
-1. **Read focused widget text** — Retrieves the last ~200 characters from the focused text field to use as a Whisper context prompt, improving transcription continuity.
-2. **Auto code mode** — Detects if the focused application is a code editor and automatically enables code-mode post-processing.
+When `atspi.auto_code_mode = true`, VoxCtr detects when the focused application is a code editor or terminal and automatically enables code-mode post-processing.
 
-Requires the `at-spi2-core` package and the `org.a11y.Bus` DBus service.
+When `atspi.injection = true`, AT-SPI2 is used as the primary text injection method (before falling back to wtype/xdotool).
+
+Requires the `at-spi2-core` package and the `org.a11y.Bus` DBus service to be running.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,269 @@
+# Integrations
+
+VoxCtr exposes several interfaces for external tools and services to interact with it.
+
+---
+
+## MCP Server
+
+**Crate:** `crates/voxctr-mcp/`
+
+### What is MCP?
+
+The [Model Context Protocol](https://modelcontextprotocol.io/) is an open standard for LLM agents to call tools on local servers. VoxCtr implements an MCP server that lets AI assistants like **Claude Desktop** or **Cursor IDE** trigger voice recording and TTS.
+
+### Transport
+
+| Platform | Socket |
+|---|---|
+| Linux | `/tmp/voxctl-mcp.sock` (Unix domain socket) |
+| Windows | `\\.\pipe\voxctl-mcp` (named pipe) |
+
+The socket is owned by the current user with mode `0600` (no other user can connect).
+
+### Protocol
+
+JSON-RPC 2.0 over the socket. Follows MCP spec v2024-11-05.
+
+**Handshake:**
+```json
+// Client sends:
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","clientInfo":{"name":"claude-desktop"}}}
+
+// Server responds:
+{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"serverInfo":{"name":"voxctr","version":"..."}}}
+
+// Client sends:
+{"jsonrpc":"2.0","method":"notifications/initialized"}
+```
+
+### Available Tools
+
+#### `transcribe_voice`
+Records audio and returns the transcription as text.
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "transcribe_voice",
+    "arguments": {
+      "timeout_seconds": 30
+    }
+  }
+}
+```
+
+Response:
+```json
+{
+  "result": {
+    "content": [{"type": "text", "text": "the transcribed text here"}]
+  }
+}
+```
+
+The call blocks until recording completes (hotkey released) or the timeout is reached.
+
+#### `speak_text`
+Queues text for TTS playback.
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "speak_text",
+    "arguments": {
+      "text": "Recording started. Please speak now."
+    }
+  }
+}
+```
+
+#### `get_status`
+Returns current recording/speaking state.
+
+```json
+{"method": "tools/call", "params": {"name": "get_status", "arguments": {}}}
+```
+
+Response:
+```json
+{"content": [{"type": "text", "text": "{\"recording\": false, \"speaking\": false}"}]}
+```
+
+### Configuring Claude Desktop
+
+Add to your Claude Desktop `claude_desktop_config.json`:
+```json
+{
+  "mcpServers": {
+    "voxctr": {
+      "command": "nc",
+      "args": ["-U", "/tmp/voxctl-mcp.sock"]
+    }
+  }
+}
+```
+
+Or use a proxy script that connects to the socket.
+
+### Enabling the MCP Server
+
+In `config.json`:
+```json
+"mcp": {
+  "enabled": true,
+  "record_timeout": 30
+}
+```
+
+---
+
+## DBus Service (Linux)
+
+**Crate:** `crates/voxctr-dbus/`
+
+### Interface
+
+VoxCtr registers on the session bus as:
+- **Bus name:** `ai.voxctl.Dictation`
+- **Object path:** `/ai/voxctl/Dictation`
+- **Interface:** `ai.voxctl.Dictation`
+
+### Methods
+
+| Method | Signature | Description |
+|---|---|---|
+| `start_recording()` | `() → ()` | Begin recording |
+| `stop_recording()` | `() → ()` | Stop recording and process audio |
+| `toggle_recording()` | `() → ()` | Toggle recording state |
+| `get_status()` | `() → s` | Returns `"recording"`, `"processing"`, or `"idle"` |
+| `get_word_count()` | `() → u` | Total words dictated this session |
+
+### Signals
+
+| Signal | Signature | Description |
+|---|---|---|
+| `status_changed` | `(s)` | Emitted when recording state changes |
+| `text_injected` | `(s)` | Emitted after text is delivered to a target |
+
+### Example Usage
+
+```bash
+# Start recording
+dbus-send --session --dest=ai.voxctl.Dictation \
+  /ai/voxctl/Dictation \
+  ai.voxctl.Dictation.start_recording
+
+# Watch for injected text
+dbus-monitor --session "type='signal',interface='ai.voxctl.Dictation'"
+
+# Get current status
+dbus-send --session --print-reply \
+  --dest=ai.voxctl.Dictation \
+  /ai/voxctl/Dictation \
+  ai.voxctl.Dictation.get_status
+```
+
+### Use Cases
+- Desktop environment macros
+- i3/Sway workspace scripts
+- System-wide voice command pipeline
+
+---
+
+## Ollama Integration
+
+**Crate:** `crates/voxctr-llm/`
+
+### Purpose
+
+After Whisper transcribes your speech, the raw text can optionally be rewritten by a local LLM running in [Ollama](https://ollama.ai/). This is useful for correcting grammar, adjusting tone, or reformatting content.
+
+### Configuration
+
+```json
+"ollama": {
+  "enabled": true,
+  "endpoint": "http://localhost:11434",
+  "model": "llama3.2",
+  "mode": "clean",
+  "custom_prompt": ""
+}
+```
+
+### Modes
+
+| Mode | Behavior |
+|---|---|
+| `clean` | Fix grammar, punctuation, and capitalization |
+| `formal` | Rewrite in formal/professional language |
+| `casual` | Rewrite in conversational language |
+| `bullet` | Convert to a bullet-point list |
+| `concise` | Shorten and summarize |
+| `custom` | Use `custom_prompt` as the instruction |
+
+### Custom Prompt Template
+
+With `mode = "custom"`, the `custom_prompt` field is used as the LLM instruction. The transcribed text is appended:
+
+```json
+"custom_prompt": "Rewrite the following as a professional email reply:"
+```
+
+### Graceful Fallback
+
+If Ollama is unreachable or returns an error, VoxCtr logs the failure and delivers the **original** Whisper transcription unchanged. It never blocks or drops text.
+
+### Testing the Connection
+
+Via the Settings → Ollama tab → "Test Connection" button, or via IPC:
+```typescript
+const result = await invoke('test_ollama', {
+  endpoint: 'http://localhost:11434',
+  timeoutSecs: 5
+});
+// result: { success: boolean, message: string, models: string[] }
+```
+
+---
+
+## HTTP Webhooks
+
+### Endpoint Delivery (`http` type)
+POST with JSON body:
+```
+POST https://your-endpoint.com/voice
+Content-Type: application/json
+
+{"text": "transcribed text"}
+```
+
+### Signed Webhooks (`webhook` type)
+Same POST but with additional HMAC-SHA256 signature:
+```
+X-VoxCtr-Signature: sha256=abc123...
+```
+
+Verify on your server:
+```python
+import hmac, hashlib
+
+def verify(payload: bytes, secret: str, signature: str) -> bool:
+    expected = 'sha256=' + hmac.new(
+        secret.encode(), payload, hashlib.sha256
+    ).hexdigest()
+    return hmac.compare_digest(expected, signature)
+```
+
+---
+
+## AT-SPI2 Context Integration (Linux)
+
+When `atspi.enabled = true`, VoxCtr uses the Linux Accessibility API (AT-SPI2) to:
+
+1. **Read focused widget text** — Retrieves the last ~200 characters from the focused text field to use as a Whisper context prompt, improving transcription continuity.
+2. **Auto code mode** — Detects if the focused application is a code editor and automatically enables code-mode post-processing.
+
+Requires the `at-spi2-core` package and the `org.a11y.Bus` DBus service.

--- a/docs/mcp_documentation.md
+++ b/docs/mcp_documentation.md
@@ -386,7 +386,7 @@ append_newline = true
 
 ## TTS Configuration
 
-All TTS and MCP settings live in `~/.config/voxctl/config.json` and in **Settings → TTS** or **Settings → Ollama**.
+All TTS settings live in `~/.config/voxctl/config.json` under the `tts` key (**Settings → TTS**). MCP settings live under the `mcp` key (**Settings → Ollama**).
 
 | Key | Type | Default | Description |
 |---|---|---|---|

--- a/docs/mcp_documentation.md
+++ b/docs/mcp_documentation.md
@@ -1,12 +1,12 @@
-# VoxCtl MCP Server
+# VoxCtr MCP Server
 
-VoxCtl ships a built-in **Model Context Protocol (MCP)** server that exposes the app's voice I/O pipeline as tools any MCP-capable AI can call. An agent can trigger the microphone, receive the transcript, and queue a spoken response — all through a standardised JSON-RPC 2.0 interface.
+VoxCtr ships a built-in **Model Context Protocol (MCP)** server that exposes the app's voice I/O pipeline as tools any MCP-capable AI can call. An agent can trigger the microphone, receive the transcript, and queue a spoken response — all through a standardised JSON-RPC 2.0 interface.
 
 ---
 
 ## Overview
 
-When the MCP server is enabled, VoxCtl listens on a local transport and presents three tools:
+When the MCP server is enabled, VoxCtr listens on a local transport and presents three tools:
 
 | Tool | What it does |
 |---|---|
@@ -18,7 +18,7 @@ This lets an AI agent have a full voice conversation:
 
 ```
 Agent → transcribe_voice()  → user speaks → transcript returned
-Agent → speak_text("…")     → VoxCtl speaks the response aloud
+Agent → speak_text("…")     → VoxCtr speaks the response aloud
 Agent → transcribe_voice()  → next turn …
 ```
 
@@ -43,7 +43,7 @@ sudo pacman -S espeak-ng
 
 ### Voice models
 
-Voice models are downloaded from inside the app. Go to **Settings → Voice Output**, select a voice from the picker, and click **⬇ Download**. Models are stored locally in:
+Voice models are downloaded from inside the app. Go to **Settings → TTS**, select a voice from the picker, and click **⬇ Download**. Models are stored locally in:
 
 ```
 ~/.local/share/voxctl/piper-voices/
@@ -55,11 +55,10 @@ Voice models are downloaded from inside the app. Go to **Settings → Voice Outp
 
 ### Via Settings UI
 
-1. Open **Settings → AI**
+1. Open **Settings → Ollama**
 2. Scroll to the **MCP Server** section
 3. Toggle **"Enable MCP Server"**
 4. The server will bind to the standard socket/pipe path shown in the settings window.
-5. Optionally click **"Register in Claude Desktop"** to auto-configure Claude Desktop (Linux).
 
 ### Via config.json
 
@@ -179,7 +178,7 @@ Opens the microphone and returns a transcript when speech ends.
 
 * While recording, the active waveform or recording overlay is shown — the user always has a visual indicator that the mic is live.
 * The microphone is released automatically once VAD detects silence or `timeout_seconds` elapses.
-* VoxCtl's full post-processing pipeline (including Ollama formatting/cleaning if enabled) is applied before the transcript is returned.
+* VoxCtr's full post-processing pipeline (including Ollama formatting/cleaning if enabled) is applied before the transcript is returned.
 
 ---
 
@@ -278,23 +277,13 @@ The `text` field is a JSON-encoded object:
 
 | Code | Meaning |
 |---|---|
+| `-32700` | Parse error (malformed JSON) |
 | `-32601` | Method not found |
-| `-32602` | Unknown tool name |
-| `-32603` | Internal error (missing required argument, callback exception) |
+| `-32603` | Internal error (unknown tool name, missing required argument, callback exception) |
 
 ---
 
 ## Connecting: Claude Desktop (Linux)
-
-### One-click registration
-
-In **Settings → AI → MCP Server**, click **"Register in Claude Desktop"**. The app writes the `socat` bridge entry to:
-
-```
-~/.config/claude/claude_desktop_config.json
-```
-
-### Manual configuration
 
 Add the following to `~/.config/claude/claude_desktop_config.json`:
 
@@ -311,7 +300,7 @@ Add the following to `~/.config/claude/claude_desktop_config.json`:
 
 Restart Claude Desktop. The tools `transcribe_voice`, `speak_text`, and `get_status` appear automatically in the tool picker.
 
-> **Note:** VoxCtl must already be running before Claude Desktop connects.
+> **Note:** VoxCtr must already be running before Claude Desktop connects.
 
 ---
 
@@ -371,7 +360,7 @@ echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
 
 ## Response Loopback (FIFO pipe)
 
-For agents that generate responses to a named FIFO, VoxCtl can dynamically read those responses and speak them automatically — without needing the agent to call `speak_text` directly.
+For agents that generate responses to a named FIFO, VoxCtr can dynamically read those responses and speak them automatically — without needing the agent to call `speak_text` directly.
 
 ### How it works
 
@@ -390,7 +379,6 @@ label = "My Agent"
 delivery = "pipe"
 pipe_path = "/tmp/my-agent.in"
 response_pipe = "/tmp/my-agent.out"   # ← agent writes responses here
-post_processing = "none"
 append_newline = true
 ```
 
@@ -398,7 +386,7 @@ append_newline = true
 
 ## TTS Configuration
 
-All TTS and MCP settings live in `~/.config/voxctl/config.json` and in **Settings → Voice Output** or **Settings → AI**.
+All TTS and MCP settings live in `~/.config/voxctl/config.json` and in **Settings → TTS** or **Settings → Ollama**.
 
 | Key | Type | Default | Description |
 |---|---|---|---|
@@ -426,7 +414,7 @@ All TTS and MCP settings live in `~/.config/voxctl/config.json` and in **Setting
 | `en-us-danny-low` | US English | Low | 16000 Hz |
 | `en-gb-alan-low` | GB English | Low | 16000 Hz |
 
-Download voices in **Settings → Voice Output → Voice Picker → ⬇ Download**.
+Download voices in **Settings → TTS → Voice Picker → ⬇ Download**.
 
 ---
 
@@ -460,11 +448,11 @@ Download voices in **Settings → Voice Output → Voice Picker → ⬇ Download
 
 **Socket does not exist**
 
-VoxCtl is not running, or the MCP server is disabled. Enable it in **Settings → AI** or set `"mcp": { "server_enabled": true }` in `config.json` and restart.
+VoxCtr is not running, or the MCP server is disabled. Enable it in **Settings → Ollama** or set `"mcp": { "server_enabled": true }` in `config.json` and restart.
 
 **`socat` connection refused**
 
-The socket exists but the server is not listening yet. Wait a moment after VoxCtl starts, or check the app's console output for errors.
+The socket exists but the server is not listening yet. Wait a moment after VoxCtr starts, or check the app's console output for errors.
 
 **TTS plays but no audio**
 
@@ -475,11 +463,12 @@ The socket exists but the server is not listening yet. Wait a moment after VoxCt
 **`transcribe_voice` returns `(no speech detected)`**
 
 * Confirm your microphone is selected in **Settings → Audio**.
-* Raise `timeout_seconds` — the default 15 s may be too short if recording takes time to initialise.
-* Check VAD threshold in **Settings → Audio** — a high threshold may cut off quiet speech.
+* Raise `timeout_seconds` — the default 15 s may be too short if recording takes time to initialize.
+* Check the VAD threshold in **Settings → Audio** — a higher sensitivity value (lower raw threshold) may be needed for quiet speech.
 
 **Claude Desktop does not see the tools**
 
 * Restart Claude Desktop after editing `claude_desktop_config.json`.
 * Confirm `socat` is installed and `socat STDIO UNIX-CONNECT:/tmp/voxctl-mcp.sock` connects successfully from a terminal.
 * Check that `voxctl-mcp.sock` exists (`ls -la /tmp/*.sock`).
+* Ensure VoxCtr is running and the MCP server is enabled in **Settings → Ollama**.

--- a/docs/overlays.md
+++ b/docs/overlays.md
@@ -1,298 +1,122 @@
 # Overlay UI Guide
 
-VoxCtl displays a visual overlay while the microphone is active. The overlay system is fully swappable: you can choose from the built-in styles or create your own by dropping a single Python file into a special folder.
+VoxCtr displays a visual overlay while the microphone is active or while TTS is speaking. The overlay is a dedicated Tauri window (560×160 px, transparent background, always-on-top, click-through) that renders a Svelte component over whatever application is in focus.
+
+---
+
+## How the Overlay Works
+
+The overlay is a separate Tauri window running the `/overlay` route. It is:
+
+- **Transparent** — the window background is fully transparent; only the component's drawn pixels are visible.
+- **Always-on-top** — floats above all other windows.
+- **Click-through** (`pointer-events: none`) — keyboard and mouse events pass through to the window beneath.
+- **Non-resizable, skip-taskbar** — does not appear in the taskbar and cannot be resized.
+
+The overlay is controlled by the `show_overlay` / `hide_overlay` IPC commands and is automatically shown when recording starts and hidden when transcription completes (when `ui.show_overlay` is enabled in config).
+
+The active component is determined by `config.ui.overlay_style`. The overlay switches between styles without restarting the window — it remounts the component after a 25 ms flush to clear the WebKit compositor buffer.
 
 ---
 
 ## Built-in Styles
 
-Three styles are included out of the box.
+Four styles are available. The default is **Blue Wave**.
 
-### Voice Card *(default)*
+### Blue Wave *(default — `"blue_wave"`)*
 
-A floating card inspired by terminal-style audio monitors.
+A layered animated ocean-wave visualization that reacts to real-time audio levels.
 
-- Scrolling bar history: new bars arrive from the right, old bars slide left
-- Symmetric bars (mirrored top and bottom from a centre line)
-- Horizontal gradient: dim purple on the left (oldest audio) through magenta to bright pink-white on the right (most recent audio)
-- "Voice Activity" label and a routing indicator badge displayed in the card header
+- Three overlapping SVG wave layers in deep blue, cyan-aqua, and ice-teal
+- Waves rise and swell in amplitude in response to the `audio-level` event stream from the Rust backend
+- Displays a "Voice Activity" label and a green routing target badge in a dark rounded card
+- Slides in with a subtle upward animation on appear
 
-### Waveform
+### Voice Card (`"voice_card"`)
 
-An OpenGL oscilloscope that renders the raw audio signal as a min/max envelope. Fast and lightweight.
+A bar-graph spectrum display with 45 animated bars.
 
-- Dark rounded box anchored to the bottom-centre of the screen
-- Updates in real time with each audio chunk
+- Bars respond to RMS audio level with a fast-attack, fast-release envelope
+- Displays "Voice Activity" label and active routing target badge
+- Dark glassy card with rounded corners
 
-### Pulse Circle
+### Waveform (`"waveform"`)
 
-A soft glowing circle that expands and contracts with the RMS amplitude of your voice.
+A centre-weighted bar graph with a Gaussian amplitude envelope.
 
-- Smooth 30 fps animation with exponential decay
-- Blue glow rings fade out during silence
+- 48 bars, tallest in the centre and tapering at the edges
+- Randomised per-bar noise during recording for a spectrum-analyser look
+- Shows a flat idle state when not recording
+
+### Pulse (`"pulse"`)
+
+A compact pill-shaped indicator with animated concentric rings.
+
+- Three states: **Initializing** (amber, shows "Connecting Mic…"), **Recording** (orange, shows active target label), **Processing** (blue, shows "Processing…")
+- Two animated CSS rings pulse outward during active recording
+- Includes an active target badge with context-appropriate icon (🎯 recording, 🧠 processing, ⏳ initializing)
+
+### None (`"none"`)
+
+Disables the overlay entirely. The window remains hidden during recording.
 
 ---
 
-## Selecting an Overlay
+## Selecting an Overlay Style
 
 1. Open **⚙ Settings** from the system tray icon.
-2. Go to the **✨ Dictation** tab.
-3. In the **Overlay Appearance** section, pick a style from the dropdown.
-4. Click **Save Settings**.
-
-The overlay switches instantly — no restart is required. Custom overlays you add to the overlays folder appear in the same dropdown automatically after the next save.
+2. Go to the **Visual** tab.
+3. In the **Overlay Appearance** section, choose a style from the dropdown.
+4. The setting saves automatically and takes effect immediately — no restart required.
 
 ---
 
-## Creating a Custom Overlay
+## Configuration
 
-### Where to put the file
+The overlay style is stored in `~/.config/voxctl/config.json` under `ui.overlay_style`:
 
-Place a `.py` file in:
-
-```
-~/.config/voxctl/overlays/
-```
-
-Click **"Open Overlays Folder"** in Settings to open this directory in your file manager. On first open, a `_template.py` starter file is written there for you.
-
-> Files whose names begin with `_` (e.g. `_template.py`) are ignored by the loader — use this convention for notes, drafts, or helper modules.
-
-### Required structure
-
-Your file must contain:
-
-| Item | Type | Required | Description |
-|------|------|----------|-------------|
-| `DISPLAY_NAME` | `str` | Yes | Name shown in the Settings dropdown |
-| `DESCRIPTION` | `str` | No | One-line description shown below the dropdown |
-| `VERSION` | `str` | No | Version string (informational only) |
-| `class OverlayUI(QWidget)` | class | Yes | The overlay widget itself |
-
-`OverlayUI` must implement these three methods:
-
-```python
-def update_audio(self, data: numpy.ndarray) -> None: ...
-def show_mode(self, label: str = "") -> None: ...
-def hide_mode(self) -> None: ...
+```json
+{
+  "ui": {
+    "show_overlay": true,
+    "overlay_style": "blue_wave"
+  }
+}
 ```
 
-### The three methods in detail
+Valid values for `overlay_style`: `"blue_wave"` (default), `"voice_card"`, `"waveform"`, `"pulse"`, `"none"`.
 
-#### `update_audio(data)`
-
-Called from the audio thread approximately every 20–60 ms while recording is active.
-
-| Parameter | Type | Details |
-|-----------|------|---------|
-| `data` | `numpy.ndarray` | `dtype=float32`, typically 1024 samples per call, amplitude range roughly ±32 768 (signed 16-bit scale) |
-
-Because this is called from a background thread, **do not call Qt drawing methods directly here**. Store the data and schedule a repaint using:
-
-```python
-QMetaObject.invokeMethod(self, "update", Qt.ConnectionType.QueuedConnection)
-```
-
-#### `show_mode(label="")`
-
-Called on the Qt main thread when the user starts recording. `label` is the human-readable name of the active output target (from `targets.toml`) and is used by built-in overlays to display the routing indicator badge. You can use it or ignore it. Your overlay should cover the full screen so it is visible over any application. The standard implementation:
-
-```python
-def show_mode(self, label: str = ""):
-    self._routing_label = label   # store for use in paintEvent
-    screen = QApplication.primaryScreen()
-    if screen:
-        g = screen.geometry()
-        self.setGeometry(g)
-        self.setFixedSize(g.width(), g.height())
-        self.move(g.x(), g.y())
-    self.show()
-    self.raise_()
-```
-
-#### `hide_mode()`
-
-Called on the Qt main thread when recording stops.
-
-```python
-def hide_mode(self):
-    self.hide()
-```
-
-### Window flags for a transparent, click-through overlay
-
-All built-in overlays use these flags. Copy them into your `__init__`:
-
-```python
-self.setWindowFlags(
-    Qt.WindowType.ToolTip |
-    Qt.WindowType.FramelessWindowHint |
-    Qt.WindowType.WindowStaysOnTopHint |
-    Qt.WindowType.X11BypassWindowManagerHint |
-    Qt.WindowType.WindowTransparentForInput   # click-through
-)
-self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
-self.setAttribute(Qt.WidgetAttribute.WA_ShowWithoutActivating)
-self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents)
-```
+Setting `show_overlay` to `false` prevents the overlay window from being shown at all, regardless of the style setting.
 
 ---
 
-## Full Template
+## Audio Level Feed
 
-This is the same file written to `_template.py` when you first open the overlays folder. Copy it, rename it (without a leading `_`), and customise freely.
+All overlay styles that react to audio receive levels via the `audio-level` Tauri event, emitted by the Rust backend approximately every 50 ms. The payload is a `number` (RMS energy, roughly 0.0–1.0). Components multiply this by a calibration factor (typically `100.0`) to map it to a usable animation amplitude.
 
-```python
-# Save as  ~/.config/voxctl/overlays/my_overlay.py
-# Then select "My Custom Overlay" in Settings → Appearance → Recording Overlay.
+```typescript
+import { listen } from '@tauri-apps/api/event';
 
-DISPLAY_NAME = "My Custom Overlay"
-DESCRIPTION  = "Describe what your overlay looks like"
-VERSION      = "1.0"
-
-import numpy as np
-from PyQt6.QtWidgets import QWidget, QApplication
-from PyQt6.QtCore import Qt, QMetaObject, QTimer
-from PyQt6.QtGui import QPainter, QColor, QBrush
-
-
-class OverlayUI(QWidget):
-
-    def __init__(self):
-        super().__init__()
-        self.setWindowFlags(
-            Qt.WindowType.ToolTip |
-            Qt.WindowType.FramelessWindowHint |
-            Qt.WindowType.WindowStaysOnTopHint |
-            Qt.WindowType.X11BypassWindowManagerHint |
-            Qt.WindowType.WindowTransparentForInput
-        )
-        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
-        self.setAttribute(Qt.WidgetAttribute.WA_ShowWithoutActivating)
-        self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents)
-        self.setFixedSize(800, 100)
-        self._amp = 0.0
-        self.hide()
-
-        # Drive smooth animations at 30 fps
-        self._timer = QTimer(self)
-        self._timer.timeout.connect(self.update)
-        self._timer.start(30)
-
-    # ------------------------------------------------------------------ #
-    #  Required interface                                                  #
-    # ------------------------------------------------------------------ #
-
-    def update_audio(self, data):
-        """
-        Called from the audio thread ~every 20-60 ms.
-        data: numpy.ndarray float32, ~1024 samples, amplitude range ±32768.
-        Store data here; schedule repaints with invokeMethod — never draw directly.
-        """
-        rms = float(np.sqrt(np.mean(data.astype(float) ** 2)))
-        self._amp = min(1.0, rms / 8192.0)
-        QMetaObject.invokeMethod(self, "update", Qt.ConnectionType.QueuedConnection)
-
-    def show_mode(self, label: str = ""):
-        """Called when recording starts. label is the active target name (routing badge)."""
-        self._routing_label = label
-        screen = QApplication.primaryScreen()
-        if screen:
-            g = screen.geometry()
-            self.setGeometry(g)
-            self.setFixedSize(g.width(), g.height())
-            self.move(g.x(), g.y())
-        self.show()
-        self.raise_()
-
-    def hide_mode(self):
-        """Called when recording stops."""
-        self.hide()
-
-    # ------------------------------------------------------------------ #
-    #  Custom drawing — replace this with your own design                 #
-    # ------------------------------------------------------------------ #
-
-    def paintEvent(self, event):
-        painter = QPainter(self)
-        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
-
-        # Example: a simple circle that grows with amplitude
-        cx = self.width() // 2
-        cy = self.height() - 65
-        r  = int(20 + self._amp * 25)
-
-        painter.setBrush(QBrush(QColor(74, 158, 255, 180)))
-        painter.setPen(Qt.PenStyle.NoPen)
-        painter.drawEllipse(cx - r, cy - r, r * 2, r * 2)
+await listen<number>('audio-level', (event) => {
+  const level = Math.min(1.0, event.payload * 100.0);
+  // drive animation
+});
 ```
+
+The `audio-level` stream is only active when monitoring is enabled. The overlay starts monitoring automatically when the recording session begins.
 
 ---
 
-## Tips
+## IPC Commands
 
-**Positioning your widget**
+```typescript
+import { invoke } from '@tauri-apps/api/core';
 
-The widget is expanded to full-screen size in `show_mode(label)`, but your visual element only needs to occupy a small part of it. Draw everything relative to `self.width()` and `self.height()` so it adapts to any screen resolution:
+// Show the overlay window and set always-on-top
+await invoke('show_overlay');
 
-```python
-cx = self.width() // 2           # horizontal centre
-cy = self.height() - 80          # near the bottom
+// Hide the overlay window
+await invoke('hide_overlay');
 ```
 
-**Smooth animations**
-
-Start a `QTimer` in `__init__` that calls `self.update()` at your desired frame rate. 30 ms (≈ 33 fps) is a good default that stays light on CPU:
-
-```python
-self._timer = QTimer(self)
-self._timer.timeout.connect(self.update)
-self._timer.start(30)
-```
-
-**Exponential smoothing**
-
-Raw RMS values jump around. A simple one-liner gives smooth motion:
-
-```python
-self._smooth = self._smooth * 0.75 + new_value * 0.25
-```
-
-**Scrolling history**
-
-Use `collections.deque` with a `maxlen` to keep a fixed-length rolling buffer of amplitude values. Appending to the right automatically evicts the oldest entry from the left — no manual shifting required:
-
-```python
-from collections import deque
-self._history = deque([0.0] * 80, maxlen=80)
-
-# In update_audio:
-self._history.append(new_amp)
-```
-
-**Importing app modules**
-
-The app's `src/` directory is temporarily added to `sys.path` when your overlay is loaded, so you can import from the app if needed:
-
-```python
-from gui.overlays.base import OverlayUIBase   # optional base class
-```
-
-Inheriting from `OverlayUIBase` is optional — plain `QWidget` works just as well. The base class is there for editors that want autocomplete on the interface methods.
-
----
-
-## How the Loader Works
-
-At startup (and again after each Settings save), `OverlayManager` scans:
-
-1. `src/gui/overlays/` — built-in overlays, always available
-2. `~/.config/voxctl/overlays/` — your custom overlays
-
-For each `.py` file (excluding `_`-prefixed files), it imports the module and looks for:
-- `DISPLAY_NAME` string
-- `OverlayUI` class
-
-If both are present the overlay is registered and appears in the Settings dropdown. Load errors are printed to the terminal but do not crash the app — the previously-active overlay continues running.
-
-The active overlay is wrapped in an `OverlayProxy`. All wiring in the main app (audio callbacks, recording signals) points at the proxy, so swapping the underlying widget at runtime requires no rewiring.
+Both commands are also called automatically by the recording pipeline when `ui.show_overlay` is `true`.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -42,15 +42,18 @@ A single hotkey binding can route to **multiple targets simultaneously**.
 
 ### Visualization & HUD
 - Transparent floating overlay window with real-time audio visualization
-- Four overlay styles: Ocean Wave, Voice Card, Waveform, Pulse
+- Four overlay styles: Blue Wave (default), Voice Card, Waveform, Pulse
 - Auto-show on recording start, auto-hide on completion
 
 ### Post-Processing Pipeline
 Applied after transcription before delivery:
-- Filler word removal (`um`, `uh`, `hmm`)
-- Spoken punctuation conversion (`"period"` → `.`)
+- Filler word removal (`um`, `uh`, `hmm`, `er`, `ah`, `ugh`, `mhm`)
+- Spoken punctuation conversion (`"period"` → `.`, `"comma"` → `,`, and 20+ more)
+- Auto-format lists (detects "first/second/third" ordinals → numbered list)
 - Snippet expansion (custom shorthand → full text)
-- Optional Ollama LLM rewrite (grammar clean, formal, casual, bullet, concise, or custom prompt)
+- Custom vocabulary fuzzy correction (Levenshtein matching for proper nouns/domain terms)
+- Code mode (camelCase conversion, spoken operators)
+- Optional Ollama LLM rewrite (clean, formal, casual, bullet, concise, or custom prompt)
 
 ### Text-to-Speech
 - Neural TTS via Piper (ONNX, ~11 English voices)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,84 @@
+# Overview
+
+## What is VoxCtr?
+
+VoxCtr ("Voice Controller") is a desktop dictation application that turns your voice into text and routes it wherever you need it — injected directly into the focused window, saved to a file, sent to an HTTP endpoint, or handed off to an LLM agent via the MCP protocol.
+
+It is designed as a **programmable voice input broker**: you define output targets (where text goes) and hotkey bindings (what keys trigger recording for which targets), and VoxCtr handles the rest.
+
+Everything runs locally. No audio ever leaves your machine.
+
+---
+
+## Key Features
+
+### Core Dictation
+- **Hold-to-record, toggle, or double-tap** gesture modes per hotkey binding
+- **Whisper speech recognition** — the same model family powering OpenAI's transcription API, running entirely on-device
+- **GPU acceleration** — automatic CUDA or Vulkan selection when available; falls back to CPU
+- **Multiple model sizes** — tiny through large-v3, trading speed for accuracy
+
+### Privacy & Offline Operation
+- Zero network requests during normal operation
+- No analytics, crash reporting, or telemetry
+- All models and voices stored locally under `~/.local/share/voxctl/`
+
+### Flexible Output Routing
+Nine output delivery types:
+
+| Type | What it does |
+|---|---|
+| `inject` | Simulates keystrokes into the focused window (wtype / xdotool / Ctrl+V) |
+| `clipboard` | Copies text to the system clipboard |
+| `exec` | Runs a shell command with the text as an argument |
+| `pipe` | Writes to a named FIFO pipe |
+| `socket` | Sends over a Unix domain socket |
+| `file` | Appends to a file with optional timestamp prefix |
+| `dbus` | Emits a DBus signal on the session bus |
+| `http` | POSTs to an HTTP endpoint |
+| `webhook` | POSTs with HMAC-SHA256 signed payload |
+
+A single hotkey binding can route to **multiple targets simultaneously**.
+
+### Visualization & HUD
+- Transparent floating overlay window with real-time audio visualization
+- Four overlay styles: Ocean Wave, Voice Card, Waveform, Pulse
+- Auto-show on recording start, auto-hide on completion
+
+### Post-Processing Pipeline
+Applied after transcription before delivery:
+- Filler word removal (`um`, `uh`, `hmm`)
+- Spoken punctuation conversion (`"period"` → `.`)
+- Snippet expansion (custom shorthand → full text)
+- Optional Ollama LLM rewrite (grammar clean, formal, casual, bullet, concise, or custom prompt)
+
+### Text-to-Speech
+- Neural TTS via Piper (ONNX, ~11 English voices)
+- Espeak-ng fallback
+- `speak_text` callable from hotkeys, MCP, or routing targets
+
+### LLM Integration (MCP Server)
+VoxCtr exposes a Model Context Protocol server so LLM agents (Claude Desktop, Cursor, etc.) can:
+- Trigger voice recording and receive the transcription
+- Queue TTS playback
+- Query live recording/speaking status
+
+### DBus Service (Linux)
+Exposes `ai.voxctl.Dictation` on the session bus for shell scripts and desktop integrations to start/stop recording and receive text output as signals.
+
+### History
+Maintains an in-memory transcript log with word count, timestamps, and source target. Viewable in a dedicated history window.
+
+---
+
+## Design Principles
+
+**Local-first.** The app functions identically offline. All models download once and run locally forever after.
+
+**Composable routing.** Targets and bindings are data files (TOML), not hardcoded behavior. You can change where your voice goes without touching the app.
+
+**Hot-reloadable config.** The app watches its config files. Edit `targets.toml` or `config.json` in your editor and VoxCtr picks up changes instantly.
+
+**Minimal footprint.** No Electron, no Node runtime. Tauri gives you a native WebView shell around a compiled Rust backend. The installed binary is ~tens of MB vs ~hundreds for Electron equivalents.
+
+**Low latency.** Audio is captured on a dedicated thread. Inference runs on a dedicated thread. UI updates and delivery happen concurrently via async channels. Hold a key and you're recording within milliseconds.

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -1,0 +1,277 @@
+# Output Routing
+
+**Crate:** `crates/voxctr-routing/`
+
+## Overview
+
+VoxCtr's routing system decouples *what you say* from *where it goes*. You define:
+
+- **Output Targets** (`targets.toml`) — named delivery destinations
+- **Hotkey Bindings** (`bindings.toml`) — which keys trigger which targets
+
+Both files are hot-reloaded when changed on disk.
+
+---
+
+## Output Targets
+
+Defined in `~/.config/voxctl/targets.toml`. Each `[[target]]` block describes one destination.
+
+### Common Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | string | Yes | Unique identifier, referenced by bindings |
+| `label` | string | Yes | Display name in the UI |
+| `delivery` | string | Yes | Delivery type (see below) |
+| `append_newline` | bool | No (false) | Append `\n` after injected text |
+| `send_on_release` | bool | No (false) | Wait for hotkey release before delivering |
+| `initial_prompt` | string | No | Whisper context prompt override for this target |
+| `processing` | object | No | Per-target post-processing overrides |
+
+### Delivery Types
+
+#### `inject` — Keystroke Injection
+Simulates typing into the currently focused window.
+
+```toml
+[[target]]
+id = "default"
+label = "Focused Window"
+delivery = "inject"
+append_newline = false
+```
+
+Linux injection priority:
+1. `wtype` (Wayland)
+2. `xdotool type --clearmodifiers` (X11)
+3. Clipboard + Ctrl+V fallback
+
+Windows: clipboard paste via PowerShell.
+
+---
+
+#### `clipboard` — System Clipboard
+Copies text to clipboard. Does not paste.
+
+```toml
+[[target]]
+id = "clipboard"
+label = "Copy to Clipboard"
+delivery = "clipboard"
+```
+
+---
+
+#### `file` — File Append
+Appends text to a file on disk.
+
+```toml
+[[target]]
+id = "notes"
+label = "Meeting Notes"
+delivery = "file"
+file_path = "~/Documents/notes.md"
+file_prefix = "- "        # Prepend to each entry
+file_timestamp = true     # Prepend ISO timestamp
+```
+
+Additional fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `file_path` | string | Path to the file (supports `~`) |
+| `file_prefix` | string | String prepended to each entry |
+| `file_timestamp` | bool | Prepend `[2024-01-15 10:23:45]` timestamp |
+
+---
+
+#### `exec` — Shell Command
+Runs a command with the transcribed text passed as an argument or via stdin.
+
+```toml
+[[target]]
+id = "cmd"
+label = "Custom Script"
+delivery = "exec"
+exec_command = "/home/user/scripts/handle-voice.sh"
+# Text is passed as $1
+```
+
+---
+
+#### `http` — HTTP POST
+POSTs the text as a JSON body to an HTTP endpoint.
+
+```toml
+[[target]]
+id = "api"
+label = "My API"
+delivery = "http"
+http_url = "http://localhost:8080/voice"
+```
+
+Request body:
+```json
+{"text": "transcribed text here"}
+```
+
+---
+
+#### `webhook` — Signed HTTP POST
+Same as `http` but adds HMAC-SHA256 signature header for verification.
+
+```toml
+[[target]]
+id = "secure_hook"
+label = "Signed Webhook"
+delivery = "webhook"
+http_url = "https://example.com/hook"
+webhook_secret = "your-shared-secret"
+```
+
+Adds header: `X-VoxCtr-Signature: sha256=<hex>`
+
+---
+
+#### `socket` — Unix Domain Socket
+Sends text (newline-terminated) to a Unix socket.
+
+```toml
+[[target]]
+id = "sock"
+label = "Socket Output"
+delivery = "socket"
+socket_path = "/tmp/myapp.sock"
+```
+
+---
+
+#### `pipe` — Named FIFO
+Writes to a named FIFO pipe.
+
+```toml
+[[target]]
+id = "fifo"
+label = "FIFO Output"
+delivery = "pipe"
+pipe_path = "/tmp/voice.fifo"
+```
+
+---
+
+#### `dbus` — DBus Signal
+Emits the text as a DBus signal on the `ai.voxctl.Dictation` interface.
+
+```toml
+[[target]]
+id = "dbus"
+label = "DBus Output"
+delivery = "dbus"
+```
+
+---
+
+#### `mcp` — MCP Response Queue
+Enqueues the text as a response to a pending MCP `transcribe_voice` tool call.
+
+This is used internally by the MCP server — you don't typically configure this in targets.toml.
+
+---
+
+### Per-Target Processing
+
+Each target can override global post-processing settings:
+
+```toml
+[[target]]
+id = "code_editor"
+label = "Code Editor"
+delivery = "inject"
+
+[target.processing]
+code_mode = true          # Preserve programming syntax
+remove_fillers = false    # Don't strip fillers
+ollama_enabled = false    # Skip LLM rewrite
+```
+
+---
+
+## Hotkey Bindings
+
+Defined in `~/.config/voxctl/bindings.toml`. Each `[[binding]]` block maps a key combo + gesture to one or more targets.
+
+### Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | string | Yes | Unique identifier |
+| `label` | string | Yes | Display name in UI |
+| `keys` | string[] | Yes | Key names (evdev format on Linux) |
+| `gesture` | string | Yes | `"hold"`, `"toggle"`, or `"double"` |
+| `target_id` | string | No | Single target (deprecated, use `target_ids`) |
+| `target_ids` | string[] | Yes | Ordered list of targets to route to |
+| `disabled` | bool | No (false) | Disable without removing |
+
+### Gesture Types
+
+| Gesture | Behavior |
+|---|---|
+| `hold` | Recording starts on press, stops on release |
+| `toggle` | First press starts, second press stops |
+| `double` | Two rapid presses start a toggle session |
+
+### Key Names
+
+Keys use evdev names (Linux) or Virtual Key codes (Windows):
+
+Common examples:
+- `KEY_LEFTMETA` — Left Super/Windows key
+- `KEY_LEFTCTRL` — Left Ctrl
+- `KEY_LEFTSHIFT` — Left Shift  
+- `KEY_SPACE` — Space bar
+- `KEY_F12` — Function key 12
+
+### Example bindings.toml
+
+```toml
+[[binding]]
+id = "dictate_hold"
+label = "Dictate to Cursor (Hold)"
+keys = ["KEY_LEFTMETA", "KEY_SPACE"]
+gesture = "hold"
+target_ids = ["default"]
+
+[[binding]]
+id = "dictate_notes"
+label = "Dictate to Notes File"
+keys = ["KEY_LEFTCTRL", "KEY_LEFTSHIFT", "KEY_N"]
+gesture = "toggle"
+target_ids = ["notes", "clipboard"]   # Routes to both sequentially
+
+[[binding]]
+id = "quick_copy"
+label = "Copy to Clipboard"
+keys = ["KEY_LEFTMETA", "KEY_V"]
+gesture = "double"
+target_ids = ["clipboard"]
+disabled = false
+```
+
+### Multi-Target Routing
+
+When `target_ids` contains multiple entries, VoxCtr delivers to each target **sequentially** in the listed order after a single recording session. This lets you, for example, inject text into a window AND log it to a file simultaneously.
+
+---
+
+## Router Logic
+
+`OutputTargetRouter::route(text, target_id, targets)`:
+
+1. Look up target by `target_id`
+2. Apply any per-target `processing` overrides
+3. Build delivery payload (append newline, prefix, timestamp)
+4. Dispatch to the appropriate delivery handler
+5. Log to history
+
+On error (e.g. socket not available, file unwritable), VoxCtr logs the error and continues — it does not interrupt the UI or crash.

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -19,15 +19,18 @@ Defined in `~/.config/voxctl/targets.toml`. Each `[[target]]` block describes on
 
 ### Common Fields
 
-| Field | Type | Required | Description |
+| Field | Type | Default | Description |
 |---|---|---|---|
-| `id` | string | Yes | Unique identifier, referenced by bindings |
-| `label` | string | Yes | Display name in the UI |
-| `delivery` | string | Yes | Delivery type (see below) |
-| `append_newline` | bool | No (false) | Append `\n` after injected text |
-| `send_on_release` | bool | No (false) | Wait for hotkey release before delivering |
-| `initial_prompt` | string | No | Whisper context prompt override for this target |
-| `processing` | object | No | Per-target post-processing overrides |
+| `id` | string | required | Unique identifier, referenced by bindings |
+| `label` | string | required | Display name in the UI |
+| `delivery` | string | required | Delivery type (see below) |
+| `append_newline` | bool | `true` | Append `\n` after injected text |
+| `send_on_release` | bool | `true` | Wait for hotkey release before delivering |
+| `initial_prompt` | string | null | Whisper context prompt override for this target |
+| `processing` | object | (inherit) | Per-target post-processing overrides |
+| `tts_engine` | string | `"piper"` | TTS engine for response loopback |
+| `tts_voice` | string | null | Voice override for TTS response |
+| `response_pipe` | string | null | FIFO path for TTS response output |
 
 ### Delivery Types
 
@@ -39,7 +42,6 @@ Simulates typing into the currently focused window.
 id = "default"
 label = "Focused Window"
 delivery = "inject"
-append_newline = false
 ```
 
 Linux injection priority:
@@ -52,7 +54,7 @@ Windows: clipboard paste via PowerShell.
 ---
 
 #### `clipboard` — System Clipboard
-Copies text to clipboard. Does not paste.
+Copies text to the system clipboard. Does not paste.
 
 ```toml
 [[target]]
@@ -63,8 +65,8 @@ delivery = "clipboard"
 
 ---
 
-#### `file` — File Append
-Appends text to a file on disk.
+#### `file` — File Append/Write
+Writes text to a file on disk.
 
 ```toml
 [[target]]
@@ -73,29 +75,21 @@ label = "Meeting Notes"
 delivery = "file"
 file_path = "~/Documents/notes.md"
 file_prefix = "- "        # Prepend to each entry
-file_timestamp = true     # Prepend ISO timestamp
+file_timestamp = true     # Prepend ISO timestamp (default: true)
+file_mode = "append"      # "append" or "write" (default: "append")
 ```
-
-Additional fields:
-
-| Field | Type | Description |
-|---|---|---|
-| `file_path` | string | Path to the file (supports `~`) |
-| `file_prefix` | string | String prepended to each entry |
-| `file_timestamp` | bool | Prepend `[2024-01-15 10:23:45]` timestamp |
 
 ---
 
 #### `exec` — Shell Command
-Runs a command with the transcribed text passed as an argument or via stdin.
+Runs a shell command. The transcribed text is passed as an argument.
 
 ```toml
 [[target]]
 id = "cmd"
 label = "Custom Script"
 delivery = "exec"
-exec_command = "/home/user/scripts/handle-voice.sh"
-# Text is passed as $1
+command = "/home/user/scripts/handle-voice.sh"
 ```
 
 ---
@@ -109,6 +103,7 @@ id = "api"
 label = "My API"
 delivery = "http"
 http_url = "http://localhost:8080/voice"
+http_method = "POST"      # Default: "POST"
 ```
 
 Request body:
@@ -116,33 +111,52 @@ Request body:
 {"text": "transcribed text here"}
 ```
 
+Optional: `http_headers` (table) and `http_json_template` (JSON value).
+
 ---
 
 #### `webhook` — Signed HTTP POST
-Same as `http` but adds HMAC-SHA256 signature header for verification.
+Like `http` but uses `webhook_url` and adds an HMAC-SHA256 signature header.
 
 ```toml
 [[target]]
 id = "secure_hook"
 label = "Signed Webhook"
 delivery = "webhook"
-http_url = "https://example.com/hook"
+webhook_url = "https://example.com/hook"
 webhook_secret = "your-shared-secret"
 ```
 
 Adds header: `X-VoxCtr-Signature: sha256=<hex>`
 
+Optional: `webhook_json_template` (JSON value) to customize the payload shape.
+
+Verify on your server:
+```python
+import hmac, hashlib
+
+def verify(payload: bytes, secret: str, signature: str) -> bool:
+    expected = 'sha256=' + hmac.new(
+        secret.encode(), payload, hashlib.sha256
+    ).hexdigest()
+    return hmac.compare_digest(expected, signature)
+```
+
 ---
 
-#### `socket` — Unix Domain Socket
-Sends text (newline-terminated) to a Unix socket.
+#### `socket` — Unix Domain Socket or TCP
+Sends text (newline-terminated) to a socket.
 
 ```toml
 [[target]]
 id = "sock"
-label = "Socket Output"
+label = "Unix Socket"
 delivery = "socket"
-socket_path = "/tmp/myapp.sock"
+socket_unix = "/tmp/myapp.sock"   # Unix domain socket path
+
+# OR for TCP:
+socket_host = "127.0.0.1"
+socket_port = 9000
 ```
 
 ---
@@ -161,27 +175,34 @@ pipe_path = "/tmp/voice.fifo"
 ---
 
 #### `dbus` — DBus Signal
-Emits the text as a DBus signal on the `ai.voxctl.Dictation` interface.
+Emits the text as a `text_injected` signal on the `ai.voxctl.Dictation` interface.
 
 ```toml
 [[target]]
 id = "dbus"
 label = "DBus Output"
 delivery = "dbus"
+dbus_signal = "text_injected"   # Optional: override signal name
 ```
 
 ---
 
 #### `mcp` — MCP Response Queue
-Enqueues the text as a response to a pending MCP `transcribe_voice` tool call.
+Enqueues the text as a response to a pending `transcribe_voice` tool call from an MCP client.
 
-This is used internally by the MCP server — you don't typically configure this in targets.toml.
+```toml
+[[target]]
+id = "mcp_out"
+delivery = "mcp"
+mcp_path = "/tmp/voxctl-mcp.sock"   # Optional socket path override
+mcp_tool = "transcribe_voice"        # Optional tool name hint
+```
 
 ---
 
 ### Per-Target Processing
 
-Each target can override global post-processing settings:
+Each target can override global post-processing settings. All fields are optional (`null` = inherit global config):
 
 ```toml
 [[target]]
@@ -189,10 +210,19 @@ id = "code_editor"
 label = "Code Editor"
 delivery = "inject"
 
-[target.processing]
-code_mode = true          # Preserve programming syntax
-remove_fillers = false    # Don't strip fillers
-ollama_enabled = false    # Skip LLM rewrite
+[code_editor.processing]
+code_mode = true
+remove_fillers = false
+spoken_punctuation = true
+auto_format_lists = false
+apply_snippets = true
+ollama_enabled = false
+ollama_model = ""
+ollama_mode = ""
+ollama_prompt = ""
+atspi_context = true
+noise_suppression = false
+quiet_mode = false
 ```
 
 ---
@@ -203,15 +233,17 @@ Defined in `~/.config/voxctl/bindings.toml`. Each `[[binding]]` block maps a key
 
 ### Fields
 
-| Field | Type | Required | Description |
+| Field | Type | Default | Description |
 |---|---|---|---|
-| `id` | string | Yes | Unique identifier |
-| `label` | string | Yes | Display name in UI |
-| `keys` | string[] | Yes | Key names (evdev format on Linux) |
-| `gesture` | string | Yes | `"hold"`, `"toggle"`, or `"double"` |
-| `target_id` | string | No | Single target (deprecated, use `target_ids`) |
-| `target_ids` | string[] | Yes | Ordered list of targets to route to |
-| `disabled` | bool | No (false) | Disable without removing |
+| `id` | string | required | Unique identifier |
+| `label` | string | `""` | Display name in UI |
+| `keys` | string[] | required | Key names (evdev format on Linux) |
+| `gesture` | string | required | `"hold"`, `"toggle"`, `"double_tap"`, or `"chord"` |
+| `target_ids` | string[] | required | Ordered list of targets to route to |
+| `target_id` | string | | Single target (legacy; resolved if `target_ids` is empty) |
+| `hold_threshold_ms` | integer | `200` | Minimum hold duration in ms |
+| `tap_ms` | integer | `250` | Double-tap inter-press window in ms |
+| `disabled` | bool | `false` | Disable without removing |
 
 ### Gesture Types
 
@@ -219,18 +251,20 @@ Defined in `~/.config/voxctl/bindings.toml`. Each `[[binding]]` block maps a key
 |---|---|
 | `hold` | Recording starts on press, stops on release |
 | `toggle` | First press starts, second press stops |
-| `double` | Two rapid presses start a toggle session |
+| `double_tap` | Two rapid presses within `tap_ms` trigger a toggle session |
+| `chord` | All keys must be pressed simultaneously (superset-shadowing applies) |
 
-### Key Names
+### Key Names (evdev format)
 
-Keys use evdev names (Linux) or Virtual Key codes (Windows):
-
-Common examples:
+Common keys:
 - `KEY_LEFTMETA` — Left Super/Windows key
 - `KEY_LEFTCTRL` — Left Ctrl
-- `KEY_LEFTSHIFT` — Left Shift  
+- `KEY_LEFTSHIFT` — Left Shift
+- `KEY_LEFTALT` — Left Alt
 - `KEY_SPACE` — Space bar
-- `KEY_F12` — Function key 12
+- `KEY_F1`–`KEY_F12` — Function keys
+- `KEY_A`–`KEY_Z` — Letter keys
+- `KEY_ESCAPE` — Escape key
 
 ### Example bindings.toml
 
@@ -253,14 +287,18 @@ target_ids = ["notes", "clipboard"]   # Routes to both sequentially
 id = "quick_copy"
 label = "Copy to Clipboard"
 keys = ["KEY_LEFTMETA", "KEY_V"]
-gesture = "double"
+gesture = "double_tap"
 target_ids = ["clipboard"]
-disabled = false
+tap_ms = 300
 ```
 
 ### Multi-Target Routing
 
 When `target_ids` contains multiple entries, VoxCtr delivers to each target **sequentially** in the listed order after a single recording session. This lets you, for example, inject text into a window AND log it to a file simultaneously.
+
+### Superset Shadowing
+
+If binding A's keys are a proper subset of binding B's keys (e.g. `META+SPACE` vs `CTRL+META+SPACE`), and both are pressed, only binding B fires. This prevents shorter combos from accidentally triggering when a longer combo is intended.
 
 ---
 
@@ -268,10 +306,10 @@ When `target_ids` contains multiple entries, VoxCtr delivers to each target **se
 
 `OutputTargetRouter::route(text, target_id, targets)`:
 
-1. Look up target by `target_id`
-2. Apply any per-target `processing` overrides
+1. Look up target by `target_id` from the in-memory cache
+2. Apply per-target `processing` overrides (inheriting globals for null fields)
 3. Build delivery payload (append newline, prefix, timestamp)
 4. Dispatch to the appropriate delivery handler
-5. Log to history
+5. On error (socket unavailable, file unwritable, etc.), log the failure and continue — never crashes or drops the UI
 
-On error (e.g. socket not available, file unwritable), VoxCtr logs the error and continues — it does not interrupt the UI or crash.
+The router is hot-reloadable: `save_targets()` via IPC updates both the TOML file and the in-memory cache, and spawns any new FIFO response pipe listeners.

--- a/docs/speech-recognition.md
+++ b/docs/speech-recognition.md
@@ -10,71 +10,88 @@ VoxCtr uses **Whisper** (via `whisper-rs`, native bindings to whisper.cpp) for s
 
 ## Model Sizes
 
-| Size | VRAM / RAM | Speed | Accuracy |
+| Size | Approx RAM | Speed | Accuracy |
 |---|---|---|---|
-| `tiny` | ~75 MB | Fastest | Lowest |
-| `base` | ~142 MB | Fast | Low |
-| `small` | ~466 MB | Medium | Medium |
-| `medium` | ~1.5 GB | Slow | High |
+| `tiny` / `tiny.en` | ~75 MB | Fastest | Lowest |
+| `base` / `base.en` | ~142 MB | Fast | Low |
+| `small` / `small.en` | ~466 MB | Medium | Medium |
+| `medium` / `medium.en` | ~1.5 GB | Slow | High |
+| `large-v2` | ~3.1 GB | Slowest | High |
 | `large-v3` | ~3.1 GB | Slowest | Highest |
+| `large-v3-turbo` | ~1.6 GB | Medium | Near large-v3 |
 
-Models are downloaded from Hugging Face as GGUF files on first use and cached at `~/.local/share/voxctl/models/`.
+The `.en` variants are English-only but slightly faster. `large-v3-turbo` is a distilled model offering near large-v3 quality at medium speed.
 
-The active model is set via `engine.model_size` in config. Changing it triggers a model reload on next recording.
+The default model is **`large-v3`**. Models are downloaded from Hugging Face as GGUF files on first use, cached at `~/.local/share/voxctl/models/`.
+
+Change the active model via `engine.whisper_cpp.model_size` in config. Changing it takes effect on next recording.
 
 ---
 
 ## Hardware Backends
 
-`engine.device` selects the compute backend:
+`engine.whisper_cpp.device` selects the compute backend:
 
 | Value | Description |
 |---|---|
-| `auto` | Auto-detect: CUDA → Vulkan → CPU |
+| `auto` | Auto-detect: tries CUDA (nvidia-smi / /dev/nvidia0), then Vulkan (vulkaninfo / ICD dirs), then CPU |
 | `cuda` | NVIDIA GPU via CUDA |
 | `vulkan` | Any GPU via Vulkan (AMD/Intel/NVIDIA) |
 | `cpu` | Force CPU |
 
-On startup, VoxCtr probes for CUDA/Vulkan availability and logs the selected backend. CPU fallback is always available.
+On startup, VoxCtr probes for CUDA (via `nvidia-smi`, `/proc/driver/nvidia/version`, `/dev/nvidia0`) and Vulkan (via `vulkaninfo`, `/usr/share/vulkan/icd.d`) to select the best backend.
 
 ---
 
 ## Inference Pipeline
 
-When a recording session ends (hotkey released or VAD timeout), the accumulated audio buffer is sent to the inference worker:
+When a recording session ends, the accumulated audio buffer is sent to the inference worker thread:
 
 ```
 InferenceRequest {
-    audio: Vec<f32>,     // 16 kHz mono PCM
-    target_id: String,   // Which output target to use
-    context_text: Option<String>, // AT-SPI context for better transcription
+    audio: Vec<f32>,           // 16 kHz mono PCM
+    target_id: String,         // Which output target (comma-separated for multi-target)
+    context_text: Option<String>, // AT-SPI context text, if enabled
 }
 ```
 
-The worker thread runs:
+The worker runs:
 
 ```
-1. Noise gate check
-   └─ rms(audio) < vad_threshold → return ""
+1. Empty audio check
+   └─ audio.is_empty() → return ""
 
-2. Silence hallucination filter
-   └─ rms < 0.003 AND text contains "Thank you" → return ""
+2. Noise gate (VAD)
+   └─ rms_threshold = (1.0 - vad_threshold) * 0.006
+   └─ rms(audio) < rms_threshold → return ""
 
-3. whisper-rs transcription
-   └─ Returns raw text with timestamps
+3. Build Whisper initial prompt
+   a. Target's initial_prompt (if set)
+   b. Custom vocabulary words from features.custom_vocabulary
+   c. AT-SPI context text (if context_prompt enabled)
+   → Merged into a single prompt string for Whisper
 
-4. Post-processing pipeline (in order):
-   a. Filler word removal
-   b. Spoken punctuation conversion
-   c. Auto-format (list detection)
-   d. Snippet expansion
-   e. Ollama LLM rewrite (optional)
+4. whisper-rs transcription
+   └─ Returns raw_text with inference_ms and language
 
-5. Return InferenceOutput {
-       text: String,          // Final processed text
-       raw_text: String,      // Pre-processing text
-       inference_ms: u32,     // Whisper wall time in ms
-       language: String,      // Detected language
+5. Post-processing pipeline (in order):
+   a. Filler word removal (if enabled)
+   b. Spoken punctuation conversion (if enabled)
+   c. Auto-format list detection (if enabled)
+   d. Snippet expansion (if snippets configured)
+   e. Custom vocabulary fuzzy correction
+   f. Code mode conversion (if enabled)
+
+6. Silence hallucination filter
+   └─ rms < 0.003 AND text is a known Whisper hallucination → return ""
+
+7. Optional Ollama post-processing (if target.processing.ollama_enabled)
+
+8. Return InferenceOutput {
+       text: String,            // Final processed text
+       raw_text: String,        // Pre-processing Whisper output
+       inference_ms: u32,       // Whisper wall time
+       language: String,        // Detected language code
        target_id: String,
    }
 ```
@@ -86,31 +103,48 @@ The worker thread runs:
 ### Filler Word Removal
 Enabled via `features.remove_fillers`.
 
-Strips common verbal fillers using regex:
-- `um`, `uh`, `hmm` (case-insensitive, at word boundaries)
+Strips common verbal fillers using a regex with repetition variants:
+- `uh`, `um`, `hmm`, `er`, `ah`, `ugh`, `mhm` (e.g. `"uhhh"`, `"umm"` also matched)
 - Cleans up resulting double spaces
 
 ### Spoken Punctuation Conversion
-Always applied. Converts spoken words to punctuation marks:
+Enabled via `features.spoken_punctuation`.
 
-| Spoken | Output |
-|---|---|
-| "period" / "full stop" | `.` |
-| "comma" | `,` |
-| "question mark" | `?` |
-| "exclamation mark" | `!` |
-| "colon" | `:` |
-| "semicolon" | `;` |
-| "new line" / "newline" | `\n` |
-| "new paragraph" | `\n\n` |
-| "open paren" | `(` |
-| "close paren" | `)` |
-| "dash" | `-` |
+Converts spoken words to their symbol equivalents (case-insensitive, word boundaries):
+
+| Spoken | Output | | Spoken | Output |
+|---|---|---|---|---|
+| "period" / "full stop" | `. ` | | "open bracket" / "open paren" | `(` |
+| "comma" | `, ` | | "close bracket" / "close paren" | `)` |
+| "question mark" | `? ` | | "new line" | `\n` |
+| "exclamation mark" / "exclamation point" | `! ` | | "new paragraph" | `\n\n` |
+| "colon" | `: ` | | "tab" | `\t` |
+| "semicolon" | `; ` | | "dash" | ` — ` |
+| "hyphen" | `-` | | "ellipsis" | `...` |
+| "slash" | `/` | | "backslash" | `\` |
+| "at sign" | `@` | | "hash" | `#` |
+| "percent" | `%` | | "ampersand" | `&` |
+| "asterisk" | `*` | | "plus sign" | `+` |
+| "equals sign" | `=` | | "less than" | `<` |
+| "greater than" | `>` | | | |
+
+### Auto-Format Lists
+Enabled via `features.auto_format_lists`.
+
+Detects ordinal pattern words (`first`, `second`, `third`, `fourth`, `fifth`, `finally`, including `firstly`, `secondly`, etc.) and reformats the text as a **numbered list**:
+
+Input: `"First do this then second check that and finally submit"`
+Output:
+```
+1. do this then
+2. check that and
+3. submit
+```
 
 ### Snippet Expansion
-Enabled via `features.snippets` (a key-value map in config).
+Enabled whenever `features.snippets` is non-empty.
 
-Short codes in transcribed text are replaced with their expansions before delivery:
+Short codes in transcribed text are replaced with their expansions (case-insensitive, word boundaries):
 
 ```json
 "snippets": {
@@ -119,44 +153,62 @@ Short codes in transcribed text are replaced with their expansions before delive
 }
 ```
 
-### Auto-Format (List Mode)
-When transcription contains list-like patterns (lines starting with numbers or dashes), VoxCtr can reformat them as a clean bullet list.
+### Custom Vocabulary Correction
+Enabled whenever `features.custom_vocabulary` is non-empty.
+
+After transcription, each word is compared against the vocabulary list using **Levenshtein distance fuzzy matching**:
+
+| Word length | Max edit distance allowed |
+|---|---|
+| 1–3 chars | 0 (exact match only) |
+| 4 chars | 1 |
+| 5+ chars | 2 |
+
+This corrects Whisper's phonetic approximations of proper nouns, names, and domain-specific terms. Example: vocabulary `["Rufer"]` would correct `"Rufur"` or `"Rupher"` to `"Rufer"`.
 
 ### Code Mode
-When an output target has `processing.code_mode = true`, the post-processor preserves camelCase, underscores, brackets, and other programming tokens that Whisper might otherwise alter.
+Enabled via target `processing.code_mode = true`.
 
-### Ollama Integration
-When `ollama.enabled = true`, the transcribed text is sent to a local Ollama endpoint for rewriting. See [Integrations → Ollama](./integrations.md#ollama) for details.
+Converts spoken phrases to code-style syntax:
+- Maps spoken operators: `"equals"` → `=`, `"plus"` → `+`, `"minus"` → `-`, `"times"` → `*`, `"divided by"` → `/`, `"modulo"` → `%`
+- Converts multi-word lowercase phrases to camelCase: `"my function name"` → `"myFunctionName"`
 
 ---
 
 ## Silence Hallucination Filter
 
-Whisper has a known behavior where it generates text like "Thank you." or "Thank you for watching." when given near-silent input. VoxCtr applies a heuristic filter:
+Whisper generates text like "Thank you." or "Thanks for watching." when given near-silent input. VoxCtr applies a filter after post-processing:
 
 ```
-IF rms_energy < 0.003
-AND result_text ∈ ["Thank you.", "Thank you for watching.", ...]
-THEN discard result
+IF rms_energy < 0.003 (absolute room silence)
+AND processed_text ∈ ["thank you", "thanks for watching", "thank you for watching"]
+THEN discard result → return ""
 ```
 
-This prevents phantom text injection when accidentally holding the hotkey in silence.
+This threshold (0.003 RMS) is intentionally below any genuine speech energy, so saying "thank you" aloud will still be transcribed correctly.
 
 ---
 
-## Context Prompting (AT-SPI)
+## Context Prompting
 
-When `atspi.context_prompt = true`, VoxCtr reads the currently focused text field using AT-SPI2 (Linux accessibility API) and includes the last ~200 characters as a Whisper context prompt. This improves transcription continuity and helps Whisper maintain consistent formatting and vocabulary with the surrounding text.
+When `atspi.context_prompt = true`, the surrounding text from the focused widget (read via AT-SPI2) is included in the Whisper initial prompt. This improves continuity with existing text in the field.
+
+The Whisper initial prompt also incorporates:
+1. The target's `initial_prompt` field (if set)
+2. The `features.custom_vocabulary` list, formatted as: `"Vocabulary: word1, word2, ..."`
+3. The AT-SPI2 surrounding text
 
 ---
 
 ## Configuration Options
 
-Under `engine` in `config.json`:
+Under `engine.whisper_cpp` in `config.json`:
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `backend` | `string` | `"whisper"` | Recognition backend (`"whisper"` or `"moonshine"`) |
-| `model_size` | `string` | `"base"` | Whisper model: tiny/base/small/medium/large-v3 |
-| `device` | `string` | `"auto"` | Compute device: auto/cpu/cuda/vulkan |
-| `language` | `string` | `"en"` | Language code or `"auto"` for detection |
+| `model_size` | string | `"large-v3"` | Whisper model |
+| `device` | string | `"auto"` | Compute device |
+| `threads` | integer | `0` | CPU threads (0 = auto) |
+| `model_dir` | string | `""` | Custom model storage path |
+
+Language detection is automatic when using whisper-cpp; use the `engine.moonshine.language` field for the Moonshine backend.

--- a/docs/speech-recognition.md
+++ b/docs/speech-recognition.md
@@ -1,0 +1,162 @@
+# Speech Recognition
+
+**Crate:** `crates/voxctr-inference/`
+
+## Overview
+
+VoxCtr uses **Whisper** (via `whisper-rs`, native bindings to whisper.cpp) for speech-to-text. Whisper runs entirely on-device using downloaded GGUF model files. No audio is ever sent to a remote server.
+
+---
+
+## Model Sizes
+
+| Size | VRAM / RAM | Speed | Accuracy |
+|---|---|---|---|
+| `tiny` | ~75 MB | Fastest | Lowest |
+| `base` | ~142 MB | Fast | Low |
+| `small` | ~466 MB | Medium | Medium |
+| `medium` | ~1.5 GB | Slow | High |
+| `large-v3` | ~3.1 GB | Slowest | Highest |
+
+Models are downloaded from Hugging Face as GGUF files on first use and cached at `~/.local/share/voxctl/models/`.
+
+The active model is set via `engine.model_size` in config. Changing it triggers a model reload on next recording.
+
+---
+
+## Hardware Backends
+
+`engine.device` selects the compute backend:
+
+| Value | Description |
+|---|---|
+| `auto` | Auto-detect: CUDA → Vulkan → CPU |
+| `cuda` | NVIDIA GPU via CUDA |
+| `vulkan` | Any GPU via Vulkan (AMD/Intel/NVIDIA) |
+| `cpu` | Force CPU |
+
+On startup, VoxCtr probes for CUDA/Vulkan availability and logs the selected backend. CPU fallback is always available.
+
+---
+
+## Inference Pipeline
+
+When a recording session ends (hotkey released or VAD timeout), the accumulated audio buffer is sent to the inference worker:
+
+```
+InferenceRequest {
+    audio: Vec<f32>,     // 16 kHz mono PCM
+    target_id: String,   // Which output target to use
+    context_text: Option<String>, // AT-SPI context for better transcription
+}
+```
+
+The worker thread runs:
+
+```
+1. Noise gate check
+   └─ rms(audio) < vad_threshold → return ""
+
+2. Silence hallucination filter
+   └─ rms < 0.003 AND text contains "Thank you" → return ""
+
+3. whisper-rs transcription
+   └─ Returns raw text with timestamps
+
+4. Post-processing pipeline (in order):
+   a. Filler word removal
+   b. Spoken punctuation conversion
+   c. Auto-format (list detection)
+   d. Snippet expansion
+   e. Ollama LLM rewrite (optional)
+
+5. Return InferenceOutput {
+       text: String,          // Final processed text
+       raw_text: String,      // Pre-processing text
+       inference_ms: u32,     // Whisper wall time in ms
+       language: String,      // Detected language
+       target_id: String,
+   }
+```
+
+---
+
+## Post-Processing Details
+
+### Filler Word Removal
+Enabled via `features.remove_fillers`.
+
+Strips common verbal fillers using regex:
+- `um`, `uh`, `hmm` (case-insensitive, at word boundaries)
+- Cleans up resulting double spaces
+
+### Spoken Punctuation Conversion
+Always applied. Converts spoken words to punctuation marks:
+
+| Spoken | Output |
+|---|---|
+| "period" / "full stop" | `.` |
+| "comma" | `,` |
+| "question mark" | `?` |
+| "exclamation mark" | `!` |
+| "colon" | `:` |
+| "semicolon" | `;` |
+| "new line" / "newline" | `\n` |
+| "new paragraph" | `\n\n` |
+| "open paren" | `(` |
+| "close paren" | `)` |
+| "dash" | `-` |
+
+### Snippet Expansion
+Enabled via `features.snippets` (a key-value map in config).
+
+Short codes in transcribed text are replaced with their expansions before delivery:
+
+```json
+"snippets": {
+  "addr": "123 Main St, Springfield",
+  "sig": "Best regards,\nJane"
+}
+```
+
+### Auto-Format (List Mode)
+When transcription contains list-like patterns (lines starting with numbers or dashes), VoxCtr can reformat them as a clean bullet list.
+
+### Code Mode
+When an output target has `processing.code_mode = true`, the post-processor preserves camelCase, underscores, brackets, and other programming tokens that Whisper might otherwise alter.
+
+### Ollama Integration
+When `ollama.enabled = true`, the transcribed text is sent to a local Ollama endpoint for rewriting. See [Integrations → Ollama](./integrations.md#ollama) for details.
+
+---
+
+## Silence Hallucination Filter
+
+Whisper has a known behavior where it generates text like "Thank you." or "Thank you for watching." when given near-silent input. VoxCtr applies a heuristic filter:
+
+```
+IF rms_energy < 0.003
+AND result_text ∈ ["Thank you.", "Thank you for watching.", ...]
+THEN discard result
+```
+
+This prevents phantom text injection when accidentally holding the hotkey in silence.
+
+---
+
+## Context Prompting (AT-SPI)
+
+When `atspi.context_prompt = true`, VoxCtr reads the currently focused text field using AT-SPI2 (Linux accessibility API) and includes the last ~200 characters as a Whisper context prompt. This improves transcription continuity and helps Whisper maintain consistent formatting and vocabulary with the surrounding text.
+
+---
+
+## Configuration Options
+
+Under `engine` in `config.json`:
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `backend` | `string` | `"whisper"` | Recognition backend (`"whisper"` or `"moonshine"`) |
+| `model_size` | `string` | `"base"` | Whisper model: tiny/base/small/medium/large-v3 |
+| `device` | `string` | `"auto"` | Compute device: auto/cpu/cuda/vulkan |
+| `language` | `string` | `"en"` | Language code or `"auto"` for detection |

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -1,0 +1,138 @@
+# Text-to-Speech
+
+**Crate:** `crates/voxctr-tts/`
+
+## Overview
+
+VoxCtr includes a neural TTS engine for voice output. This is useful for reading back transcriptions, confirming commands, or building conversational voice interactions via the MCP server.
+
+---
+
+## Engines
+
+### Piper (Primary)
+[Piper](https://github.com/rhasspy/piper) is a fast, local neural TTS system using ONNX models. It produces high-quality natural-sounding speech entirely offline.
+
+VoxCtr ships with support for approximately 11 English voices from the Piper v0.0.2 release.
+
+Voice files are stored at `~/.local/share/voxctl/piper-voices/`. Each voice requires:
+- `voice-name.onnx` — the neural network model
+- `voice-name.onnx.json` — model configuration
+
+### Espeak-ng (Fallback)
+If Piper is unavailable or no voice is downloaded, VoxCtr falls back to [espeak-ng](https://github.com/espeak-ng/espeak-ng), a formant-synthesis engine that requires no downloads. Quality is lower but it is always available.
+
+---
+
+## Voice Packs
+
+### Available Voices
+
+Voices are downloaded from the Piper GitHub release. Available English voices include (names are illustrative):
+
+- `en_US-lessac-medium`
+- `en_US-libritts-high`
+- `en_US-ryan-high`
+- `en_US-kusal-medium`
+- `en_US-joe-medium`
+- `en_GB-alan-medium`
+- `en_GB-jenny_dioco-medium`
+
+Check the Settings → TTS tab for the full current list and download status.
+
+### Downloading Voices
+
+Via the UI: Settings → TTS → select a voice → click Download.
+
+Via IPC:
+```typescript
+await invoke('download_voice', { name: 'en_US-lessac-medium' });
+```
+
+Via the Tauri command from Rust:
+```rust
+download_voice("en_US-lessac-medium").await?;
+```
+
+---
+
+## Audio Playback
+
+After synthesis, VoxCtr plays audio using the system audio stack:
+
+- **Linux:** `aplay` (ALSA)
+- **Windows:** PowerShell `[System.Media.SoundPlayer]`
+
+The audio plays asynchronously — the TTS engine queues requests and a dedicated task drains the queue sequentially so speech doesn't overlap.
+
+---
+
+## Triggering TTS
+
+### From the MCP Server
+LLM agents can queue speech via the `speak_text` MCP tool:
+```json
+{"method": "tools/call", "params": {"name": "speak_text", "arguments": {"text": "Recording complete."}}}
+```
+
+### From a Hotkey Binding Target
+Route to a TTS target — the `tts_engine` field on a target specifies which voice to use.
+
+### From the IPC Command
+```typescript
+await invoke('speak_text', { text: 'Hello world', voice: 'en_US-lessac-medium' });
+```
+
+### From the FIFO Pipe
+VoxCtr watches a named FIFO for newline-terminated text to speak. Write to it from any script:
+```bash
+echo "Recording started" > /tmp/voxctl-tts.fifo
+```
+
+---
+
+## Stop Keys
+
+TTS playback can be interrupted with a configurable key combination. Set `tts.stop_keys` in config:
+
+```json
+"tts": {
+  "stop_keys": ["KEY_ESC"]
+}
+```
+
+When the stop key is pressed during playback, the current utterance is cancelled and the queue is cleared.
+
+---
+
+## Configuration Options
+
+Under `tts` in `config.json`:
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | bool | `false` | Enable TTS functionality |
+| `engine` | string | `"piper"` | `"piper"` or `"espeak"` |
+| `voice` | string | `"en_US-lessac-medium"` | Voice name for Piper |
+| `stop_keys` | string[] | `["KEY_ESC"]` | Keys that interrupt playback |
+| `rate` | int | `175` | Speech rate in words-per-minute (espeak only) |
+| `pitch` | int | `50` | Pitch level 0-99 (espeak only) |
+
+---
+
+## TtsEngineHandle
+
+The TTS handle is stored in `AppState` and shared with the MCP server and routing system:
+
+```rust
+pub struct TtsEngineHandle {
+    tx: mpsc::Sender<TtsRequest>,
+}
+
+pub struct TtsRequest {
+    pub text: String,
+    pub voice: Option<String>,
+}
+```
+
+Send a request by cloning the handle and sending on the channel. The worker task picks it up and synthesizes/plays sequentially.

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -13,95 +13,103 @@ VoxCtr includes a neural TTS engine for voice output. This is useful for reading
 ### Piper (Primary)
 [Piper](https://github.com/rhasspy/piper) is a fast, local neural TTS system using ONNX models. It produces high-quality natural-sounding speech entirely offline.
 
-VoxCtr ships with support for approximately 11 English voices from the Piper v0.0.2 release.
-
-Voice files are stored at `~/.local/share/voxctl/piper-voices/`. Each voice requires:
-- `voice-name.onnx` — the neural network model
-- `voice-name.onnx.json` — model configuration
+VoxCtr invokes the `piper` binary directly (looks first in `~/.local/share/voxctl/piper/piper`, then on PATH). It pipes text to Piper's stdin, receives raw 16-bit PCM on stdout, and plays via `aplay` (Linux) or a temp WAV file + PowerShell `SoundPlayer` (Windows).
 
 ### Espeak-ng (Fallback)
-If Piper is unavailable or no voice is downloaded, VoxCtr falls back to [espeak-ng](https://github.com/espeak-ng/espeak-ng), a formant-synthesis engine that requires no downloads. Quality is lower but it is always available.
+If Piper is unavailable or no voice is downloaded, VoxCtr falls back to `espeak-ng`. It is invoked as a subprocess with the text as an argument. Quality is lower but espeak-ng is always available as a system package.
+
+---
+
+## Voice Catalogue
+
+Voices are downloaded as `.tar.gz` archives from the Piper GitHub release (`v0.0.2`). Extracted `.onnx` and `.onnx.json` files are stored at `~/.local/share/voxctl/piper-voices/`.
+
+| Voice name | Quality | Sample rate |
+|---|---|---|
+| `en-us-libritts-high` | high | 22050 Hz |
+| `en-us-ryan-high` | high | 22050 Hz |
+| `en-us-ryan-medium` | medium | 22050 Hz |
+| `en-us-ryan-low` | low | 16000 Hz |
+| `en-us-lessac-medium` | medium | 16000 Hz |
+| `en-us-lessac-low` | low | 16000 Hz |
+| `en-us-amy-low` | low | 16000 Hz |
+| `en-us-kathleen-low` | low | 16000 Hz |
+| `en-us-danny-low` | low | 16000 Hz |
+| `en-gb-southern_english_female-low` | low | 16000 Hz |
+| `en-gb-alan-low` | low | 16000 Hz |
+
+The default voice is **`en-us-lessac-medium`**.
 
 ---
 
 ## Voice Packs
 
-### Available Voices
+### Checking if a voice is downloaded
+```typescript
+const downloaded = await invoke<boolean>('check_voice_downloaded', {
+  voiceName: 'en-us-lessac-medium'
+});
+```
 
-Voices are downloaded from the Piper GitHub release. Available English voices include (names are illustrative):
-
-- `en_US-lessac-medium`
-- `en_US-libritts-high`
-- `en_US-ryan-high`
-- `en_US-kusal-medium`
-- `en_US-joe-medium`
-- `en_GB-alan-medium`
-- `en_GB-jenny_dioco-medium`
-
-Check the Settings → TTS tab for the full current list and download status.
-
-### Downloading Voices
-
+### Downloading a voice
 Via the UI: Settings → TTS → select a voice → click Download.
 
 Via IPC:
 ```typescript
-await invoke('download_voice', { name: 'en_US-lessac-medium' });
+await invoke('download_voice', { voiceName: 'en-us-ryan-high' });
 ```
 
-Via the Tauri command from Rust:
-```rust
-download_voice("en_US-lessac-medium").await?;
-```
+The download fetches `voice-<name>.tar.gz` from the Piper GitHub release, extracts the `.onnx` and `.onnx.json` files into the voices directory, and uses atomic temp-file writes to avoid partial downloads.
 
 ---
 
 ## Audio Playback
 
-After synthesis, VoxCtr plays audio using the system audio stack:
+After synthesis, raw PCM audio is played using the system audio stack:
 
-- **Linux:** `aplay` (ALSA)
-- **Windows:** PowerShell `[System.Media.SoundPlayer]`
+- **Linux:** `aplay -r <sample_rate> -f S16_LE -c 1 -` (ALSA, streaming from stdin)
+- **Windows:** Writes a temp WAV file, plays with PowerShell `[System.Media.SoundPlayer]::PlaySync()`
 
-The audio plays asynchronously — the TTS engine queues requests and a dedicated task drains the queue sequentially so speech doesn't overlap.
+The TTS engine queues requests in a bounded channel (capacity 32). Utterances play sequentially — subsequent calls are queued and played in order without overlapping.
 
 ---
 
 ## Triggering TTS
 
 ### From the MCP Server
-LLM agents can queue speech via the `speak_text` MCP tool:
 ```json
 {"method": "tools/call", "params": {"name": "speak_text", "arguments": {"text": "Recording complete."}}}
 ```
 
-### From a Hotkey Binding Target
-Route to a TTS target — the `tts_engine` field on a target specifies which voice to use.
-
-### From the IPC Command
+### From a Tauri IPC Command
 ```typescript
-await invoke('speak_text', { text: 'Hello world', voice: 'en_US-lessac-medium' });
+await invoke('speak_text', { text: 'Hello world', voice: 'en-us-ryan-high' });
 ```
 
-### From the FIFO Pipe
-VoxCtr watches a named FIFO for newline-terminated text to speak. Write to it from any script:
+The `voice` parameter is optional; if omitted, the configured default voice is used.
+
+### From a FIFO Response Pipe
+If a target has a `response_pipe` path configured, VoxCtr watches that FIFO for newline-terminated text and speaks each line:
+
 ```bash
 echo "Recording started" > /tmp/voxctl-tts.fifo
 ```
 
+Multiple targets can have different `response_pipe` paths. VoxCtr spawns a FIFO watcher task for each unique path when targets are loaded or updated.
+
 ---
 
-## Stop Keys
+## Stopping Playback
 
-TTS playback can be interrupted with a configurable key combination. Set `tts.stop_keys` in config:
+The `stop_key` (singular, an array) config field lists keys that interrupt current TTS playback when pressed:
 
 ```json
 "tts": {
-  "stop_keys": ["KEY_ESC"]
+  "stop_key": ["KEY_ESCAPE"]
 }
 ```
 
-When the stop key is pressed during playback, the current utterance is cancelled and the queue is cleared.
+Sending `None` through the TTS engine channel (via `TtsEngineHandle::stop()`) clears the current utterance.
 
 ---
 
@@ -113,26 +121,32 @@ Under `tts` in `config.json`:
 |---|---|---|---|
 | `enabled` | bool | `false` | Enable TTS functionality |
 | `engine` | string | `"piper"` | `"piper"` or `"espeak"` |
-| `voice` | string | `"en_US-lessac-medium"` | Voice name for Piper |
-| `stop_keys` | string[] | `["KEY_ESC"]` | Keys that interrupt playback |
-| `rate` | int | `175` | Speech rate in words-per-minute (espeak only) |
-| `pitch` | int | `50` | Pitch level 0-99 (espeak only) |
+| `voice` | string | `"en-us-lessac-medium"` | Voice name (hyphen-delimited) |
+| `stop_key` | string[] | `["KEY_ESCAPE"]` | Keys that interrupt playback |
+| `response_overlay` | bool | `true` | Show overlay indicator while TTS is speaking |
 
 ---
 
 ## TtsEngineHandle
 
-The TTS handle is stored in `AppState` and shared with the MCP server and routing system:
+The TTS handle is stored in `AppState` and shared with the MCP server, routing system, and IPC commands:
 
 ```rust
-pub struct TtsEngineHandle {
-    tx: mpsc::Sender<TtsRequest>,
+pub struct Utterance {
+    pub text: String,
+    pub voice: Option<String>,      // None = use config default
+    pub source_label: Option<String>,
 }
 
-pub struct TtsRequest {
-    pub text: String,
-    pub voice: Option<String>,
+pub struct TtsEngineHandle {
+    tx: Sender<Option<Utterance>>,  // None = stop signal
+}
+
+impl TtsEngineHandle {
+    pub fn speak(&self, text: impl Into<String>);
+    pub fn speak_utterance(&self, u: Utterance);
+    pub fn stop(&self);  // sends None, clears current playback
 }
 ```
 
-Send a request by cloning the handle and sending on the channel. The worker task picks it up and synthesizes/plays sequentially.
+The handle is `Clone` — multiple callers can hold a copy and enqueue utterances concurrently.

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -8,56 +8,70 @@ VoxCtr opens three separate native windows managed by Tauri:
 
 | Window | Route | Default Size | Properties |
 |---|---|---|---|
-| Settings | `/settings` | 840 × 640 | Resizable, standard chrome |
-| Overlay | `/overlay` | 560 × 160 | Transparent, always-on-top, no decorations, non-focusable |
+| Settings | `/settings` | 840 × 640 (min 700 × 500) | Resizable, standard chrome |
+| Overlay | `/overlay` | 560 × 160 | Transparent, always-on-top, no decorations, not resizable, skip taskbar |
 | History | `/history` | 600 × 500 | Resizable, standard chrome |
 
-Windows are declared in `src-tauri/tauri.conf.json`.
+Windows are declared in `src-tauri/tauri.conf.json`. All three start hidden (`visible: false`) and are shown programmatically.
 
 ---
 
 ## Settings Window
 
-The main configuration interface. Organized into tabs:
+The main configuration interface. Organized into a sidebar with nine tabs:
 
 ### General Tab
-- Overlay style selector (Ocean Wave, Voice Card, Waveform, Pulse)
-- Auto-show overlay on recording toggle
+- Overlay show/hide toggle
+- Overlay style selector
+- Auto-show settings on startup toggle
 - Desktop notification toggle
 - History tracking toggle
-- Word count display
+- Recording status indicator and word count
+- Manual record/stop button
+
+### Engine Tab
+- Backend selector (`auto`, `whisper-cpp`, `moonshine`)
+- Inference mode selector (`Balanced`, `Aggressive`)
+- Whisper model size selector with download status
+- Compute device selector (auto / CPU / CUDA / Vulkan)
+- Thread count control
+- Moonshine model/language settings
+- "Download Model" button with progress
+
+### Routing Tab
+- Visual editor for `targets.toml` — add/edit/delete output targets
+- Per-target fields: label, delivery type, type-specific options
+- Per-target processing override controls
+- Hotkey binding management (add/edit/delete bindings, key combo recorder, gesture selector)
+
+### Visual Tab
+- Preview and selection of overlay animation styles
+- Overlay appearance controls
 
 ### Audio Tab
 - Input device selector (lists all CPAL devices)
-- Gain slider (0.0 – 4.0)
+- Gain slider
 - VAD threshold slider
+- Noise suppression toggle
 - Dynamic stream toggle
-- Live audio level meter (VU meter, updates from `audio-level` events)
-- "Test Microphone" button
+- Live audio level meter (VU meter, updates from `audio-level` events during monitoring)
+- Evdev device path input
 
-### Visual Tab
-- Preview of each overlay animation style
-- Overlay opacity and size controls
+### TTS Tab
+- Enable/disable toggle
+- Engine selector (Piper / Espeak)
+- Voice selector with download status per voice
+- "Download Voice" button per voice
+- Stop key configuration
+- Response overlay toggle
 
-### Routing Tab
-- Visual editor for `targets.toml`
-- Add/edit/delete output targets
-- Per-target fields: label, delivery type, type-specific options
-- Per-target processing overrides
-
-### Hotkeys Tab
-- Visual editor for `bindings.toml`
-- Add/edit/delete hotkey bindings
-- Key combo recorder (press keys to set)
-- Gesture selector
-- Multi-target assignment
-
-### Engine Tab
-- Backend selector (Whisper / Moonshine)
-- Model size selector with download status
-- Compute device selector (auto / CPU / CUDA / Vulkan)
-- Language selector
-- "Download Model" button with progress indicator
+### Features Tab
+- Filler removal toggle
+- Spoken punctuation toggle
+- Auto-format lists toggle
+- Quiet mode toggle
+- Custom vocabulary list editor
+- Snippet key-value editor
 
 ### Ollama Tab
 - Enable/disable toggle
@@ -67,43 +81,34 @@ The main configuration interface. Organized into tabs:
 - Custom prompt text area
 - "Test Connection" button → shows available models
 
-### TTS Tab
-- Enable/disable toggle
-- Engine selector (Piper / Espeak)
-- Voice selector with download status per voice
-- "Download Voice" button per voice
-- Stop key configuration
-- "Test Voice" button
-
 ### About Tab
 - Version information
-- Links to documentation
-- License info
+- Links to documentation and source
 
 ---
 
 ## Overlay Window
 
-A transparent, always-on-top floating HUD that visualizes audio activity. It has no title bar, cannot be focused by clicking, and auto-shows/hides based on recording state.
+A transparent, always-on-top floating HUD that visualizes audio activity. It has no title bar, no taskbar entry, is not resizable, and auto-shows/hides based on recording state (controlled by `ui.show_overlay`).
 
 ### Visualization Styles
 
-#### Ocean Wave
-Animated flowing wave in blue/cyan tones. Wave amplitude responds to microphone input level.
+Set via `ui.overlay_style` in config:
 
-#### Voice Card
-A minimal card with a pulsing animated circle and the current status text ("Listening...", "Processing...", "Speaking...").
+#### `blue_wave` (default)
+Animated flowing wave in blue/cyan tones. Wave amplitude responds to microphone input level. Component: `BlueWave.svelte`.
 
-#### Waveform
-Classic oscilloscope-style waveform visualization. The amplitude tracks the real-time audio level.
+#### `voice_card`
+A minimal card with a pulsing animated circle and the current status text ("Listening...", "Processing...", "Speaking..."). Component: `VoiceCard.svelte`.
 
-#### Pulse
-A series of animated bars (like an equalizer) that pulse in response to audio input.
+#### `waveform`
+Classic oscilloscope-style waveform visualization. Amplitude tracks the real-time audio level. Component: `Waveform.svelte`.
 
-### Overlay Auto-Behavior
-Controlled by `ui.auto_show_overlay`:
-- `true` — overlay appears automatically when recording starts and hides when text is delivered
-- `false` — overlay must be shown manually via the tray icon or IPC
+#### `pulse`
+A series of animated bars (like an equalizer) that pulse in response to audio input. Component: `Pulse.svelte`.
+
+#### `none`
+Overlay is disabled entirely.
 
 ---
 
@@ -113,16 +118,15 @@ Displays a log of all transcription sessions in reverse-chronological order.
 
 Each entry shows:
 - Timestamp
-- Transcribed text (truncated with expand option)
+- Transcribed text
 - Target that received the text
-- Word count
 - Inference time (ms)
-- Detected language
 
 Features:
-- Click an entry to copy text to clipboard
-- "Clear History" button
-- Persists in memory until the app is closed (not written to disk by default)
+- "Clear History" button (also resets word count)
+- History persists in memory until the app is closed (not written to disk)
+
+Enabled via `ui.history_enabled = true` in config.
 
 ---
 
@@ -131,16 +135,17 @@ Features:
 ### Config Store (`src/stores/config.ts`)
 
 ```typescript
-// Reactive store — all Settings components read from this
+// Reactive store — all Settings components bind to this
 export const config = writable<AppConfig>(defaultConfig);
+export const configDirty = writable(false);
 
 // Auto-save: debounced 400ms after any change
-config.subscribe(debounce(async (cfg) => {
-  await invoke('save_config', { config: cfg });
-}, 400));
+config.subscribe((cfg) => {
+  // 400ms debounce → invoke('save_config', { newConfig: cfg })
+});
 ```
 
-The store is initialized by calling `get_config()` on startup. The `config-changed` Tauri event refreshes it when another window or external process modifies the config.
+Initialized by `loadConfig()` which calls `get_config()` IPC on startup. The `config-changed` Tauri event refreshes the store when another window or external process modifies config, with a guard to avoid circular auto-save loops.
 
 ### Status Store (`src/stores/status.ts`)
 
@@ -149,13 +154,20 @@ export const status = writable<AppStatus>({
   recording: false,
   processing: false,
   speaking: false,
+  audio_ready: true,
   word_count: 0,
-  active_target: '',
+  active_target_id: "default",
+  active_target_label: "Focused Window",
 });
 
-// Updated every 250ms from backend status-tick events
-listen('status-tick', (event) => status.set(event.payload));
+// Derived convenience stores:
+export const recording = derived(status, ($s) => $s.recording);
+export const speaking = derived(status, ($s) => $s.speaking);
+export const wordCount = derived(status, ($s) => $s.word_count);
+export const activeTargetLabel = derived(status, ($s) => $s.active_target_label ?? "Focused Window");
 ```
+
+Updated by `status-tick` Tauri events (emitted by backend every ~250ms) and an initial `get_status()` call on load.
 
 ---
 
@@ -163,9 +175,9 @@ listen('status-tick', (event) => status.set(event.payload));
 
 | Event | Payload | Description |
 |---|---|---|
-| `status-tick` | `AppStatus` | Periodic state update (every 250ms) |
-| `config-changed` | `AppConfig` | Config was modified externally |
-| `audio-level` | `f32` | RMS audio level for VU meter |
+| `status-tick` | `AppStatus` | Periodic state update (~250ms) |
+| `config-changed` | `AppConfig` | Config was modified (by any window or externally) |
+| `audio-level` | `f32` | RMS audio level for VU meter (while monitoring is active) |
 
 ---
 
@@ -175,7 +187,7 @@ listen('status-tick', (event) => status.set(event.payload));
 # Development (hot-reload frontend, Rust recompiles on save)
 npm run tauri dev
 
-# Production build
+# Production build (AppImage on Linux, .exe/.msi on Windows)
 npm run tauri build
 ```
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -1,0 +1,182 @@
+# UI & Windows
+
+**Frontend:** `src/` (Svelte 5, Tailwind CSS 4, Vite 5)
+
+## Window Layout
+
+VoxCtr opens three separate native windows managed by Tauri:
+
+| Window | Route | Default Size | Properties |
+|---|---|---|---|
+| Settings | `/settings` | 840 × 640 | Resizable, standard chrome |
+| Overlay | `/overlay` | 560 × 160 | Transparent, always-on-top, no decorations, non-focusable |
+| History | `/history` | 600 × 500 | Resizable, standard chrome |
+
+Windows are declared in `src-tauri/tauri.conf.json`.
+
+---
+
+## Settings Window
+
+The main configuration interface. Organized into tabs:
+
+### General Tab
+- Overlay style selector (Ocean Wave, Voice Card, Waveform, Pulse)
+- Auto-show overlay on recording toggle
+- Desktop notification toggle
+- History tracking toggle
+- Word count display
+
+### Audio Tab
+- Input device selector (lists all CPAL devices)
+- Gain slider (0.0 – 4.0)
+- VAD threshold slider
+- Dynamic stream toggle
+- Live audio level meter (VU meter, updates from `audio-level` events)
+- "Test Microphone" button
+
+### Visual Tab
+- Preview of each overlay animation style
+- Overlay opacity and size controls
+
+### Routing Tab
+- Visual editor for `targets.toml`
+- Add/edit/delete output targets
+- Per-target fields: label, delivery type, type-specific options
+- Per-target processing overrides
+
+### Hotkeys Tab
+- Visual editor for `bindings.toml`
+- Add/edit/delete hotkey bindings
+- Key combo recorder (press keys to set)
+- Gesture selector
+- Multi-target assignment
+
+### Engine Tab
+- Backend selector (Whisper / Moonshine)
+- Model size selector with download status
+- Compute device selector (auto / CPU / CUDA / Vulkan)
+- Language selector
+- "Download Model" button with progress indicator
+
+### Ollama Tab
+- Enable/disable toggle
+- Endpoint URL
+- Model name
+- Mode selector
+- Custom prompt text area
+- "Test Connection" button → shows available models
+
+### TTS Tab
+- Enable/disable toggle
+- Engine selector (Piper / Espeak)
+- Voice selector with download status per voice
+- "Download Voice" button per voice
+- Stop key configuration
+- "Test Voice" button
+
+### About Tab
+- Version information
+- Links to documentation
+- License info
+
+---
+
+## Overlay Window
+
+A transparent, always-on-top floating HUD that visualizes audio activity. It has no title bar, cannot be focused by clicking, and auto-shows/hides based on recording state.
+
+### Visualization Styles
+
+#### Ocean Wave
+Animated flowing wave in blue/cyan tones. Wave amplitude responds to microphone input level.
+
+#### Voice Card
+A minimal card with a pulsing animated circle and the current status text ("Listening...", "Processing...", "Speaking...").
+
+#### Waveform
+Classic oscilloscope-style waveform visualization. The amplitude tracks the real-time audio level.
+
+#### Pulse
+A series of animated bars (like an equalizer) that pulse in response to audio input.
+
+### Overlay Auto-Behavior
+Controlled by `ui.auto_show_overlay`:
+- `true` — overlay appears automatically when recording starts and hides when text is delivered
+- `false` — overlay must be shown manually via the tray icon or IPC
+
+---
+
+## History Window
+
+Displays a log of all transcription sessions in reverse-chronological order.
+
+Each entry shows:
+- Timestamp
+- Transcribed text (truncated with expand option)
+- Target that received the text
+- Word count
+- Inference time (ms)
+- Detected language
+
+Features:
+- Click an entry to copy text to clipboard
+- "Clear History" button
+- Persists in memory until the app is closed (not written to disk by default)
+
+---
+
+## Frontend State Management
+
+### Config Store (`src/stores/config.ts`)
+
+```typescript
+// Reactive store — all Settings components read from this
+export const config = writable<AppConfig>(defaultConfig);
+
+// Auto-save: debounced 400ms after any change
+config.subscribe(debounce(async (cfg) => {
+  await invoke('save_config', { config: cfg });
+}, 400));
+```
+
+The store is initialized by calling `get_config()` on startup. The `config-changed` Tauri event refreshes it when another window or external process modifies the config.
+
+### Status Store (`src/stores/status.ts`)
+
+```typescript
+export const status = writable<AppStatus>({
+  recording: false,
+  processing: false,
+  speaking: false,
+  word_count: 0,
+  active_target: '',
+});
+
+// Updated every 250ms from backend status-tick events
+listen('status-tick', (event) => status.set(event.payload));
+```
+
+---
+
+## Tauri Events (Backend → Frontend)
+
+| Event | Payload | Description |
+|---|---|---|
+| `status-tick` | `AppStatus` | Periodic state update (every 250ms) |
+| `config-changed` | `AppConfig` | Config was modified externally |
+| `audio-level` | `f32` | RMS audio level for VU meter |
+
+---
+
+## Build & Dev
+
+```bash
+# Development (hot-reload frontend, Rust recompiles on save)
+npm run tauri dev
+
+# Production build
+npm run tauri build
+```
+
+The Vite dev server runs on `http://localhost:5173`. In dev mode, Tauri loads the frontend from Vite. In production, frontend assets are bundled into the binary.


### PR DESCRIPTION
## Summary

- Creates a `docs/` folder with 14 new Markdown files forming a complete technical documentation wiki, written against the actual source code
- Fixes three pre-existing docs (`overlays.md`, `mcp_documentation.md`, `appimage_build_process.md`) that were outdated or described a previous version of the app

---

## New documentation (14 files)

| File | Contents |
|---|---|
| `docs/README.md` | Index with quick-start summary and data-flow diagram |
| `docs/overview.md` | Feature set, design principles, capability overview |
| `docs/architecture.md` | Crate layout, data-flow pipeline, concurrency model, file locations |
| `docs/audio.md` | Audio capture, device selection, resampling, VAD, configuration |
| `docs/speech-recognition.md` | Whisper engine, models, GPU backends, inference pipeline, post-processing |
| `docs/routing.md` | All 9 delivery types, targets.toml schema, bindings.toml schema, multi-target routing |
| `docs/hotkeys.md` | evdev/Win32 listener, gesture types, key names, hot-reload |
| `docs/tts.md` | Piper/Espeak engines, voice packs, playback, stop keys |
| `docs/integrations.md` | MCP server (protocol + tools), DBus service, Ollama, webhooks, AT-SPI2 |
| `docs/ui.md` | Three windows, Settings tabs, overlay styles, Svelte stores, Tauri events |
| `docs/api.md` | All Tauri IPC commands with TypeScript signatures, event payloads, full type definitions |
| `docs/configuration.md` | Complete schema for config.json, targets.toml, bindings.toml with all fields and defaults |
| `docs/installation.md` | AppImage install, permissions, first-run setup, troubleshooting |
| `docs/development.md` | Dev environment, build system, crate conventions, debugging, how to add new target types |

---

## Pre-existing doc fixes

### `docs/overlays.md` — complete rewrite
The old document described a Python/PyQt6 custom overlay plugin system from a previous version of the app. Replaced with an accurate description of the current system:
- Four Svelte/Tauri WebView overlay components: **Blue Wave** (default), **Voice Card**, **Waveform**, **Pulse**
- Correct `overlay_style` config values (`"blue_wave"`, `"voice_card"`, `"waveform"`, `"pulse"`, `"none"`)
- How the `audio-level` event drives animations; IPC commands; window properties (560×160 px, transparent, always-on-top)
- Correct Settings navigation (Visual tab, not "Dictation" tab)

### `docs/mcp_documentation.md` — targeted fixes
- Renamed "VoxCtl" → "VoxCtr" throughout
- Fixed Settings tab names: "Voice Output" → **TTS**, "AI" → **Ollama**
- Removed non-existent "Register in Claude Desktop" one-click button
- Removed invalid `post_processing = "none"` field from TOML target example
- Fixed error code table: added `-32700` (parse error), removed `-32602` (never emitted by the server — unknown tool is `-32603`)
- Clarified TTS settings live in Settings → TTS; MCP settings in Settings → Ollama

### `docs/appimage_build_process.md` — targeted fixes
- Corrected audio backend: `portaudio` → `alsa-lib` / `libasound2-dev` (VoxCtr uses CPAL, not PortAudio)
- Removed hardcoded `/home/jrufer/` absolute paths from the shebang-fix script; replaced with `$HOME` and a note to adapt the IDE path pattern to the local environment
- Fixed `tauri.conf.json` reference from an absolute `file:///` URL to a relative path
- Added note that the `VoxCtl-x86_64.AppImage` output filename is a legacy artifact name not yet updated to match current branding

## Test plan

- [x] All new docs written against source code (`crates/voxctr-config/src/lib.rs`, `crates/voxctr-routing/src/models.rs`, `src-tauri/src/commands.rs`, etc.)
- [x] Pre-existing docs cross-checked against current codebase and corrected
- [x] Reviewed each file for accuracy against source code — one additional fix applied (mcp_documentation.md TTS/MCP tab clarification)
- [x] All cross-links between docs verified — all 14 links in README.md and the one in installation.md resolve to existing files

https://claude.ai/code/session_01754in3ZzCEJd7ojVvpKgBp