### PR TITLE
fix(packaging): bundle voxctrl-overlay sidecar + update tray icon on main thread

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ Thumbs.db
 # Logs
 *.log
 
+# Tauri sidecar binaries staged at build time (see scripts/prepare-sidecar.mjs)
+/src-tauri/binaries/
+
 # Rust
 /target/
 **/target/

--- a/scripts/prepare-sidecar.mjs
+++ b/scripts/prepare-sidecar.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+// Stage the freshly-built `voxctrl-overlay` binary as a Tauri sidecar so it
+// gets bundled *inside* the AppImage / deb / installer next to the main app.
+//
+// Tauri's `externalBin` mechanism expects each sidecar to be named with the
+// host target triple suffix (e.g. `voxctrl-overlay-x86_64-unknown-linux-gnu`).
+// At bundle time Tauri strips the triple and drops `voxctrl-overlay` alongside
+// the main `voxctrl` binary, which is exactly where `get_overlay_path()` looks
+// first. Without this the overlay binary is missing from packaged builds and
+// the app silently falls back to a stale dev binary (or none at all).
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, copyFileSync, chmodSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+// Resolve the host target triple from rustc (e.g. "x86_64-unknown-linux-gnu").
+function hostTriple() {
+  const out = execFileSync('rustc', ['-vV'], { encoding: 'utf8' });
+  const match = out.match(/^host:\s*(\S+)$/m);
+  if (!match) {
+    throw new Error('Could not determine host triple from `rustc -vV`');
+  }
+  return match[1];
+}
+
+const triple = hostTriple();
+const isWindows = process.platform === 'win32';
+const exeSuffix = isWindows ? '.exe' : '';
+
+const srcBinary = join(repoRoot, 'target', 'release', `voxctrl-overlay${exeSuffix}`);
+if (!existsSync(srcBinary)) {
+  throw new Error(
+    `Overlay binary not found at ${srcBinary}.\n` +
+      'Run `cargo build --bin voxctrl-overlay --release` before staging the sidecar.'
+  );
+}
+
+const destDir = join(repoRoot, 'src-tauri', 'binaries');
+mkdirSync(destDir, { recursive: true });
+const destBinary = join(destDir, `voxctrl-overlay-${triple}${exeSuffix}`);
+
+copyFileSync(srcBinary, destBinary);
+if (!isWindows) {
+  chmodSync(destBinary, 0o755);
+}
+
+console.log(`[prepare-sidecar] staged ${srcBinary} -> ${destBinary}`);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -753,17 +753,33 @@ pub fn run() {
                     let is_recording = state_for_ticker.is_recording();
                     let is_processing = state_for_ticker.is_processing();
 
-                    if let Some(tray) = handle.tray_by_id("main-tray") {
-                        if is_processing {
-                            let icon = &processing_frames[frame_idx];
-                            let _ = tray.set_icon(Some(icon.clone()));
-                            frame_idx = (frame_idx + 1) % 6;
-                            was_animating = true;
-                        } else if was_animating || is_recording != last_recording {
-                            let icon = if is_recording { &record_on_icon } else { &record_off_icon };
-                            let _ = tray.set_icon(Some(icon.clone()));
-                            was_animating = false;
-                        }
+                    // Decide whether the tray icon needs updating this tick and,
+                    // if so, which frame to show. The actual `set_icon` call must
+                    // happen on the GTK main thread: on Linux the tray is backed by
+                    // ayatana-appindicator/GTK, which is not thread-safe. Calling it
+                    // from this Tokio worker thread makes icon updates unreliable —
+                    // the animated icon flickers or disappears entirely on
+                    // appindicator-based desktops (e.g. GNOME). `run_on_main_thread`
+                    // marshals the update onto the loop that owns the tray.
+                    let next_icon: Option<tauri::image::Image<'static>> = if is_processing {
+                        let icon = processing_frames[frame_idx].clone();
+                        frame_idx = (frame_idx + 1) % 6;
+                        was_animating = true;
+                        Some(icon)
+                    } else if was_animating || is_recording != last_recording {
+                        was_animating = false;
+                        Some(if is_recording { record_on_icon.clone() } else { record_off_icon.clone() })
+                    } else {
+                        None
+                    };
+
+                    if let Some(icon) = next_icon {
+                        let handle_for_icon = handle.clone();
+                        let _ = handle.run_on_main_thread(move || {
+                            if let Some(tray) = handle_for_icon.tray_by_id("main-tray") {
+                                let _ = tray.set_icon(Some(icon));
+                            }
+                        });
                     }
 
                     let is_mcp_recording = state_for_ticker.is_mcp_recording();

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
     "frontendDist": "../dist",
     "devUrl": "http://localhost:5173",
     "beforeDevCommand": "cargo build --bin voxctrl-overlay && npm run dev",
-    "beforeBuildCommand": "cargo build --bin voxctrl-overlay --release && npm run build"
+    "beforeBuildCommand": "cargo build --bin voxctrl-overlay --release && node scripts/prepare-sidecar.mjs && npm run build"
   },
   "app": {
     "security": {
@@ -61,7 +61,9 @@
       "resources/cublas64_12.dll",
       "resources/cublasLt64_12.dll"
     ],
-    "externalBin": [],
+    "externalBin": [
+      "binaries/voxctrl-overlay"
+    ],
     "linux": {
       "deb": {
         "depends": [


### PR DESCRIPTION
## Summary

Fixes the AppImage-only regressions reported on the `v0.2.3.2` release: the overlay only appears on the first dictation, subsequent presses show no overlay and inject text with a delay, and the animated tray icon disappears.

## Root causes

**Overlay shows once, then text is delayed/misrouted (overlay symptoms)**
The `voxctrl-overlay` helper binary was *built* by `beforeBuildCommand` but **never bundled** into the AppImage — `externalBin` was empty and nothing staged it into the AppDir. At runtime `get_overlay_path()` (`src-tauri/src/lib.rs`) failed its co-located lookups (`p1`/`p2`) and fell back to cwd-relative `target/debug/voxctrl-overlay` (`p3`/`p4`), silently picking up whatever **stale debug overlay** was in the user's cloned repo. That stale binary predates the Wayland focus-theft fixes, so it used the old `hide()/show()` remap path: the overlay maps once, then on every later dictation the freshly-remapped always-on-top surface grabs Wayland keyboard focus, so no overlay appears and injected text is delayed/misrouted. Local builds were unaffected because the fresh release overlay sits next to the main binary and `p1` finds it.

**Animated tray icon disappears**
The periodic `tray.set_icon(...)` calls ran on a Tokio worker thread, but the Linux tray is backed by ayatana-appindicator/GTK, which is not thread-safe. Off-main-thread icon updates are unreliable and blank the icon on appindicator desktops (e.g. GNOME), while being tolerated on the dev's setup.

## Changes

- **Stage the overlay as a proper Tauri sidecar** so it's packaged inside the AppImage/deb/installer next to the main app, where `get_overlay_path()` finds it first:
  - `scripts/prepare-sidecar.mjs` — copies the built overlay to the target-triple-suffixed name Tauri's `externalBin` expects (cross-platform, derives the triple from `rustc -vV`).
  - `tauri.conf.json` — declare `binaries/voxctrl-overlay` in `externalBin` and run the staging script from `beforeBuildCommand`.
  - `.gitignore` — ignore the generated `src-tauri/binaries/`.
- **Marshal tray `set_icon` onto the GTK main thread** via `run_on_main_thread` (`src-tauri/src/lib.rs`).

## Verification

- `tauri.conf.json` validated as JSON; `scripts/prepare-sidecar.mjs` exercised with a stub binary — produces `src-tauri/binaries/voxctrl-overlay-x86_64-unknown-linux-gnu` as expected.
- `run_on_main_thread<F: FnOnce() + Send + 'static>` confirmed against the vendored Tauri 2.11.2 source; `Image<'static>` is `Send + Clone`.
- A full `cargo check` could not run in the build sandbox (missing GTK/webkit dev libs) — please confirm CI compiles. The most meaningful check is a real packaged AppImage: confirm `usr/bin/voxctrl-overlay` is present, the overlay shows on repeated dictations, injected text is immediate, and the tray animates during processing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RkpDbnQdrTEY56HaEzuKBK)_