### PR TITLE
Add four new overlay styles: Mono Bars, Neon Spectrum, Retro Terminal, Analog VU

### DIFF
--- a/docs/overlays.md
+++ b/docs/overlays.md
@@ -54,7 +54,7 @@ If the configured target monitor is unplugged or disconnected at runtime, the Ta
 
 ## Built-in Styles
 
-Four built-in styles are available — each with its own visual identity, its own kind of audio visualizer, its own load/unload animation, and a clear indicator of the active routing target. The default is **Ocean Wave**.
+Eight built-in styles are available — each with its own visual identity, its own kind of audio visualizer, its own load/unload animation, and a clear indicator of the active routing target. The default is **Ocean Wave**.
 
 All styles share three state palettes: **Recording** (the style's signature color), **Initializing** (amber, while the microphone stream is connecting), and **Processing** (sky blue, while the AI is transcribing).
 
@@ -84,6 +84,34 @@ A sonar/radar dial paired with a target-lock plate.
 - **Target indicator**: a "PULSE // TARGET LOCK" plate beside the dial with a pulsing reticle (⌖) and lock frame showing the active target label.
 - **Load/unload**: the dial drops in and the lock plate slides out from behind it; both reverse on unload.
 - **States**: "TARGET LOCK" (tangerine), "ACQUIRING" (amber), "ANALYZING" (blue).
+
+### Mono Bars (`"mono_bars"`)
+A hyper-minimal, pure black & white panel — no color, no gradients, no glow.
+- **Visualizer**: a 5-bar level meter, centre-weighted so the middle bar reacts most strongly, with a gentle ripple traveling across the row while recording and all bars pulsing in lock-step while processing.
+- **Target indicator**: a small caption beneath the bars showing the active target label.
+- **Load/unload**: the whole panel simply fades in and out — no motion, scaling, or color, in keeping with its minimal aesthetic.
+- **States**: "LISTENING" (dot lit, blinking), "STANDBY" (dim, dot hollow — initializing), "PROCESSING" (bars pulse together, dot blinks faster).
+
+### Neon Spectrum (`"spectrum"`)
+A 16-band equalizer in a deep-violet panel with a magenta-to-cyan gradient and a soft glow.
+- **Visualizer**: 16 bars across a magenta → purple → cyan gradient. Bass (left) bands swing wider and slower; treble (right) bands flicker faster with a smaller share of the level.
+- **Target indicator**: an "OUT ▸" chip in the header showing the active target label.
+- **Load/unload**: the panel rises up out of the floor — its height grows while the bars stay anchored to the bottom edge — and sinks back down on unload.
+- **States**: "· LIVE" (magenta LED), "· WARMING UP" (amber, initializing), "· ANALYZING" (blue, bars pulse in a traveling wave while processing).
+
+### Retro Terminal (`"terminal"`)
+A DOS-blue console window with a three-dot title bar and monospace readouts.
+- **Visualizer**: a block-character ASCII meter (`█`/`·`) that fills left-to-right with the audio level.
+- **Target indicator**: a `$ voxctrl listen --target "..."` command line showing the active target label.
+- **Load/unload**: the console drops down from the top edge on load and retracts back up on unload.
+- **States**: "[REC ]" (white meter, "streaming to output"), "[INIT]" (amber, "connecting input device"), "[PROC]" (sky blue, "transcribing audio stream"), with a blinking text cursor.
+
+### Analog VU (`"vinyl"`)
+A warm, vintage VU meter in cream and amber tones with a real dial face.
+- **Visualizer**: a spring-loaded needle that kicks toward the audio level and settles with realistic ballistics (the same critically-damped spring used for load/unload animations), sweeping across a `-20` to `+3` scale.
+- **Target indicator**: a caption beneath the meter face showing the active target label.
+- **Load/unload**: the panel fades in and settles upward slightly into place on load, and reverses on unload.
+- **States**: red LED + needle resting at `-20` (idle/standby), amber LED (initializing), blue LED with the needle sweeping on its own (processing), red LED with the needle tracking your voice (recording).
 
 ### Speaking Pill
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -464,7 +464,10 @@ pub async fn get_custom_overlays() -> Result<Vec<CustomOverlayInfo>, String> {
                     let mut folder_name = entry.file_name().to_string_lossy().to_string();
 
                     // Automatically resolve naming conflicts with built-in styles
-                    let reserved = ["waveform", "pulse", "blue_wave", "voice_card", "none"];
+                    let reserved = [
+                        "waveform", "pulse", "blue_wave", "voice_card", "none",
+                        "mono_bars", "spectrum", "terminal", "vinyl",
+                    ];
                     if reserved.contains(&folder_name.to_lowercase().as_str()) {
                         folder_name = format!("{}_custom", folder_name);
                     }

--- a/src-tauri/src/overlay.rs
+++ b/src-tauri/src/overlay.rs
@@ -56,6 +56,13 @@ slint::slint! {
         in property <[float]> pill-bars: [];
         in property <[BubbleData]> bubbles: [];
 
+        // Mono bars (mono_bars), spectrum bars (spectrum), ASCII meter
+        // (terminal) and needle path (vinyl)
+        in property <[float]> mono-bars: [];
+        in property <[float]> spectrum-bars: [];
+        in property <string> ascii-meter: "";
+        in property <string> vu-needle-path: "";
+
         // ─────────────────────────────────────────────────────────────
         // 1. WAVEFORM — "OSC-01" green phosphor oscilloscope.
         //    Loads like a CRT powering on (expands from a scanline),
@@ -672,6 +679,376 @@ slint::slint! {
         }
 
         // ─────────────────────────────────────────────────────────────
+        // 5. MONO BARS — hyper-minimal black & white 5-bar level meter.
+        //    Pure greyscale: no color, no gradients, no glow. Fades in
+        //    and the bars grow from the baseline on load, shrink back
+        //    on unload.
+        // ─────────────────────────────────────────────────────────────
+        if (overlay-style == "mono_bars" && reveal-main > 0.004) : Rectangle {
+            x: (560px - 190px) / 2;
+            y: 39px;
+            width: 190px;
+            height: 112px;
+            clip: true;
+            background: #000000;
+            border-width: 1px;
+            border-color: rgba(255, 255, 255, 0.16);
+            border-radius: 6px;
+            opacity: Math.min(1.0, reveal-main);
+
+            // Status row
+            HorizontalLayout {
+                x: 18px;
+                y: 14px;
+                width: 154px;
+                height: 12px;
+                spacing: 6px;
+
+                Rectangle {
+                    width: 6px;
+                    height: 6px;
+                    y: (parent.height - self.height) / 2;
+                    border-radius: 3px;
+                    border-width: 1px;
+                    border-color: rgba(245, 245, 245, 0.7);
+                    background: (!is-processing && is-audio-ready) ? #f5f5f5 : transparent;
+                    opacity: is-processing ? (0.3 + 0.7 * blink) : (!is-audio-ready ? 0.35 : (0.5 + 0.5 * blink));
+                }
+
+                Text {
+                    text: is-processing ? "PROCESSING" : (!is-audio-ready ? "STANDBY" : "LISTENING");
+                    color: rgba(255, 255, 255, 0.55);
+                    font-size: 8px;
+                    font-weight: 700;
+                    font-family: "Outfit";
+                    letter-spacing: 2px;
+                    vertical-alignment: center;
+                }
+            }
+
+            // 5-bar minimal wave
+            for h[i] in mono-bars : Rectangle {
+                x: 37px + i * 26px;
+                y: 84px - h * Math.min(1.0, reveal-main) * 1px;
+                width: 12px;
+                height: h * Math.min(1.0, reveal-main) * 1px;
+                border-radius: 6px;
+                background: #f5f5f5;
+                opacity: is-processing ? 0.55 : (!is-audio-ready ? 0.3 : 1.0);
+            }
+
+            // Baseline
+            Rectangle { x: 18px; y: 84px; width: 154px; height: 1px; background: rgba(255, 255, 255, 0.12); }
+
+            // Target label
+            Text {
+                x: 18px;
+                y: 92px;
+                width: 154px;
+                height: 14px;
+                text: target-label;
+                color: rgba(255, 255, 255, 0.4);
+                font-size: 8.5px;
+                font-weight: 600;
+                font-family: "Outfit";
+                letter-spacing: 0.5px;
+                overflow: elide;
+                horizontal-alignment: center;
+            }
+        }
+
+        // ─────────────────────────────────────────────────────────────
+        // 6. NEON SPECTRUM — a 16-band equalizer in a magenta-to-cyan
+        //    gradient. Powers up from the floor: the panel's height
+        //    grows while the content stays anchored to the bottom edge,
+        //    so the bars appear to rise into view. Reverses on unload.
+        // ─────────────────────────────────────────────────────────────
+        if (overlay-style == "spectrum" && reveal-main > 0.004) : Rectangle {
+            x: 60px;
+            y: 150px - 132px * Math.min(1.0, reveal-main);
+            width: 440px;
+            height: 132px * Math.min(1.0, reveal-main);
+            clip: true;
+            border-radius: 16px;
+            background: @linear-gradient(160deg, #1b0c2e 0%, #0a0614 100%);
+            border-width: 1px;
+            border-color: rgba(232, 121, 249, 0.25);
+            opacity: reveal-main > 0.2 ? 1.0 : reveal-main * 5.0;
+            drop-shadow-blur: 26px;
+            drop-shadow-color: rgba(192, 132, 252, 0.22);
+
+            // Fixed-size inner content, bottom-anchored so the bars read
+            // as rising up out of the floor as the panel grows.
+            Rectangle {
+                x: 0;
+                y: parent.height - 132px;
+                width: 440px;
+                height: 132px;
+
+                // Header
+                HorizontalLayout {
+                    x: 20px; y: 12px; width: 400px; height: 16px; spacing: 8px;
+
+                    Rectangle {
+                        width: 7px; height: 7px; border-radius: 3.5px;
+                        y: (parent.height - self.height) / 2;
+                        background: is-processing ? #38bdf8 : (!is-audio-ready ? #f59e0b : #e879f9);
+                        drop-shadow-blur: 6px;
+                        drop-shadow-color: is-processing ? #38bdf8 : (!is-audio-ready ? #f59e0b : #e879f9);
+                        opacity: 0.4 + 0.6 * blink;
+                    }
+                    Text {
+                        text: "SPECTRUM // EQ-16";
+                        color: #f5d0fe;
+                        font-size: 10px;
+                        font-weight: 800;
+                        font-family: "Outfit";
+                        letter-spacing: 1.5px;
+                        vertical-alignment: center;
+                    }
+                    Text {
+                        text: is-processing ? "· ANALYZING" : (!is-audio-ready ? "· WARMING UP" : "· LIVE");
+                        color: rgba(245, 208, 254, 0.35);
+                        font-size: 9px;
+                        font-weight: 500;
+                        font-family: "Outfit";
+                        letter-spacing: 1px;
+                        vertical-alignment: center;
+                    }
+                    Rectangle { horizontal-stretch: 1; }
+                    Rectangle {
+                        horizontal-stretch: 0;
+                        background: rgba(232, 121, 249, 0.08);
+                        border-width: 1px;
+                        border-color: rgba(232, 121, 249, 0.3);
+                        border-radius: 4px;
+
+                        HorizontalLayout {
+                            padding-left: 8px; padding-right: 8px; padding-top: 2px; padding-bottom: 2px;
+                            spacing: 5px; alignment: center;
+
+                            Text {
+                                text: "OUT ▸";
+                                color: #e879f9;
+                                font-size: 8.5px;
+                                font-weight: 800;
+                                font-family: "Outfit";
+                                letter-spacing: 1px;
+                                vertical-alignment: center;
+                            }
+                            Text {
+                                text: target-label;
+                                color: #fae8ff;
+                                font-size: 8.5px;
+                                font-weight: 700;
+                                font-family: "Outfit";
+                                letter-spacing: 0.6px;
+                                vertical-alignment: center;
+                                overflow: elide;
+                                max-width: 150px;
+                            }
+                        }
+                    }
+                }
+
+                // Equalizer bars
+                for h[i] in spectrum-bars : Rectangle {
+                    x: 20px + i * 25.5px;
+                    y: 116px - h * 1px;
+                    width: 19px;
+                    height: h * 1px;
+                    border-radius: 3px;
+                    background: @linear-gradient(180deg, #f0abfc 0%, #c084fc 45%, #38bdf8 100%);
+                    opacity: 0.45 + 0.55 * (h / 96.0);
+                }
+
+                // Floor line
+                Rectangle { x: 20px; y: 116px; width: 400px; height: 1px; background: rgba(232, 121, 249, 0.15); }
+            }
+        }
+
+        // ─────────────────────────────────────────────────────────────
+        // 7. RETRO TERMINAL — a DOS-blue console window with monospace
+        //    readouts and a block-character level meter. Drops down
+        //    from the top edge on load, retracts back up on unload.
+        // ─────────────────────────────────────────────────────────────
+        if (overlay-style == "terminal" && reveal-main > 0.004) : Rectangle {
+            x: 90px;
+            y: 16px;
+            width: 380px;
+            height: 130px * Math.min(1.0, reveal-main);
+            clip: true;
+            background: #0d1b4c;
+            border-width: 1.5px;
+            border-color: rgba(125, 211, 252, 0.35);
+            border-radius: 8px;
+            opacity: reveal-main > 0.2 ? 1.0 : reveal-main * 5.0;
+            drop-shadow-blur: 20px;
+            drop-shadow-color: rgba(8, 15, 48, 0.6);
+
+            // Title bar
+            Rectangle {
+                x: 0; y: 0; width: 380px; height: 24px;
+                background: rgba(255, 255, 255, 0.06);
+
+                HorizontalLayout {
+                    padding-left: 12px;
+                    spacing: 6px;
+
+                    Rectangle { width: 8px; height: 8px; border-radius: 4px; y: (parent.height - self.height) / 2; background: rgba(255, 255, 255, 0.22); }
+                    Rectangle { width: 8px; height: 8px; border-radius: 4px; y: (parent.height - self.height) / 2; background: rgba(255, 255, 255, 0.22); }
+                    Rectangle { width: 8px; height: 8px; border-radius: 4px; y: (parent.height - self.height) / 2; background: rgba(255, 255, 255, 0.22); }
+
+                    Text {
+                        text: "VOXCTRL — /dev/mic0";
+                        color: rgba(224, 242, 254, 0.55);
+                        font-size: 9px;
+                        font-weight: 700;
+                        font-family: "Outfit";
+                        letter-spacing: 1px;
+                        vertical-alignment: center;
+                    }
+                }
+            }
+
+            // Body
+            VerticalLayout {
+                x: 16px; y: 34px; width: 348px; height: 88px;
+                spacing: 8px;
+
+                Text {
+                    text: "$ voxctrl listen --target \"" + target-label + "\"";
+                    color: rgba(186, 230, 253, 0.7);
+                    font-size: 10px;
+                    font-weight: 600;
+                    font-family: "monospace";
+                    overflow: elide;
+                }
+
+                Text {
+                    text: (is-processing ? "[PROC] " : (!is-audio-ready ? "[INIT] " : "[REC ] ")) + ascii-meter;
+                    color: is-processing ? #7dd3fc : (!is-audio-ready ? #fcd34d : #ffffff);
+                    font-size: 11px;
+                    font-weight: 700;
+                    font-family: "monospace";
+                    letter-spacing: 1px;
+                }
+
+                Text {
+                    text: (is-processing ? "transcribing audio stream" : (!is-audio-ready ? "connecting input device" : "streaming to output")) + (blink > 0.5 ? "_" : " ");
+                    color: rgba(186, 230, 253, 0.45);
+                    font-size: 9.5px;
+                    font-weight: 500;
+                    font-family: "monospace";
+                }
+            }
+        }
+
+        // ─────────────────────────────────────────────────────────────
+        // 8. ANALOG VU — a warm vintage VU meter with a spring-loaded
+        //    needle that kicks and settles with your voice. Fades in
+        //    and rises slightly into place on load, settles back down
+        //    on unload.
+        // ─────────────────────────────────────────────────────────────
+        if (overlay-style == "vinyl" && reveal-main > 0.004) : Rectangle {
+            x: 120px;
+            y: 24px + (1.0 - Math.min(1.0, reveal-main)) * 16px;
+            width: 320px;
+            height: 132px;
+            clip: true;
+            border-radius: 14px;
+            background: @linear-gradient(180deg, #f7ecd9 0%, #e7d6b8 100%);
+            border-width: 1.5px;
+            border-color: rgba(120, 89, 53, 0.35);
+            opacity: Math.min(1.0, reveal-main);
+            drop-shadow-blur: 22px;
+            drop-shadow-color: rgba(0, 0, 0, 0.35);
+
+            // Header
+            HorizontalLayout {
+                x: 16px; y: 12px; width: 288px; height: 14px; spacing: 8px;
+
+                Text {
+                    text: "VU";
+                    color: #5b4530;
+                    font-size: 12px;
+                    font-weight: 900;
+                    font-family: "Outfit";
+                    letter-spacing: 2px;
+                    vertical-alignment: center;
+                }
+                Text {
+                    text: is-processing ? "ANALOG // PROCESSING" : (!is-audio-ready ? "ANALOG // WARMING UP" : "ANALOG // INPUT LEVEL");
+                    color: rgba(91, 69, 48, 0.55);
+                    font-size: 8px;
+                    font-weight: 700;
+                    font-family: "Outfit";
+                    letter-spacing: 1.5px;
+                    vertical-alignment: center;
+                }
+                Rectangle { horizontal-stretch: 1; }
+                Rectangle {
+                    horizontal-stretch: 0;
+                    width: 8px; height: 8px; border-radius: 4px;
+                    y: (parent.height - self.height) / 2;
+                    background: is-processing ? #38bdf8 : (!is-audio-ready ? #f59e0b : #dc2626);
+                    drop-shadow-blur: 6px;
+                    drop-shadow-color: is-processing ? #38bdf8 : (!is-audio-ready ? #f59e0b : #dc2626);
+                    opacity: 0.4 + 0.6 * blink;
+                }
+            }
+
+            // Meter face
+            Rectangle {
+                x: 16px; y: 30px; width: 288px; height: 72px;
+                border-radius: 8px;
+                background: rgba(255, 252, 244, 0.55);
+                border-width: 1px;
+                border-color: rgba(120, 89, 53, 0.25);
+
+                // Scale ticks (the rightmost, in the red, is the +3dB mark)
+                for t in [0, 1, 2, 3, 4, 5, 6] : Rectangle {
+                    x: 18px + t * 42px;
+                    y: 14px;
+                    width: 1.5px;
+                    height: t == 6 ? 30px : 22px;
+                    background: t == 6 ? #dc2626 : rgba(91, 69, 48, 0.4);
+                }
+                Text { x: 12px; y: 40px; text: "-20"; color: rgba(91, 69, 48, 0.5); font-size: 7px; font-family: "Outfit"; }
+                Text { x: 122px; y: 40px; text: "0"; color: rgba(91, 69, 48, 0.5); font-size: 7px; font-family: "Outfit"; }
+                Text { x: 252px; y: 34px; text: "+3"; color: #dc2626; font-size: 7px; font-weight: 800; font-family: "Outfit"; }
+
+                // Needle (path rebuilt every frame in Rust, spring-driven)
+                Path {
+                    x: 0; y: 0; width: 288px; height: 72px;
+                    viewbox-width: 288; viewbox-height: 72;
+                    commands: vu-needle-path;
+                    stroke: #292524;
+                    stroke-width: 2px;
+                    fill: transparent;
+                }
+
+                // Pivot cap
+                Rectangle {
+                    x: 138px; y: 64px; width: 12px; height: 12px; border-radius: 6px;
+                    background: #292524;
+                }
+            }
+
+            // Target label
+            Text {
+                x: 16px; y: 110px;
+                width: 288px;
+                text: target-label;
+                color: rgba(91, 69, 48, 0.65);
+                font-size: 9.5px;
+                font-weight: 700;
+                font-family: "Outfit";
+                overflow: elide;
+            }
+        }
+
+        // ─────────────────────────────────────────────────────────────
         // Speaking pill — slides up from the bottom while the system
         // responds, with a live mini-equalizer.
         // ─────────────────────────────────────────────────────────────
@@ -889,6 +1266,101 @@ fn led_step(current: f32, target: f32) -> f32 {
     if target > current { target } else { current * 0.86 }
 }
 
+// ── Mono bars (mono_bars style) ───────────────────────────────────────
+const MONO_BAR_MIN: f32 = 8.0;
+const MONO_BAR_MAX: f32 = 52.0;
+
+/// Bar height in px for bar `i` of `n` (always within [MONO_BAR_MIN,
+/// MONO_BAR_MAX]). Bars are centre-weighted and ripple gently across the
+/// row while recording, in lock-step while processing, and sit flat at
+/// the baseline otherwise.
+fn mono_bar_height(i: usize, n: usize, level: f32, phase: f32, recording: bool, processing: bool, ready: bool, noise: f32) -> f32 {
+    let mid = (n as f32 - 1.0) / 2.0;
+    let envelope = 1.0 - (i as f32 - mid).abs() / (mid + 1.0) * 0.4;
+    let amp = if processing {
+        ((phase * 4.0 - i as f32 * 0.85).sin() * 0.5 + 0.5) * envelope
+    } else if recording && !ready {
+        0.0
+    } else if recording {
+        let ripple = (phase * 3.0 - i as f32 * 0.8).sin();
+        (level * envelope * (0.9 + 0.1 * ripple) * (0.85 + 0.3 * noise)).clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+    MONO_BAR_MIN + (MONO_BAR_MAX - MONO_BAR_MIN) * amp
+}
+
+// ── Neon spectrum (spectrum style) ──────────────────────────────────────
+const SPECTRUM_BARS: usize = 16;
+const SPECTRUM_MIN: f32 = 6.0;
+const SPECTRUM_MAX: f32 = 96.0;
+
+/// Bar height in px for band `i` of `n` (always within [SPECTRUM_MIN,
+/// SPECTRUM_MAX]). Lower bands ("bass") swing wider and slower; higher
+/// bands ("treble") flicker faster with a smaller share of the level.
+fn spectrum_bar_height(i: usize, n: usize, level: f32, phase: f32, recording: bool, processing: bool, ready: bool, noise: f32) -> f32 {
+    let band = i as f32 / (n as f32 - 1.0);
+    let amp = if processing {
+        ((phase * 2.4 - band * 6.0).sin() * 0.5 + 0.5).powf(1.5)
+    } else if recording && !ready {
+        noise * 0.06
+    } else if recording {
+        let band_freq = 2.0 + band * 9.0;
+        let band_phase = i as f32 * 0.7;
+        let wobble = (phase * band_freq + band_phase).sin() * 0.5 + 0.5;
+        let band_gain = 1.0 - band * 0.35;
+        (level * band_gain * (0.35 + 0.65 * wobble) * (0.7 + 0.6 * noise)).clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+    SPECTRUM_MIN + (SPECTRUM_MAX - SPECTRUM_MIN) * amp
+}
+
+// ── Retro terminal (terminal style) ─────────────────────────────────────
+const ASCII_METER_WIDTH: usize = 20;
+
+/// Build a fixed-width block-character meter for the terminal's level
+/// readout. While processing it shows a scanning block bouncing back and
+/// forth; while recording it fills left-to-right with the audio level.
+fn ascii_meter(level: f32, phase: f32, recording: bool, processing: bool, ready: bool) -> String {
+    let w = ASCII_METER_WIDTH;
+    if processing {
+        let cycle = 2 * w;
+        let raw = (phase * 10.0) as usize % cycle;
+        let pos = if raw < w { raw } else { cycle - 1 - raw };
+        (0..w).map(|i| if i == pos { '█' } else { '·' }).collect()
+    } else if recording && !ready {
+        (0..w).map(|i| if i % 4 == 0 { '·' } else { ' ' }).collect()
+    } else if recording {
+        let filled = (level.clamp(0.0, 1.0) * w as f32).round() as usize;
+        (0..w).map(|i| if i < filled { '█' } else { '·' }).collect()
+    } else {
+        "·".repeat(w)
+    }
+}
+
+// ── Analog VU (vinyl style) ──────────────────────────────────────────────
+const VU_PIVOT_X: f32 = 144.0;
+const VU_PIVOT_Y: f32 = 70.0;
+const VU_RADIUS: f32 = 58.0;
+const VU_ANGLE_MIN: f32 = -0.95; // resting position (full left)
+const VU_ANGLE_MAX: f32 = 0.95; // full-scale (full right)
+
+/// Map a 0..1 audio level to a needle angle (radians from straight up).
+fn vu_target_angle(level: f32) -> f32 {
+    VU_ANGLE_MIN + level.clamp(0.0, 1.0) * (VU_ANGLE_MAX - VU_ANGLE_MIN)
+}
+
+/// The needle: a line from the pivot to a point on the dial rim at `angle`
+/// radians from straight up.
+fn vu_needle_path(angle: f32) -> String {
+    format!(
+        "M {VU_PIVOT_X} {VU_PIVOT_Y} L {:.1} {:.1}",
+        VU_PIVOT_X + angle.sin() * VU_RADIUS,
+        VU_PIVOT_Y - angle.cos() * VU_RADIUS
+    )
+}
+
 fn main() {
     let ui = OverlayWindow::new().unwrap();
 
@@ -973,6 +1445,8 @@ fn main() {
     let mut cur_level = 0.0_f32;
     let mut osc_hist: VecDeque<f32> = VecDeque::from(vec![0.0_f32; 126]);
     let mut led_cols = [0.0_f32; 20];
+    let mut vu_angle = VU_ANGLE_MIN;
+    let mut vu_vel = 0.0_f32;
     let mut lcg_state = 12345_u32;
     let mut shown = false;
 
@@ -1130,6 +1604,45 @@ fn main() {
                     cols.push(*c);
                 }
                 ui.set_led_cols(cols.into());
+            }
+
+            // Mono bars: hyper-minimal 5-bar black & white level meter.
+            "mono_bars" => {
+                let n = 5;
+                let bars = std::rc::Rc::new(slint::VecModel::default());
+                for i in 0..n {
+                    bars.push(mono_bar_height(i, n, cur_level, phase, rec, proc, ready, rand()));
+                }
+                ui.set_mono_bars(bars.into());
+            }
+
+            // Neon spectrum: 16-band magenta-to-cyan equalizer.
+            "spectrum" => {
+                let n = SPECTRUM_BARS;
+                let bars = std::rc::Rc::new(slint::VecModel::default());
+                for i in 0..n {
+                    bars.push(spectrum_bar_height(i, n, cur_level, phase, rec, proc, ready, rand()));
+                }
+                ui.set_spectrum_bars(bars.into());
+            }
+
+            // Retro terminal: block-character ASCII level meter.
+            "terminal" => {
+                ui.set_ascii_meter(ascii_meter(cur_level, phase, rec, proc, ready).into());
+            }
+
+            // Analog VU: spring-loaded needle kicks toward the level and
+            // settles back to rest when idle.
+            "vinyl" => {
+                let target_angle = if proc {
+                    vu_target_angle(0.3 + 0.25 * (phase * 2.0).sin().abs())
+                } else if rec && ready {
+                    vu_target_angle(cur_level)
+                } else {
+                    VU_ANGLE_MIN
+                };
+                spring(&mut vu_angle, &mut vu_vel, target_angle, DT);
+                ui.set_vu_needle_path(vu_needle_path(vu_angle).into());
             }
 
             _ => {}
@@ -1396,5 +1909,140 @@ mod tests {
         // level must light at least the bottom row of the centre column.
         let t = led_column_target(10, 20, 0.05, 0.0, true, false, true, 0.5);
         assert!(t * 6.0 >= 1.0, "quiet speech should light an LED, got {t}");
+    }
+
+    // ── Mono bars (mono_bars) ─────────────────────────────────────────
+
+    #[test]
+    fn mono_bars_stay_within_range() {
+        for i in 0..5 {
+            for &(rec, proc, ready) in &[(true, false, true), (true, false, false), (false, true, true), (false, false, true)] {
+                for &phase in &[0.0_f32, 1.3, 5.0, 12.0] {
+                    let h = mono_bar_height(i, 5, 1.0, phase, rec, proc, ready, 1.0);
+                    assert!(
+                        (MONO_BAR_MIN..=MONO_BAR_MAX).contains(&h),
+                        "bar {i} out of range: {h}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn mono_bars_sit_at_baseline_when_idle() {
+        assert_eq!(mono_bar_height(2, 5, 1.0, 0.0, false, false, true, 1.0), MONO_BAR_MIN);
+        assert_eq!(mono_bar_height(2, 5, 1.0, 0.0, true, false, false, 1.0), MONO_BAR_MIN);
+    }
+
+    #[test]
+    fn mono_bars_grow_with_level() {
+        let quiet = mono_bar_height(2, 5, 0.0, 0.0, true, false, true, 1.0);
+        let loud = mono_bar_height(2, 5, 1.0, 0.0, true, false, true, 1.0);
+        assert_eq!(quiet, MONO_BAR_MIN);
+        assert!(loud > quiet, "bars must grow louder with voice level");
+    }
+
+    #[test]
+    fn mono_bars_are_centre_weighted() {
+        let edge = mono_bar_height(0, 5, 0.8, 0.0, true, false, true, 0.5);
+        let centre = mono_bar_height(2, 5, 0.8, 0.0, true, false, true, 0.5);
+        assert!(centre >= edge, "centre bar should be at least as tall as an edge bar");
+    }
+
+    // ── Neon spectrum (spectrum) ────────────────────────────────────────
+
+    #[test]
+    fn spectrum_bars_stay_within_range() {
+        for i in 0..SPECTRUM_BARS {
+            for &(rec, proc, ready) in &[(true, false, true), (true, false, false), (false, true, true), (false, false, true)] {
+                for &phase in &[0.0_f32, 2.2, 7.7] {
+                    let h = spectrum_bar_height(i, SPECTRUM_BARS, 1.0, phase, rec, proc, ready, 1.0);
+                    assert!(
+                        (SPECTRUM_MIN..=SPECTRUM_MAX).contains(&h),
+                        "band {i} out of range: {h}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn spectrum_bars_sit_at_floor_when_idle() {
+        assert_eq!(spectrum_bar_height(0, SPECTRUM_BARS, 1.0, 0.0, false, false, true, 1.0), SPECTRUM_MIN);
+    }
+
+    #[test]
+    fn spectrum_bars_react_to_level() {
+        let quiet = spectrum_bar_height(0, SPECTRUM_BARS, 0.0, 0.0, true, false, true, 1.0);
+        let loud = spectrum_bar_height(0, SPECTRUM_BARS, 1.0, 0.0, true, false, true, 1.0);
+        assert_eq!(quiet, SPECTRUM_MIN);
+        assert!(loud > quiet, "spectrum bars must rise with voice level");
+    }
+
+    // ── Retro terminal (terminal) ───────────────────────────────────────
+
+    #[test]
+    fn ascii_meter_is_always_the_configured_width() {
+        for &(rec, proc, ready) in &[(true, false, true), (true, false, false), (false, true, true), (false, false, true)] {
+            let m = ascii_meter(0.5, 1.0, rec, proc, ready);
+            assert_eq!(m.chars().count(), ASCII_METER_WIDTH);
+        }
+    }
+
+    #[test]
+    fn ascii_meter_fills_with_level_when_recording() {
+        assert_eq!(ascii_meter(0.0, 0.0, true, false, true), "·".repeat(ASCII_METER_WIDTH));
+        assert_eq!(ascii_meter(1.0, 0.0, true, false, true), "█".repeat(ASCII_METER_WIDTH));
+
+        let half = ascii_meter(0.5, 0.0, true, false, true);
+        let filled = half.chars().filter(|&c| c == '█').count();
+        assert_eq!(filled, ASCII_METER_WIDTH / 2);
+    }
+
+    #[test]
+    fn ascii_meter_scans_while_processing() {
+        let m = ascii_meter(0.5, 0.0, false, true, true);
+        assert_eq!(m.chars().filter(|&c| c == '█').count(), 1, "exactly one lit cell while scanning");
+
+        // The scanning position must move as phase advances.
+        let m2 = ascii_meter(0.5, 0.5, false, true, true);
+        assert_ne!(m, m2, "scanner must move over time");
+    }
+
+    // ── Analog VU (vinyl) ────────────────────────────────────────────────
+
+    #[test]
+    fn vu_target_angle_spans_the_dial() {
+        assert_eq!(vu_target_angle(0.0), VU_ANGLE_MIN);
+        assert_eq!(vu_target_angle(1.0), VU_ANGLE_MAX);
+        assert!(vu_target_angle(1.0) > vu_target_angle(0.0));
+    }
+
+    #[test]
+    fn vu_needle_starts_at_pivot_and_stays_on_radius() {
+        for angle in [VU_ANGLE_MIN, 0.0, VU_ANGLE_MAX] {
+            let path = vu_needle_path(angle);
+            assert!(path.starts_with(&format!("M {VU_PIVOT_X} {VU_PIVOT_Y}")));
+
+            let nums: Vec<f32> = path
+                .split_whitespace()
+                .filter_map(|t| t.parse::<f32>().ok())
+                .collect();
+            let (tx, ty) = (nums[2], nums[3]);
+            let dist = ((tx - VU_PIVOT_X).powi(2) + (ty - VU_PIVOT_Y).powi(2)).sqrt();
+            assert!((dist - VU_RADIUS).abs() < 0.2, "needle tip must sit on the dial radius, got {dist}");
+        }
+    }
+
+    #[test]
+    fn vu_needle_points_straight_up_at_zero_angle() {
+        let path = vu_needle_path(0.0);
+        let nums: Vec<f32> = path
+            .split_whitespace()
+            .filter_map(|t| t.parse::<f32>().ok())
+            .collect();
+        let (tx, ty) = (nums[2], nums[3]);
+        assert!((tx - VU_PIVOT_X).abs() < 0.01, "zero angle must point straight up");
+        assert!(ty < VU_PIVOT_Y, "needle tip must be above the pivot");
     }
 }

--- a/src/lib/Overlay/MonoBars.svelte
+++ b/src/lib/Overlay/MonoBars.svelte
@@ -1,0 +1,232 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { listen } from "@tauri-apps/api/event";
+  import { status } from "../../stores/status";
+
+  let { recording = false, active = true } = $props();
+
+  const BAR_COUNT = 5;
+  const MONO_BAR_MIN = 8;
+  const MONO_BAR_MAX = 52;
+
+  let barHeights = $state<number[]>(Array(BAR_COUNT).fill(MONO_BAR_MIN));
+  let unlistenAudioLevel: (() => void) | null = null;
+  let animationFrameId: number;
+  let targetVolume = 0;
+  let currentVolume = 0;
+
+  const isReady = $derived($status.audio_ready !== false);
+  const targetLabel = $derived($status.active_target_label || "Focused Window");
+
+  // Mirrors mono_bar_height() in src-tauri/src/overlay.rs
+  function monoBarHeight(
+    i: number,
+    n: number,
+    level: number,
+    phase: number,
+    rec: boolean,
+    proc: boolean,
+    ready: boolean,
+    noise: number
+  ): number {
+    const mid = (n - 1) / 2;
+    const envelope = 1.0 - (Math.abs(i - mid) / (mid + 1)) * 0.4;
+    let amp: number;
+    if (proc) {
+      amp = (Math.sin(phase * 4.0 - i * 0.85) * 0.5 + 0.5) * envelope;
+    } else if (rec && !ready) {
+      amp = 0;
+    } else if (rec) {
+      const ripple = Math.sin(phase * 3.0 - i * 0.8);
+      amp = Math.min(1, Math.max(0, level * envelope * (0.9 + 0.1 * ripple) * (0.85 + 0.3 * noise)));
+    } else {
+      amp = 0;
+    }
+    return MONO_BAR_MIN + (MONO_BAR_MAX - MONO_BAR_MIN) * amp;
+  }
+
+  onMount(() => {
+    listen<number>("audio-level", (event) => {
+      targetVolume = Math.min(1.0, event.payload * 100.0);
+    }).then((unlisten) => {
+      unlistenAudioLevel = unlisten;
+    });
+
+    let phase = 0;
+
+    function update() {
+      phase += 0.016;
+      currentVolume += (targetVolume - currentVolume) * 0.35;
+      targetVolume *= 0.86;
+
+      const ready = $status.audio_ready !== false;
+      const heights = new Array(BAR_COUNT);
+      for (let i = 0; i < BAR_COUNT; i++) {
+        heights[i] = monoBarHeight(i, BAR_COUNT, currentVolume, phase, recording, $status.processing, ready, Math.random());
+      }
+      barHeights = heights;
+
+      animationFrameId = requestAnimationFrame(update);
+    }
+    animationFrameId = requestAnimationFrame(update);
+
+    return () => {
+      if (unlistenAudioLevel) unlistenAudioLevel();
+      cancelAnimationFrame(animationFrameId);
+    };
+  });
+</script>
+
+<div class="mono" class:on={active}>
+  <div class="status">
+    <span
+      class="dot"
+      class:lit={!$status.processing && !(recording && !isReady)}
+      class:processing={$status.processing}
+      class:standby={recording && !isReady}
+    ></span>
+    <span class="status-text">
+      {#if $status.processing}
+        PROCESSING
+      {:else if recording && !isReady}
+        STANDBY
+      {:else}
+        LISTENING
+      {/if}
+    </span>
+  </div>
+
+  <div class="bars">
+    {#each barHeights as h}
+      <div
+        class="bar"
+        class:dim={recording && !isReady}
+        class:processing={$status.processing}
+        style="height: {h}px"
+      ></div>
+    {/each}
+  </div>
+
+  <div class="baseline"></div>
+  <div class="target">{targetLabel}</div>
+</div>
+
+<style>
+  /* Hyper-minimal black & white panel: fades in/out, no motion or color */
+  .mono {
+    width: 190px;
+    height: 112px;
+    background: #000000;
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    border-radius: 6px;
+    position: relative;
+    font-family: 'Outfit', 'Inter', sans-serif;
+    pointer-events: none;
+    user-select: none;
+    opacity: 0;
+    transition: opacity 0.28s ease;
+  }
+
+  .mono.on {
+    opacity: 1;
+  }
+
+  .status {
+    position: absolute;
+    left: 18px;
+    top: 14px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 3px;
+    border: 1px solid rgba(245, 245, 245, 0.7);
+    background: transparent;
+  }
+
+  .dot.lit {
+    background: #f5f5f5;
+    animation: mono-blink 1.2s ease-in-out infinite;
+  }
+
+  .dot.processing {
+    animation: mono-blink-dim 1.2s ease-in-out infinite;
+  }
+
+  .dot.standby {
+    opacity: 0.35;
+  }
+
+  @keyframes mono-blink {
+    0%, 100% { opacity: 0.5; }
+    50% { opacity: 1; }
+  }
+
+  @keyframes mono-blink-dim {
+    0%, 100% { opacity: 0.3; }
+    50% { opacity: 1; }
+  }
+
+  .status-text {
+    color: rgba(255, 255, 255, 0.55);
+    font-size: 8px;
+    font-weight: 700;
+    letter-spacing: 0.25em;
+  }
+
+  .bars {
+    position: absolute;
+    left: 18px;
+    bottom: 28px;
+    width: 154px;
+    height: 52px;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    gap: 14px;
+  }
+
+  .bar {
+    width: 12px;
+    background: #f5f5f5;
+    border-radius: 6px;
+    opacity: 1;
+    transition: height 0.05s linear, opacity 0.2s ease;
+  }
+
+  .bar.dim {
+    opacity: 0.3;
+  }
+
+  .bar.processing {
+    opacity: 0.55;
+  }
+
+  .baseline {
+    position: absolute;
+    left: 18px;
+    bottom: 28px;
+    width: 154px;
+    height: 1px;
+    background: rgba(255, 255, 255, 0.12);
+  }
+
+  .target {
+    position: absolute;
+    left: 18px;
+    bottom: 6px;
+    width: 154px;
+    text-align: center;
+    color: rgba(255, 255, 255, 0.4);
+    font-size: 8.5px;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+</style>

--- a/src/lib/Overlay/Overlay.svelte
+++ b/src/lib/Overlay/Overlay.svelte
@@ -8,6 +8,10 @@
   import Waveform from "./Waveform.svelte";
   import Pulse from "./Pulse.svelte";
   import BlueWave from "./BlueWave.svelte";
+  import MonoBars from "./MonoBars.svelte";
+  import Spectrum from "./Spectrum.svelte";
+  import Terminal from "./Terminal.svelte";
+  import Vinyl from "./Vinyl.svelte";
 
   interface CustomOverlay {
     name: string;
@@ -181,6 +185,14 @@
       <Pulse recording={$recording} active={animateActive} />
     {:else if $config.ui.overlay_style === "blue_wave"}
       <BlueWave recording={$recording} speaking={$speaking} active={animateActive} />
+    {:else if $config.ui.overlay_style === "mono_bars"}
+      <MonoBars recording={$recording} active={animateActive} />
+    {:else if $config.ui.overlay_style === "spectrum"}
+      <Spectrum recording={$recording} active={animateActive} />
+    {:else if $config.ui.overlay_style === "terminal"}
+      <Terminal recording={$recording} active={animateActive} />
+    {:else if $config.ui.overlay_style === "vinyl"}
+      <Vinyl recording={$recording} active={animateActive} />
     {:else if activeCustomOverlay}
       {@html `<style>${activeCustomOverlay.css}</style>`}
       <div class="custom-overlay-content" class:active={animateActive} use:executeScripts>

--- a/src/lib/Overlay/Spectrum.svelte
+++ b/src/lib/Overlay/Spectrum.svelte
@@ -1,0 +1,245 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { listen } from "@tauri-apps/api/event";
+  import { status } from "../../stores/status";
+
+  let { recording = false, active = true } = $props();
+
+  const SPECTRUM_BARS = 16;
+  const SPECTRUM_MIN = 6;
+  const SPECTRUM_MAX = 96;
+
+  let barHeights = $state<number[]>(Array(SPECTRUM_BARS).fill(SPECTRUM_MIN));
+  let unlistenAudioLevel: (() => void) | null = null;
+  let animationFrameId: number;
+  let targetVolume = 0;
+  let currentVolume = 0;
+
+  const isReady = $derived($status.audio_ready !== false);
+  const targetLabel = $derived($status.active_target_label || "Focused Window");
+
+  // Mirrors spectrum_bar_height() in src-tauri/src/overlay.rs
+  function spectrumBarHeight(
+    i: number,
+    n: number,
+    level: number,
+    phase: number,
+    rec: boolean,
+    proc: boolean,
+    ready: boolean,
+    noise: number
+  ): number {
+    const band = i / (n - 1);
+    let amp: number;
+    if (proc) {
+      amp = Math.pow(Math.sin(phase * 2.4 - band * 6.0) * 0.5 + 0.5, 1.5);
+    } else if (rec && !ready) {
+      amp = noise * 0.06;
+    } else if (rec) {
+      const bandFreq = 2.0 + band * 9.0;
+      const bandPhase = i * 0.7;
+      const wobble = Math.sin(phase * bandFreq + bandPhase) * 0.5 + 0.5;
+      const bandGain = 1.0 - band * 0.35;
+      amp = Math.min(1, Math.max(0, level * bandGain * (0.35 + 0.65 * wobble) * (0.7 + 0.6 * noise)));
+    } else {
+      amp = 0;
+    }
+    return SPECTRUM_MIN + (SPECTRUM_MAX - SPECTRUM_MIN) * amp;
+  }
+
+  onMount(() => {
+    listen<number>("audio-level", (event) => {
+      targetVolume = Math.min(1.0, event.payload * 100.0);
+    }).then((unlisten) => {
+      unlistenAudioLevel = unlisten;
+    });
+
+    let phase = 0;
+
+    function update() {
+      phase += 0.016;
+      currentVolume += (targetVolume - currentVolume) * 0.35;
+      targetVolume *= 0.86;
+
+      const ready = $status.audio_ready !== false;
+      const heights = new Array(SPECTRUM_BARS);
+      for (let i = 0; i < SPECTRUM_BARS; i++) {
+        heights[i] = spectrumBarHeight(i, SPECTRUM_BARS, currentVolume, phase, recording, $status.processing, ready, Math.random());
+      }
+      barHeights = heights;
+
+      animationFrameId = requestAnimationFrame(update);
+    }
+    animationFrameId = requestAnimationFrame(update);
+
+    return () => {
+      if (unlistenAudioLevel) unlistenAudioLevel();
+      cancelAnimationFrame(animationFrameId);
+    };
+  });
+</script>
+
+<div class="spectrum" class:on={active}>
+  <div class="header">
+    <span class="led" class:processing={$status.processing} class:standby={recording && !isReady}></span>
+    <span class="title">SPECTRUM // EQ-16</span>
+    <span class="subtitle">
+      {#if $status.processing}
+        · ANALYZING
+      {:else if recording && !isReady}
+        · WARMING UP
+      {:else}
+        · LIVE
+      {/if}
+    </span>
+    <span class="spacer"></span>
+    <span class="chip">
+      <span class="tgt">OUT ▸</span>
+      <span class="tgt-label">{targetLabel}</span>
+    </span>
+  </div>
+
+  <div class="floor"></div>
+  <div class="bars">
+    {#each barHeights as h}
+      <div class="bar" style="height: {h}px; opacity: {0.45 + 0.55 * (h / SPECTRUM_MAX)}"></div>
+    {/each}
+  </div>
+</div>
+
+<style>
+  /* Neon equalizer: rises up from the floor on load, sinks back on unload */
+  .spectrum {
+    width: 440px;
+    height: 132px;
+    background: linear-gradient(160deg, #1b0c2e 0%, #0a0614 100%);
+    border: 1px solid rgba(232, 121, 249, 0.25);
+    border-radius: 16px;
+    box-shadow: 0 0 26px rgba(192, 132, 252, 0.22);
+    position: relative;
+    overflow: hidden;
+    pointer-events: none;
+    user-select: none;
+    transform: scaleY(0.04);
+    transform-origin: bottom center;
+    opacity: 0;
+    transition:
+      transform 0.34s cubic-bezier(0.175, 0.885, 0.32, 1.2),
+      opacity 0.16s ease;
+  }
+
+  .spectrum.on {
+    transform: scaleY(1);
+    opacity: 1;
+  }
+
+  .header {
+    position: absolute;
+    left: 20px;
+    top: 12px;
+    right: 20px;
+    height: 16px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-family: 'Outfit', 'Inter', sans-serif;
+  }
+
+  .led {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: #e879f9;
+    box-shadow: 0 0 6px #e879f9;
+    animation: spectrum-blink 1.2s ease-in-out infinite;
+    flex-shrink: 0;
+  }
+
+  .led.standby {
+    background: #f59e0b;
+    box-shadow: 0 0 6px #f59e0b;
+  }
+
+  .led.processing {
+    background: #38bdf8;
+    box-shadow: 0 0 6px #38bdf8;
+  }
+
+  @keyframes spectrum-blink {
+    0%, 100% { opacity: 0.4; }
+    50% { opacity: 1; }
+  }
+
+  .title {
+    color: #f5d0fe;
+    font-size: 10px;
+    font-weight: 800;
+    letter-spacing: 0.15em;
+  }
+
+  .subtitle {
+    color: rgba(245, 208, 254, 0.35);
+    font-size: 9px;
+    font-weight: 500;
+    letter-spacing: 0.1em;
+  }
+
+  .spacer {
+    flex: 1;
+  }
+
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    background: rgba(232, 121, 249, 0.08);
+    border: 1px solid rgba(232, 121, 249, 0.3);
+    border-radius: 4px;
+    padding: 2px 8px;
+  }
+
+  .tgt {
+    color: #e879f9;
+    font-size: 8.5px;
+    font-weight: 800;
+    letter-spacing: 0.1em;
+  }
+
+  .tgt-label {
+    color: #fae8ff;
+    font-size: 8.5px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    max-width: 150px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .bars {
+    position: absolute;
+    left: 20px;
+    right: 20px;
+    bottom: 16px;
+    display: flex;
+    gap: 6.5px;
+    align-items: flex-end;
+    height: 96px;
+  }
+
+  .bar {
+    width: 19px;
+    border-radius: 3px;
+    background: linear-gradient(180deg, #f0abfc 0%, #c084fc 45%, #38bdf8 100%);
+    transition: height 0.05s linear;
+  }
+
+  .floor {
+    position: absolute;
+    left: 20px;
+    right: 20px;
+    bottom: 16px;
+    height: 1px;
+    background: rgba(232, 121, 249, 0.15);
+  }
+</style>

--- a/src/lib/Overlay/Terminal.svelte
+++ b/src/lib/Overlay/Terminal.svelte
@@ -1,0 +1,186 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { listen } from "@tauri-apps/api/event";
+  import { status } from "../../stores/status";
+
+  let { recording = false, active = true } = $props();
+
+  const ASCII_METER_WIDTH = 20;
+
+  let meter = $state("·".repeat(ASCII_METER_WIDTH));
+  let cursorOn = $state(false);
+  let unlistenAudioLevel: (() => void) | null = null;
+  let animationFrameId: number;
+  let targetVolume = 0;
+  let currentVolume = 0;
+
+  const isReady = $derived($status.audio_ready !== false);
+  const targetLabel = $derived($status.active_target_label || "Focused Window");
+
+  // Mirrors ascii_meter() in src-tauri/src/overlay.rs
+  function asciiMeter(level: number, phase: number, rec: boolean, proc: boolean, ready: boolean): string {
+    const w = ASCII_METER_WIDTH;
+    if (proc) {
+      const cycle = 2 * w;
+      const raw = Math.floor(phase * 10) % cycle;
+      const pos = raw < w ? raw : cycle - 1 - raw;
+      return Array.from({ length: w }, (_, i) => (i === pos ? "█" : "·")).join("");
+    } else if (rec && !ready) {
+      return Array.from({ length: w }, (_, i) => (i % 4 === 0 ? "·" : " ")).join("");
+    } else if (rec) {
+      const filled = Math.round(Math.min(1, Math.max(0, level)) * w);
+      return Array.from({ length: w }, (_, i) => (i < filled ? "█" : "·")).join("");
+    } else {
+      return "·".repeat(w);
+    }
+  }
+
+  onMount(() => {
+    listen<number>("audio-level", (event) => {
+      targetVolume = Math.min(1.0, event.payload * 100.0);
+    }).then((unlisten) => {
+      unlistenAudioLevel = unlisten;
+    });
+
+    let phase = 0;
+
+    function update() {
+      phase += 0.016;
+      currentVolume += (targetVolume - currentVolume) * 0.35;
+      targetVolume *= 0.86;
+
+      const ready = $status.audio_ready !== false;
+      meter = asciiMeter(currentVolume, phase, recording, $status.processing, ready);
+      cursorOn = Math.sin(phase * 5.5) > 0;
+
+      animationFrameId = requestAnimationFrame(update);
+    }
+    animationFrameId = requestAnimationFrame(update);
+
+    return () => {
+      if (unlistenAudioLevel) unlistenAudioLevel();
+      cancelAnimationFrame(animationFrameId);
+    };
+  });
+</script>
+
+<div class="terminal" class:on={active}>
+  <div class="titlebar">
+    <span class="dot"></span>
+    <span class="dot"></span>
+    <span class="dot"></span>
+    <span class="titletext">VOXCTRL — /dev/mic0</span>
+  </div>
+  <div class="body">
+    <div class="line1">$ voxctrl listen --target "{targetLabel}"</div>
+    <div class="line2" class:processing={$status.processing} class:standby={recording && !isReady}>
+      {#if $status.processing}
+        [PROC]
+      {:else if recording && !isReady}
+        [INIT]
+      {:else}
+        [REC ]
+      {/if}
+      {meter}
+    </div>
+    <div class="line3">
+      {#if $status.processing}
+        transcribing audio stream
+      {:else if recording && !isReady}
+        connecting input device
+      {:else}
+        streaming to output
+      {/if}{cursorOn ? "_" : " "}
+    </div>
+  </div>
+</div>
+
+<style>
+  /* DOS-blue console: drops down from the top edge on load, retracts on unload */
+  .terminal {
+    width: 380px;
+    height: 130px;
+    background: #0d1b4c;
+    border: 1.5px solid rgba(125, 211, 252, 0.35);
+    border-radius: 8px;
+    box-shadow: 0 0 20px rgba(8, 15, 48, 0.6);
+    overflow: hidden;
+    pointer-events: none;
+    user-select: none;
+    transform: scaleY(0.04);
+    transform-origin: top center;
+    opacity: 0;
+    transition:
+      transform 0.34s cubic-bezier(0.175, 0.885, 0.32, 1.2),
+      opacity 0.16s ease;
+  }
+
+  .terminal.on {
+    transform: scaleY(1);
+    opacity: 1;
+  }
+
+  .titlebar {
+    height: 24px;
+    background: rgba(255, 255, 255, 0.06);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 0 12px;
+    font-family: 'Outfit', 'Inter', sans-serif;
+  }
+
+  .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.22);
+  }
+
+  .titletext {
+    color: rgba(224, 242, 254, 0.55);
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+  }
+
+  .body {
+    padding: 12px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .line1 {
+    color: rgba(186, 230, 253, 0.7);
+    font-size: 10px;
+    font-weight: 600;
+    font-family: 'SF Mono', Menlo, Consolas, monospace;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .line2 {
+    color: #ffffff;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    font-family: 'SF Mono', Menlo, Consolas, monospace;
+  }
+
+  .line2.standby {
+    color: #fcd34d;
+  }
+
+  .line2.processing {
+    color: #7dd3fc;
+  }
+
+  .line3 {
+    color: rgba(186, 230, 253, 0.45);
+    font-size: 9.5px;
+    font-weight: 500;
+    font-family: 'SF Mono', Menlo, Consolas, monospace;
+  }
+</style>

--- a/src/lib/Overlay/Vinyl.svelte
+++ b/src/lib/Overlay/Vinyl.svelte
@@ -1,0 +1,275 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { listen } from "@tauri-apps/api/event";
+  import { status } from "../../stores/status";
+
+  let { recording = false, active = true } = $props();
+
+  // Mirrors the analog VU needle constants in src-tauri/src/overlay.rs
+  const VU_PIVOT_X = 144;
+  const VU_PIVOT_Y = 70;
+  const VU_RADIUS = 58;
+  const VU_ANGLE_MIN = -0.95;
+  const VU_ANGLE_MAX = 0.95;
+  const DT = 0.016;
+
+  let needlePath = $state(vuNeedlePath(VU_ANGLE_MIN));
+  let unlistenAudioLevel: (() => void) | null = null;
+  let animationFrameId: number;
+  let targetVolume = 0;
+  let currentVolume = 0;
+
+  const isReady = $derived($status.audio_ready !== false);
+  const targetLabel = $derived($status.active_target_label || "Focused Window");
+
+  function vuTargetAngle(level: number): number {
+    return VU_ANGLE_MIN + Math.min(1, Math.max(0, level)) * (VU_ANGLE_MAX - VU_ANGLE_MIN);
+  }
+
+  function vuNeedlePath(angle: number): string {
+    const x = VU_PIVOT_X + Math.sin(angle) * VU_RADIUS;
+    const y = VU_PIVOT_Y - Math.cos(angle) * VU_RADIUS;
+    return `M ${VU_PIVOT_X} ${VU_PIVOT_Y} L ${x.toFixed(1)} ${y.toFixed(1)}`;
+  }
+
+  // Mirrors spring() in src-tauri/src/overlay.rs
+  function spring(state: { x: number; v: number }, target: number, dt: number) {
+    const omega = 16.0;
+    const zeta = 0.78;
+    const a = omega * omega * (target - state.x) - 2.0 * zeta * omega * state.v;
+    state.v += a * dt;
+    state.x += state.v * dt;
+    if (Math.abs(state.x - target) < 0.001 && Math.abs(state.v) < 0.02) {
+      state.x = target;
+      state.v = 0;
+    }
+  }
+
+  onMount(() => {
+    listen<number>("audio-level", (event) => {
+      targetVolume = Math.min(1.0, event.payload * 100.0);
+    }).then((unlisten) => {
+      unlistenAudioLevel = unlisten;
+    });
+
+    let phase = 0;
+    const needle = { x: VU_ANGLE_MIN, v: 0 };
+
+    function update() {
+      phase += DT;
+      currentVolume += (targetVolume - currentVolume) * 0.35;
+      targetVolume *= 0.86;
+
+      const ready = $status.audio_ready !== false;
+      let target: number;
+      if ($status.processing) {
+        target = vuTargetAngle(0.3 + 0.25 * Math.abs(Math.sin(phase * 2.0)));
+      } else if (recording && ready) {
+        target = vuTargetAngle(currentVolume);
+      } else {
+        target = VU_ANGLE_MIN;
+      }
+      spring(needle, target, DT);
+      needlePath = vuNeedlePath(needle.x);
+
+      animationFrameId = requestAnimationFrame(update);
+    }
+    animationFrameId = requestAnimationFrame(update);
+
+    return () => {
+      if (unlistenAudioLevel) unlistenAudioLevel();
+      cancelAnimationFrame(animationFrameId);
+    };
+  });
+</script>
+
+<div class="vinyl" class:on={active}>
+  <div class="header">
+    <span class="vu-label">VU</span>
+    <span class="subtitle">
+      {#if $status.processing}
+        ANALOG // PROCESSING
+      {:else if recording && !isReady}
+        ANALOG // WARMING UP
+      {:else}
+        ANALOG // INPUT LEVEL
+      {/if}
+    </span>
+    <span class="spacer"></span>
+    <span class="led" class:processing={$status.processing} class:standby={recording && !isReady}></span>
+  </div>
+
+  <div class="face">
+    <div class="tick" style="left: 18px;"></div>
+    <div class="tick" style="left: 60px;"></div>
+    <div class="tick" style="left: 102px;"></div>
+    <div class="tick" style="left: 144px;"></div>
+    <div class="tick" style="left: 186px;"></div>
+    <div class="tick" style="left: 228px;"></div>
+    <div class="tick red" style="left: 270px;"></div>
+    <div class="scale-label" style="left: 12px; top: 40px;">-20</div>
+    <div class="scale-label" style="left: 122px; top: 40px;">0</div>
+    <div class="scale-label red" style="left: 252px; top: 34px;">+3</div>
+
+    <svg class="needle-svg" viewBox="0 0 288 72" preserveAspectRatio="none">
+      <path class="needle" d={needlePath} />
+    </svg>
+    <div class="pivot"></div>
+  </div>
+
+  <div class="target">{targetLabel}</div>
+</div>
+
+<style>
+  /* Vintage VU meter: fades in and settles slightly downward on load */
+  .vinyl {
+    width: 320px;
+    height: 132px;
+    background: linear-gradient(180deg, #f7ecd9 0%, #e7d6b8 100%);
+    border: 1.5px solid rgba(120, 89, 53, 0.35);
+    border-radius: 14px;
+    box-shadow: 0 0 22px rgba(0, 0, 0, 0.35);
+    position: relative;
+    pointer-events: none;
+    user-select: none;
+    transform: translateY(16px);
+    opacity: 0;
+    transition:
+      transform 0.34s cubic-bezier(0.175, 0.885, 0.32, 1.2),
+      opacity 0.28s ease;
+  }
+
+  .vinyl.on {
+    transform: translateY(0);
+    opacity: 1;
+  }
+
+  .header {
+    position: absolute;
+    left: 16px;
+    top: 12px;
+    right: 16px;
+    height: 14px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-family: 'Outfit', 'Inter', sans-serif;
+  }
+
+  .vu-label {
+    color: #5b4530;
+    font-size: 12px;
+    font-weight: 900;
+    letter-spacing: 0.17em;
+  }
+
+  .subtitle {
+    color: rgba(91, 69, 48, 0.55);
+    font-size: 8px;
+    font-weight: 700;
+    letter-spacing: 0.19em;
+  }
+
+  .spacer {
+    flex: 1;
+  }
+
+  .led {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: #dc2626;
+    box-shadow: 0 0 6px #dc2626;
+    animation: vinyl-blink 1.2s ease-in-out infinite;
+    flex-shrink: 0;
+  }
+
+  .led.standby {
+    background: #f59e0b;
+    box-shadow: 0 0 6px #f59e0b;
+  }
+
+  .led.processing {
+    background: #38bdf8;
+    box-shadow: 0 0 6px #38bdf8;
+  }
+
+  @keyframes vinyl-blink {
+    0%, 100% { opacity: 0.4; }
+    50% { opacity: 1; }
+  }
+
+  .face {
+    position: absolute;
+    left: 16px;
+    top: 30px;
+    width: 288px;
+    height: 72px;
+    background: rgba(255, 252, 244, 0.55);
+    border: 1px solid rgba(120, 89, 53, 0.25);
+    border-radius: 8px;
+  }
+
+  .tick {
+    position: absolute;
+    top: 14px;
+    width: 1.5px;
+    height: 22px;
+    background: rgba(91, 69, 48, 0.4);
+  }
+
+  .tick.red {
+    background: #dc2626;
+    height: 30px;
+  }
+
+  .scale-label {
+    position: absolute;
+    color: rgba(91, 69, 48, 0.5);
+    font-size: 7px;
+    font-family: 'Outfit', 'Inter', sans-serif;
+  }
+
+  .scale-label.red {
+    color: #dc2626;
+    font-weight: 800;
+  }
+
+  .needle-svg {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+  }
+
+  .needle {
+    fill: none;
+    stroke: #292524;
+    stroke-width: 2px;
+    vector-effect: non-scaling-stroke;
+  }
+
+  .pivot {
+    position: absolute;
+    left: 138px;
+    top: 64px;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: #292524;
+  }
+
+  .target {
+    position: absolute;
+    left: 16px;
+    bottom: 12px;
+    width: 288px;
+    color: rgba(91, 69, 48, 0.65);
+    font-size: 9.5px;
+    font-weight: 700;
+    font-family: 'Outfit', 'Inter', sans-serif;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+</style>

--- a/src/lib/Settings/VisualTab.svelte
+++ b/src/lib/Settings/VisualTab.svelte
@@ -29,6 +29,10 @@
     { value: "waveform", label: "Waveform" },
     { value: "pulse", label: "Pulse Ring" },
     { value: "blue_wave", label: "Ocean Wave" },
+    { value: "mono_bars", label: "Mono Bars" },
+    { value: "spectrum", label: "Neon Spectrum" },
+    { value: "terminal", label: "Retro Terminal" },
+    { value: "vinyl", label: "Analog VU" },
     ...customOverlays.map(o => ({ value: o.name, label: o.name }))
   ]);
 


### PR DESCRIPTION
## Summary
- Adds 4 new overlay styles, distinct from the existing Waveform/Pulse/Ocean Wave/Voice Card:
  - **Mono Bars** (`mono_bars`) — the requested hyper-minimal black & white 5-bar level meter, centre-weighted with a gentle ripple, no color/motion in its reveal (pure fade).
  - **Neon Spectrum** (`spectrum`) — a 16-band magenta→cyan equalizer panel that rises up out of the floor on load.
  - **Retro Terminal** (`terminal`) — a DOS-blue console with a block-character ASCII meter, drops down from the top edge on load.
  - **Analog VU** (`vinyl`) — a warm vintage VU meter with a spring-loaded needle (reuses the existing critically-damped spring physics) sweeping a -20..+3 dial.
- Implemented in both the native Slint overlay helper (`src-tauri/src/overlay.rs`) and the Svelte web overlay (`src/lib/Overlay/*.svelte`), with formulas mirrored 1:1 between the two.
- Wired into `VisualTab.svelte` (style picker), `Overlay.svelte` (routing), and `commands.rs` (reserved style names, to avoid collisions with custom overlays).
- Documented each new style in `docs/overlays.md` alongside the existing four.

## Test plan
- [x] `cargo test --bin voxctrl-overlay` — all 32 tests pass (12 new tests covering the new visualizer formulas).
- [x] `cargo check --bin voxctrl-overlay` — compiles cleanly.
- [x] `npx svelte-check` — no new type errors introduced (remaining errors are pre-existing, in unrelated files).
- [x] `npm run build` — frontend builds successfully.
- [ ] Manual visual check of each new style in the running app (overlay window + settings dropdown).

https://claude.ai/code/session_011rYqDeWdrtKZmGChABaxyR


---
_Generated by [Claude Code](https://claude.ai/code/session_011rYqDeWdrtKZmGChABaxyR)_