### PR TITLE
fix(packaging): stage overlay sidecar before tauri-build validates it

### DIFF
--- a/scripts/prepare-sidecar.mjs
+++ b/scripts/prepare-sidecar.mjs
@@ -8,13 +8,26 @@
 // the main `voxctrl` binary, which is exactly where `get_overlay_path()` looks
 // first. Without this the overlay binary is missing from packaged builds and
 // the app silently falls back to a stale dev binary (or none at all).
+//
+// Chicken-and-egg note: `voxctrl-overlay` lives in the same crate that declares
+// `externalBin`, and `tauri-build`'s build script validates that the sidecar
+// file exists on *every* compile of that crate — including the `cargo build
+// --bin voxctrl-overlay` we run to produce the binary in the first place. So
+// this script runs in two phases:
+//   --ensure : guarantee the triple-named file exists before the overlay is
+//              built. Copies the real binary if it is already present (e.g.
+//              warm cache), otherwise writes a tiny placeholder just so the
+//              build-script validation passes.
+//   (default): require the freshly-built release binary and copy it over,
+//              replacing any placeholder, before Tauri bundles.
 
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdirSync, copyFileSync, chmodSync } from 'node:fs';
+import { existsSync, mkdirSync, copyFileSync, writeFileSync, chmodSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const ensureOnly = process.argv.includes('--ensure');
 
 // Resolve the host target triple from rustc (e.g. "x86_64-unknown-linux-gnu").
 function hostTriple() {
@@ -30,21 +43,39 @@ const triple = hostTriple();
 const isWindows = process.platform === 'win32';
 const exeSuffix = isWindows ? '.exe' : '';
 
-const srcBinary = join(repoRoot, 'target', 'release', `voxctrl-overlay${exeSuffix}`);
-if (!existsSync(srcBinary)) {
+const destDir = join(repoRoot, 'src-tauri', 'binaries');
+const destBinary = join(destDir, `voxctrl-overlay-${triple}${exeSuffix}`);
+
+// The overlay binary may live under either profile depending on how it was
+// built. Prefer release (what packaged builds use) but fall back to debug for
+// the dev flow.
+const candidates = [
+  join(repoRoot, 'target', 'release', `voxctrl-overlay${exeSuffix}`),
+  join(repoRoot, 'target', 'debug', `voxctrl-overlay${exeSuffix}`),
+];
+const srcBinary = candidates.find((p) => existsSync(p));
+
+mkdirSync(destDir, { recursive: true });
+
+if (srcBinary) {
+  copyFileSync(srcBinary, destBinary);
+  if (!isWindows) {
+    chmodSync(destBinary, 0o755);
+  }
+  console.log(`[prepare-sidecar] staged ${srcBinary} -> ${destBinary}`);
+} else if (ensureOnly) {
+  // Build-script validation only checks that the path exists; the real binary
+  // is staged by the second (default) invocation once it has been compiled.
+  if (!existsSync(destBinary)) {
+    writeFileSync(destBinary, '');
+    if (!isWindows) {
+      chmodSync(destBinary, 0o755);
+    }
+    console.log(`[prepare-sidecar] wrote placeholder ${destBinary} (overlay not built yet)`);
+  }
+} else {
   throw new Error(
-    `Overlay binary not found at ${srcBinary}.\n` +
+    `Overlay binary not found in ${candidates.join(' or ')}.\n` +
       'Run `cargo build --bin voxctrl-overlay --release` before staging the sidecar.'
   );
 }
-
-const destDir = join(repoRoot, 'src-tauri', 'binaries');
-mkdirSync(destDir, { recursive: true });
-const destBinary = join(destDir, `voxctrl-overlay-${triple}${exeSuffix}`);
-
-copyFileSync(srcBinary, destBinary);
-if (!isWindows) {
-  chmodSync(destBinary, 0o755);
-}
-
-console.log(`[prepare-sidecar] staged ${srcBinary} -> ${destBinary}`);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -6,8 +6,8 @@
   "build": {
     "frontendDist": "../dist",
     "devUrl": "http://localhost:5173",
-    "beforeDevCommand": "cargo build --bin voxctrl-overlay && npm run dev",
-    "beforeBuildCommand": "cargo build --bin voxctrl-overlay --release && node scripts/prepare-sidecar.mjs && npm run build"
+    "beforeDevCommand": "node scripts/prepare-sidecar.mjs --ensure && cargo build --bin voxctrl-overlay && node scripts/prepare-sidecar.mjs && npm run dev",
+    "beforeBuildCommand": "node scripts/prepare-sidecar.mjs --ensure && cargo build --bin voxctrl-overlay --release && node scripts/prepare-sidecar.mjs && npm run build"
   },
   "app": {
     "security": {


### PR DESCRIPTION
## Summary

Follow-up to #48, which broke every job in the `v0.2.3.3` Release run (all four matrix builds failed at the Tauri build step).

## What went wrong

`voxctrl-overlay` is defined in the **same crate** (`voxctrl-app`) that #48 made declare `externalBin`. `tauri-build`'s build script validates that the sidecar file exists on *every* compile of that crate — including the `cargo build --bin voxctrl-overlay` we run to produce it. Because the staging script only ran *after* that compile, the first compile aborted:

```
resource path `binaries/voxctrl-overlay-x86_64-unknown-linux-gnu` doesn't exist
beforeBuildCommand `... && node scripts/prepare-sidecar.mjs && ...` failed with exit code 101
```

The same validation also affects `beforeDevCommand`.

## Fix

Stage the sidecar in **two phases** in `prepare-sidecar.mjs`:

- `--ensure` (runs *before* the overlay compile): copies the real binary if it's already present (warm cache), otherwise writes a tiny placeholder so the build-script validation passes.
- default (runs *after* the overlay compile, before bundling): requires the freshly built release binary and copies it over the placeholder, so the real binary is what Tauri bundles.

`beforeBuildCommand` and `beforeDevCommand` now run `--ensure` → build overlay → stage → frontend build.

## Verification

Simulated the full clean sequence locally:
- `--ensure` with no binary → writes a 0-byte placeholder at `binaries/voxctrl-overlay-x86_64-unknown-linux-gnu`.
- after the overlay binary exists → default pass overwrites the placeholder with the real binary.
- default pass with no binary → still errors loudly (catches a genuinely missing build).

A real `tauri build` couldn't run in the sandbox (no GTK/webkit), so the meaningful check is the next CI run reaching a green AppImage with `usr/bin/voxctrl-overlay` present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RkpDbnQdrTEY56HaEzuKBK)_