### PR TITLE
fix(build/ci): make bare cargo builds work + build Windows NSIS only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,9 +195,13 @@ jobs:
         run: node_modules/.bin/tauri build --bundles deb -- --features cuda
 
       # ── Tauri build (Windows) ───────────────────────────────────────────────
+      # NSIS (setup.exe) only — the advertised Windows installer. The WiX/MSI
+      # bundler's `light.exe` fails to harvest the voxctrl-overlay sidecar, and
+      # the MSI is a secondary, unadvertised artifact. Call tauri directly so
+      # `--bundles nsis` reaches tauri instead of cargo.
       - name: Build installer (Windows, CPU)
         if: runner.os == 'Windows' && !matrix.cuda
-        run: npm run tauri build
+        run: npx tauri build --bundles nsis
 
       - name: Copy real CUDA DLLs (Windows, CUDA)
         if: runner.os == 'Windows' && matrix.cuda
@@ -209,7 +213,7 @@ jobs:
 
       - name: Build installer (Windows, CUDA)
         if: runner.os == 'Windows' && matrix.cuda
-        run: npm run tauri build -- --features cuda
+        run: npx tauri build --bundles nsis -- --features cuda
 
       # ── Collect and rename Linux artifacts ──────────────────────────────────
       # Search the whole workspace so the path is correct regardless of whether

--- a/scripts/prepare-sidecar.mjs
+++ b/scripts/prepare-sidecar.mjs
@@ -9,25 +9,17 @@
 // first. Without this the overlay binary is missing from packaged builds and
 // the app silently falls back to a stale dev binary (or none at all).
 //
-// Chicken-and-egg note: `voxctrl-overlay` lives in the same crate that declares
-// `externalBin`, and `tauri-build`'s build script validates that the sidecar
-// file exists on *every* compile of that crate — including the `cargo build
-// --bin voxctrl-overlay` we run to produce the binary in the first place. So
-// this script runs in two phases:
-//   --ensure : guarantee the triple-named file exists before the overlay is
-//              built. Copies the real binary if it is already present (e.g.
-//              warm cache), otherwise writes a tiny placeholder just so the
-//              build-script validation passes.
-//   (default): require the freshly-built release binary and copy it over,
-//              replacing any placeholder, before Tauri bundles.
+// Run from beforeBuildCommand/beforeDevCommand *after* the overlay binary has
+// been compiled. The crate's build.rs writes a placeholder so plain cargo
+// builds still compile; this script replaces that placeholder with the real
+// binary before Tauri bundles.
 
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdirSync, copyFileSync, writeFileSync, chmodSync } from 'node:fs';
+import { existsSync, mkdirSync, copyFileSync, chmodSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
-const ensureOnly = process.argv.includes('--ensure');
 
 // Resolve the host target triple from rustc (e.g. "x86_64-unknown-linux-gnu").
 function hostTriple() {
@@ -43,9 +35,6 @@ const triple = hostTriple();
 const isWindows = process.platform === 'win32';
 const exeSuffix = isWindows ? '.exe' : '';
 
-const destDir = join(repoRoot, 'src-tauri', 'binaries');
-const destBinary = join(destDir, `voxctrl-overlay-${triple}${exeSuffix}`);
-
 // The overlay binary may live under either profile depending on how it was
 // built. Prefer release (what packaged builds use) but fall back to debug for
 // the dev flow.
@@ -54,28 +43,20 @@ const candidates = [
   join(repoRoot, 'target', 'debug', `voxctrl-overlay${exeSuffix}`),
 ];
 const srcBinary = candidates.find((p) => existsSync(p));
-
-mkdirSync(destDir, { recursive: true });
-
-if (srcBinary) {
-  copyFileSync(srcBinary, destBinary);
-  if (!isWindows) {
-    chmodSync(destBinary, 0o755);
-  }
-  console.log(`[prepare-sidecar] staged ${srcBinary} -> ${destBinary}`);
-} else if (ensureOnly) {
-  // Build-script validation only checks that the path exists; the real binary
-  // is staged by the second (default) invocation once it has been compiled.
-  if (!existsSync(destBinary)) {
-    writeFileSync(destBinary, '');
-    if (!isWindows) {
-      chmodSync(destBinary, 0o755);
-    }
-    console.log(`[prepare-sidecar] wrote placeholder ${destBinary} (overlay not built yet)`);
-  }
-} else {
+if (!srcBinary) {
   throw new Error(
     `Overlay binary not found in ${candidates.join(' or ')}.\n` +
       'Run `cargo build --bin voxctrl-overlay --release` before staging the sidecar.'
   );
 }
+
+const destDir = join(repoRoot, 'src-tauri', 'binaries');
+mkdirSync(destDir, { recursive: true });
+const destBinary = join(destDir, `voxctrl-overlay-${triple}${exeSuffix}`);
+
+copyFileSync(srcBinary, destBinary);
+if (!isWindows) {
+  chmodSync(destBinary, 0o755);
+}
+
+console.log(`[prepare-sidecar] staged ${srcBinary} -> ${destBinary}`);

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,41 @@
+use std::path::PathBuf;
+
 fn main() {
+    // The `voxctrl-overlay` helper is shipped as a Tauri sidecar (see
+    // `externalBin` in tauri.conf.json) so it lands next to the main binary in
+    // packaged builds. Tauri validates that the sidecar file exists on *every*
+    // compile of this crate, including a bare `cargo build`/`cargo check` or
+    // rust-analyzer — none of which run `beforeBuildCommand`. Guarantee a
+    // placeholder exists here, before tauri_build::build() runs its validation,
+    // so ordinary development builds never fail. Packaging overwrites this with
+    // the real binary via scripts/prepare-sidecar.mjs before Tauri bundles.
+    ensure_overlay_sidecar_placeholder();
+
     tauri_build::build()
+}
+
+fn ensure_overlay_sidecar_placeholder() {
+    let manifest_dir = match std::env::var("CARGO_MANIFEST_DIR") {
+        Ok(dir) => PathBuf::from(dir),
+        Err(_) => return,
+    };
+    // Tauri names sidecars with the target triple it is compiling for.
+    let target = std::env::var("TARGET").unwrap_or_default();
+    if target.is_empty() {
+        return;
+    }
+    let exe_suffix = if target.contains("windows") { ".exe" } else { "" };
+
+    let dir = manifest_dir.join("binaries");
+    let sidecar = dir.join(format!("voxctrl-overlay-{target}{exe_suffix}"));
+    if sidecar.exists() {
+        return;
+    }
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        println!("cargo:warning=could not create {}: {e}", dir.display());
+        return;
+    }
+    if let Err(e) = std::fs::write(&sidecar, []) {
+        println!("cargo:warning=could not write placeholder sidecar {}: {e}", sidecar.display());
+    }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -6,8 +6,8 @@
   "build": {
     "frontendDist": "../dist",
     "devUrl": "http://localhost:5173",
-    "beforeDevCommand": "node scripts/prepare-sidecar.mjs --ensure && cargo build --bin voxctrl-overlay && node scripts/prepare-sidecar.mjs && npm run dev",
-    "beforeBuildCommand": "node scripts/prepare-sidecar.mjs --ensure && cargo build --bin voxctrl-overlay --release && node scripts/prepare-sidecar.mjs && npm run build"
+    "beforeDevCommand": "cargo build --bin voxctrl-overlay && node scripts/prepare-sidecar.mjs && npm run dev",
+    "beforeBuildCommand": "cargo build --bin voxctrl-overlay --release && node scripts/prepare-sidecar.mjs && npm run build"
   },
   "app": {
     "security": {


### PR DESCRIPTION
Follow-ups to the sidecar work (#48/#49) that surfaced when actually building. Two independent fixes:

## 1. Bare `cargo build` failed (local dev)

Declaring `externalBin` makes `tauri-build` validate the sidecar exists on **every** compile of the `voxctrl-app` crate — not just `tauri build`. A plain `cargo build`/`cargo check`/`cargo test` or rust-analyzer (none run `beforeBuildCommand`) therefore failed with:

```
resource path `binaries/voxctrl-overlay-<triple>` doesn't exist
```

**Fix:** create the placeholder from the crate's own `build.rs`, before `tauri_build::build()` validates, so ordinary dev builds always compile. Packaging still overwrites it with the real binary via `prepare-sidecar.mjs`. With the placeholder guaranteed by `build.rs`, the `--ensure` pre-step from #49 is redundant, so `beforeDev`/`beforeBuild` commands and the staging script are simplified back to one stage-the-real-binary pass.

## 2. Windows release jobs failed at WiX/MSI

Both Windows jobs compiled and staged the overlay sidecar fine, then failed at the MSI step:

```
Running light to produce ...VoxCtrl_0.2.3_x64_en-US.msi
failed to bundle project `failed to run ...\WixTools314\light.exe`
```

WiX `light.exe` chokes harvesting the `voxctrl-overlay.exe` sidecar (MSI worked in v0.2.3.2, before `externalBin`). The NSIS `setup.exe` is the advertised Windows installer and bundles the sidecar fine.

**Fix:** build Windows with `--bundles nsis` only (drop the secondary, unadvertised MSI). Linux is unaffected and still builds AppImage + deb.

## Status of the v0.2.3.4 build (run #19, from before these fixes)

- ✅ Linux CPU (AppImage + deb) and Linux CUDA (deb) — **succeeded** (sidecar bundling confirmed working).
- ❌ Windows CPU + CUDA — failed at MSI (fixed here).
- No `v0.2.3.4` tag/release was created, so nothing to clean up.

After merge, re-run the release from `master` and all four jobs should be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)