### PR TITLE
fix: Wayland dictation injection — overlay focus theft, modifier-release timing, and overlay toggle

### DIFF
--- a/crates/voxctrl-hotkeys/src/linux.rs
+++ b/crates/voxctrl-hotkeys/src/linux.rs
@@ -291,7 +291,7 @@ fn handle_press(
 fn handle_release(
     key: &str,
     states: &mut Vec<BindingState>,
-    _pressed: &HashSet<String>,
+    pressed: &HashSet<String>,
     tx: &GestureSender,
 ) {
     // Collect keys for any currently active DoubleTapHold gestures
@@ -311,16 +311,37 @@ fn handle_release(
 
         match s.binding.gesture {
             GestureType::Hold => {
-                if let Some(cancel) = s.hold_cancel.take() {
+                // Is any *other* key of this binding still held? `pressed` still
+                // contains the key currently being released (the caller removes it
+                // only after this returns), so exclude it explicitly.
+                let others_still_held = s
+                    .binding
+                    .keys
+                    .iter()
+                    .any(|k| k.as_str() != key && pressed.contains(k));
+
+                if s.hold_active.load(std::sync::atomic::Ordering::SeqCst) {
+                    // Recording is active. Stop only once the *whole* combo has been
+                    // released. If we stopped on the first key-up, transcription could
+                    // be injected while a hotkey modifier (e.g. Super/Ctrl) is still
+                    // down — the Wayland compositor then interprets the synthetic
+                    // keystrokes as shortcuts and swallows them, so the text never
+                    // reaches the cursor. wtype cannot clear a physically-held
+                    // modifier, so the only reliable fix is to wait for full release.
+                    if !others_still_held {
+                        s.hold_cancel.take();
+                        s.hold_active.store(false, std::sync::atomic::Ordering::SeqCst);
+                        let _ = tx.send(GestureEvent {
+                            binding_id: s.binding.id.clone(),
+                            binding_label: s.binding.label.clone(),
+                            target_id: s.binding.target_ids_string(),
+                            kind: GestureKind::Stop,
+                        });
+                    }
+                } else if let Some(cancel) = s.hold_cancel.take() {
+                    // Still within the hold threshold (Start not yet fired).
+                    // Releasing any key breaks the pending combo, so cancel the timer.
                     cancel.cancel();
-                }
-                if s.hold_active.swap(false, std::sync::atomic::Ordering::SeqCst) {
-                    let _ = tx.send(GestureEvent {
-                        binding_id: s.binding.id.clone(),
-                        binding_label: s.binding.label.clone(),
-                        target_id: s.binding.target_ids_string(),
-                        kind: GestureKind::Stop,
-                    });
                 }
             }
             GestureType::DoubleTap => {
@@ -613,6 +634,47 @@ mod tests {
         // Assert we get GestureKind::Stop immediately on release
         let event = rx.recv().await.unwrap();
         assert_eq!(event.binding_id, "test_hold");
+        assert_eq!(event.kind, GestureKind::Stop);
+    }
+
+    #[tokio::test]
+    async fn test_hold_multikey_stops_only_on_full_release() {
+        // Regression: a Hold combo (Super+Space) must not emit Stop until *every*
+        // key is released. Stopping on the first key-up let transcription be
+        // injected while Super was still held, which Wayland compositors swallow
+        // as a shortcut — so the dictated text never reached the cursor.
+        let (tx, mut rx) = crate::channel();
+        let mut states = vec![make_test_binding(
+            "test_hold_combo",
+            GestureType::Hold,
+            vec!["KEY_LEFTMETA", "KEY_SPACE"],
+        )];
+        let mut pressed = HashSet::new();
+
+        // Press the full combo.
+        pressed.insert("KEY_LEFTMETA".to_string());
+        handle_press("KEY_LEFTMETA", &mut states, &pressed, &tx);
+        pressed.insert("KEY_SPACE".to_string());
+        handle_press("KEY_SPACE", &mut states, &pressed, &tx);
+
+        // Wait past the hold threshold to receive Start.
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        let event = rx.recv().await.unwrap();
+        assert_eq!(event.kind, GestureKind::Start);
+
+        // Release SPACE first while LEFTMETA is still held — must NOT stop yet.
+        handle_release("KEY_SPACE", &mut states, &pressed, &tx);
+        pressed.remove("KEY_SPACE");
+        assert!(
+            rx.try_recv().is_err(),
+            "Stop fired while a hotkey modifier was still held"
+        );
+
+        // Release the last key — now Stop should fire.
+        handle_release("KEY_LEFTMETA", &mut states, &pressed, &tx);
+        pressed.remove("KEY_LEFTMETA");
+        let event = rx.recv().await.unwrap();
+        assert_eq!(event.binding_id, "test_hold_combo");
         assert_eq!(event.kind, GestureKind::Stop);
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -95,6 +95,7 @@ pub async fn save_config(
     state.set_dynamic_stream(new_config.audio.dynamic_stream);
     state.set_input_device_index(new_config.audio.input_device_index);
     state.set_gain(new_config.audio.gain);
+    state.set_overlay_enabled(new_config.ui.show_overlay);
 
     // Dynamic TTS engine lifecycle management
     {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -175,6 +175,7 @@ pub fn run() {
         recording: Arc::new(AtomicBool::new(false)),
         processing: Arc::new(AtomicBool::new(false)),
         speaking: Arc::new(AtomicBool::new(false)),
+        overlay_enabled: Arc::new(AtomicBool::new(cfg_data.ui.show_overlay)),
         mcp_recording: Arc::new(AtomicBool::new(false)),
         audio_ready: Arc::new(AtomicBool::new(false)),
         dynamic_stream: Arc::new(AtomicBool::new(cfg_data.audio.dynamic_stream)),
@@ -591,10 +592,14 @@ pub fn run() {
                 while let Ok(level) = audio_level_rx.recv() {
                     let _ = handle.emit("audio-level", level);
 
-                    // Forward to Slint overlay channel
-                    let is_recording = state_for_audio_level.is_recording();
-                    let is_processing = state_for_audio_level.is_processing();
-                    let is_speaking = state_for_audio_level.is_speaking();
+                    // Forward to Slint overlay channel. When the overlay is
+                    // disabled, report idle state so the native window never maps
+                    // (a mapped overlay steals keyboard focus on Wayland and breaks
+                    // text injection).
+                    let overlay_on = state_for_audio_level.is_overlay_enabled();
+                    let is_recording = overlay_on && state_for_audio_level.is_recording();
+                    let is_processing = overlay_on && state_for_audio_level.is_processing();
+                    let is_speaking = overlay_on && state_for_audio_level.is_speaking();
                     let audio_ready = state_for_audio_level.is_audio_ready();
                     let active_target_label = {
                         if let Ok(label) = state_for_audio_level.active_binding_label.try_lock() {
@@ -839,12 +844,21 @@ pub fn run() {
                     });
                     let _ = handle.emit("status-tick", payload.clone());
 
-                    // Forward status to Slint overlay channel
+                    // Forward status to Slint overlay channel. When the overlay is
+                    // disabled, force the visibility flags off so the native window
+                    // never maps — a mapped overlay grabs keyboard focus on Wayland
+                    // and prevents transcribed text from reaching the cursor.
+                    let overlay_on = state_for_ticker.is_overlay_enabled();
                     let mut payload_value = payload.clone();
                     if let Some(obj) = payload_value.as_object_mut() {
                         obj.insert("type".to_string(), serde_json::json!("status"));
                         obj.insert("audio_level".to_string(), serde_json::json!(0.0));
                         obj.insert("overlay_style".to_string(), serde_json::json!(overlay_style));
+                        if !overlay_on {
+                            obj.insert("recording".to_string(), serde_json::json!(false));
+                            obj.insert("processing".to_string(), serde_json::json!(false));
+                            obj.insert("speaking".to_string(), serde_json::json!(false));
+                        }
                     }
                     if let Ok(json_str) = serde_json::to_string(&payload_value) {
                         let _ = state_for_ticker.overlay_tx.send(json_str);
@@ -1173,6 +1187,7 @@ mod tests {
             recording: Arc::new(AtomicBool::new(false)),
             processing: Arc::new(AtomicBool::new(false)),
             speaking: Arc::new(AtomicBool::new(false)),
+            overlay_enabled: Arc::new(AtomicBool::new(true)),
             mcp_recording: Arc::new(AtomicBool::new(false)),
             audio_ready: Arc::new(AtomicBool::new(false)),
             dynamic_stream: Arc::new(AtomicBool::new(false)),

--- a/src-tauri/src/overlay.rs
+++ b/src-tauri/src/overlay.rs
@@ -1449,6 +1449,7 @@ fn main() {
     let mut vu_vel = 0.0_f32;
     let mut lcg_state = 12345_u32;
     let mut shown = false;
+    let mut idle = false;
 
     const DT: f32 = 0.016;
 
@@ -1487,14 +1488,17 @@ fn main() {
             (lcg_state >> 8) as f32 / ((u32::MAX >> 8) as f32)
         };
 
-        // ── Window visibility (kept alive through the unload anim) ──
-        let visible_needed = active_main || active_pill || reveal_main > 0.004 || reveal_pill > 0.004;
-        if visible_needed && !shown {
+        // ── Window mapping ──────────────────────────────────────────────
+        // Map the overlay exactly once and keep it mapped for the lifetime of
+        // the process. On Wayland, hide()/show() re-maps the surface and the
+        // compositor re-grabs keyboard focus for the overlay on every dictation,
+        // stealing focus from the user's window so injected text never reaches
+        // the cursor. Keeping the window mapped (transparent when idle) avoids
+        // the per-dictation focus grab entirely.
+        if !shown {
             if let Err(e) = ui.show() {
                 eprintln!("[overlay] Failed to show window: {:?}", e);
             }
-            // Re-assert pass-through + always-on-top every time the window
-            // (re)appears — some WMs reset these across hide/show cycles.
             ui.window().with_winit_window(|w| {
                 if let Err(e) = w.set_cursor_hittest(false) {
                     eprintln!("[overlay] Failed to make window click-through: {:?}", e);
@@ -1502,16 +1506,23 @@ fn main() {
                 w.set_window_level(i_slint_backend_winit::winit::window::WindowLevel::AlwaysOnTop);
             });
             shown = true;
-        } else if !visible_needed && shown {
-            if let Err(e) = ui.hide() {
-                eprintln!("[overlay] Failed to hide window: {:?}", e);
-            }
-            shown = false;
         }
 
-        if !shown {
+        // When fully idle, push a single transparent frame and then stop
+        // updating, so the still-mapped window stays invisible without driving
+        // continuous redraws.
+        let visible_needed = active_main || active_pill || reveal_main > 0.004 || reveal_pill > 0.004;
+        if !visible_needed {
+            if !idle {
+                ui.set_reveal_main(0.0);
+                ui.set_reveal_pill(0.0);
+                ui.set_level(0.0);
+                idle = true;
+            }
             return;
         }
+        idle = false;
+
         if tx > -10000 {
             ui.window().set_position(slint::PhysicalPosition::new(tx, ty));
         }

--- a/src-tauri/src/overlay.rs
+++ b/src-tauri/src/overlay.rs
@@ -1489,13 +1489,17 @@ fn main() {
         };
 
         // ── Window mapping ──────────────────────────────────────────────
-        // Map the overlay exactly once and keep it mapped for the lifetime of
-        // the process. On Wayland, hide()/show() re-maps the surface and the
-        // compositor re-grabs keyboard focus for the overlay on every dictation,
+        // Map the overlay lazily the first time it is actually needed, then
+        // keep it mapped for the lifetime of the process. On Wayland,
+        // hide()/show() re-maps the surface and the compositor (KWin) grabs
+        // keyboard focus for the freshly-mapped overlay on every dictation —
         // stealing focus from the user's window so injected text never reaches
-        // the cursor. Keeping the window mapped (transparent when idle) avoids
-        // the per-dictation focus grab entirely.
-        if !shown {
+        // the cursor. Mapping once (with real content) and never unmapping
+        // avoids the per-dictation focus grab; when idle we simply render a
+        // transparent frame instead of hiding.
+        let visible_needed = active_main || active_pill || reveal_main > 0.004 || reveal_pill > 0.004;
+
+        if visible_needed && !shown {
             if let Err(e) = ui.show() {
                 eprintln!("[overlay] Failed to show window: {:?}", e);
             }
@@ -1508,10 +1512,13 @@ fn main() {
             shown = true;
         }
 
-        // When fully idle, push a single transparent frame and then stop
-        // updating, so the still-mapped window stays invisible without driving
-        // continuous redraws.
-        let visible_needed = active_main || active_pill || reveal_main > 0.004 || reveal_pill > 0.004;
+        // Nothing has needed the overlay yet — leave it unmapped.
+        if !shown {
+            return;
+        }
+
+        // Mapped but idle: push a single transparent frame, then stop updating
+        // so the window stays invisible without driving continuous redraws.
         if !visible_needed {
             if !idle {
                 ui.set_reveal_main(0.0);

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -16,6 +16,9 @@ pub struct AppState {
     pub processing: Arc<AtomicBool>,
     /// True while TTS is playing back
     pub speaking: Arc<AtomicBool>,
+    /// Live mirror of `ui.show_overlay` so the hot status-forwarding loops can
+    /// gate the native overlay without locking the config on every audio sample.
+    pub overlay_enabled: Arc<AtomicBool>,
     /// True while MCP server is actively recording/listening to the microphone
     pub mcp_recording: Arc<AtomicBool>,
     /// True when dynamic stream has successfully opened and is active (Option A)
@@ -127,6 +130,14 @@ impl AppState {
 
     pub fn set_speaking(&self, v: bool) {
         self.speaking.store(v, Ordering::SeqCst);
+    }
+
+    pub fn is_overlay_enabled(&self) -> bool {
+        self.overlay_enabled.load(Ordering::SeqCst)
+    }
+
+    pub fn set_overlay_enabled(&self, v: bool) {
+        self.overlay_enabled.store(v, Ordering::SeqCst);
     }
 
     pub fn is_mcp_recording(&self) -> bool {

--- a/src/lib/Settings/GeneralTab.svelte
+++ b/src/lib/Settings/GeneralTab.svelte
@@ -15,15 +15,6 @@
 
 
   <div class="field-group">
-    <h3>Overlay</h3>
-    <label class="field">
-      <span>Show visual overlay while dictating</span>
-      <input type="checkbox" bind:checked={cfg.ui.show_overlay} onchange={markDirty} />
-    </label>
-    <p class="hint">Displays the animated waveform overlay during dictation. Turn off if the overlay interferes with text insertion on your desktop.</p>
-  </div>
-
-  <div class="field-group">
     <h3>History</h3>
     <label class="field">
       <span>Enable transcript history</span>

--- a/src/lib/Settings/GeneralTab.svelte
+++ b/src/lib/Settings/GeneralTab.svelte
@@ -15,6 +15,15 @@
 
 
   <div class="field-group">
+    <h3>Overlay</h3>
+    <label class="field">
+      <span>Show visual overlay while dictating</span>
+      <input type="checkbox" bind:checked={cfg.ui.show_overlay} onchange={markDirty} />
+    </label>
+    <p class="hint">Displays the animated waveform overlay during dictation. Turn off if the overlay interferes with text insertion on your desktop.</p>
+  </div>
+
+  <div class="field-group">
     <h3>History</h3>
     <label class="field">
       <span>Enable transcript history</span>


### PR DESCRIPTION
## Problem

On Wayland (confirmed on KDE/KWin), a push-to-talk shortcut transcribed speech correctly but the text never landed at the cursor. It would sometimes work the first time and then fail repeatedly, and focus often didn't return to the original window.

## Root causes & fixes

This turned out to be three distinct bugs, fixed in order:

### 1. The visual overlay steals keyboard focus (primary cause)
The native Slint overlay called `ui.show()` at the start of each dictation and `ui.hide()` at the end. On Wayland, re-mapping a surface makes the compositor grab keyboard focus for the freshly-mapped overlay, so `wtype` typed into the overlay instead of the user's window. Confirmed empirically: overlay off → injection reliable; overlay on → broken.

**Fix:** map the overlay window once (lazily, the first time it's needed, with real content) and keep it mapped for the process lifetime; render a transparent frame when idle instead of unmapping. This eliminates the per-dictation re-map and the focus grab.

### 2. The overlay couldn't be turned off
The overlay's visibility is driven by the `recording`/`processing`/`speaking` flags forwarded from the Tauri side, and that code never checked `ui.show_overlay` — so the existing "Show overlay while speaking" toggle (Visual tab) did nothing for the native overlay.

**Fix:** mirror `ui.show_overlay` into an `AppState` atomic so the hot status-forwarding loops can gate the overlay without locking the config per audio sample; keep it in sync in `save_config`; force the overlay-bound flags off when disabled (the tray icon and the frontend status event still reflect real state). This makes the existing Visual-tab toggle work as a reliable on/off and fallback.

### 3. Hold gesture stops before the combo is fully released
For a Hold binding (e.g. `Super+Space`), `handle_release` emitted `Stop` the moment the *first* key was released. Transcription/injection could then fire while a modifier was still held, and `wtype` (unlike `xdotool --clearmodifiers`) can't clear a physically-held modifier, so the keystrokes became shortcuts and were swallowed.

**Fix:** an active Hold now stops only once *every* key in the binding is released. Combo-abort during the hold threshold and single-key holds are unchanged. Covered by a new test (`test_hold_multikey_stops_only_on_full_release`); the hotkeys suite passes 14/14.

## Notes / things to verify on KWin
- The overlay now maps once on the first dictation after launch, which may cause a single one-time focus grab on that first dictation; every dictation afterward avoids the re-map. If the first-dictation case still misses, the proper long-term fix is a non-focusable surface via wlr-layer-shell (a larger change, since Slint/winit only create ordinary `xdg-toplevel` windows).
- A duplicate overlay toggle that was briefly added to the General tab has been removed in favor of the existing Visual-tab control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Co7akYcofvW7focTJodjho