### PR TITLE
feat(gpu+overlay): Vulkan AppImage for portable GPU + overlay stderr diagnostics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,16 @@ jobs:
             artifact_label: linux-x86_64-cuda
             cuda: true
 
+          # ── Linux Vulkan ───────────────────────────────────────────────────
+          # Portable GPU AppImage: accelerates NVIDIA/AMD/Intel via the host
+          # Vulkan driver, with CPU fallback. Far lighter to bundle than CUDA.
+          - name: linux-vulkan
+            os: ubuntu-22.04
+            features: "vulkan"
+            artifact_label: linux-x86_64-vulkan
+            cuda: false
+            vulkan: true
+
           # ── Windows CPU ────────────────────────────────────────────────────
           - name: windows-cpu
             os: windows-2022
@@ -79,6 +89,21 @@ jobs:
             squashfs-tools \
             pkg-config \
             build-essential
+
+      # ── Vulkan SDK (Linux) ──────────────────────────────────────────────────
+      # The ggml Vulkan backend compiles its compute shaders at build time with
+      # glslc, which ships in the LunarG Vulkan SDK. End-users only need their
+      # GPU's Vulkan driver at runtime (bundled loader finds the host ICD).
+      - name: Install Vulkan SDK (Linux)
+        if: runner.os == 'Linux' && matrix.vulkan
+        run: |
+          wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc \
+            | sudo tee /etc/apt/trusted.gpg.d/lunarg.asc >/dev/null
+          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-jammy.list \
+            https://packages.lunarg.com/vulkan/lunarg-vulkan-jammy.list
+          sudo apt-get update -q
+          sudo apt-get install -y vulkan-sdk
+          glslc --version
 
       # ── CUDA toolkit ────────────────────────────────────────────────────────
       # Installs CUDA headers + libraries for compilation only.
@@ -175,11 +200,20 @@ jobs:
       # and run without FUSE (uses unsquashfs from squashfs-tools instead).
       # QT_QPA_PLATFORM=offscreen prevents Qt platform errors in headless CI.
       - name: Build AppImage + deb (Linux, CPU)
-        if: runner.os == 'Linux' && !matrix.cuda
+        if: runner.os == 'Linux' && !matrix.cuda && !matrix.vulkan
         env:
           APPIMAGE_EXTRACT_AND_RUN: 1
           QT_QPA_PLATFORM: offscreen
         run: npm run tauri build
+
+      # Portable GPU AppImage. whisper.cpp's Vulkan backend links only
+      # libvulkan (lightweight, unlike CUDA), so linuxdeploy bundles it fine.
+      - name: Build AppImage + deb (Linux, Vulkan)
+        if: runner.os == 'Linux' && matrix.vulkan
+        env:
+          APPIMAGE_EXTRACT_AND_RUN: 1
+          QT_QPA_PLATFORM: offscreen
+        run: npm run tauri build -- --features vulkan
 
       # CUDA build uses --bundles deb only: the CUDA toolkit populates system
       # library paths with hundreds of CUDA .so files that linuxdeploy tries to

--- a/crates/voxctrl-inference/Cargo.toml
+++ b/crates/voxctrl-inference/Cargo.toml
@@ -25,6 +25,10 @@ tempfile = { workspace = true }
 [features]
 default = []
 cuda = ["whisper-rs/cuda"]
+# Portable GPU acceleration via the ggml Vulkan backend. Works on NVIDIA/AMD/
+# Intel with just the host Vulkan driver and bundles into an AppImage without
+# CUDA's heavy runtime. Falls back to CPU when no Vulkan device is present.
+vulkan = ["whisper-rs/vulkan"]
 
 # Moonshine ONNX backend via onnxruntime
 moonshine = ["dep:ort", "dep:ndarray"]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -64,6 +64,7 @@ gtk = { version = "0.18", features = ["v3_24"] }
 default = ["custom-protocol"]
 custom-protocol = ["tauri/custom-protocol"]
 cuda = ["voxctrl-inference/cuda"]
+vulkan = ["voxctrl-inference/vulkan"]
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -688,7 +688,7 @@ pub fn run() {
 
             // Spawn the Slint overlay helper process
             if let Some(overlay_path) = get_overlay_path() {
-                println!("Spawning Slint overlay helper: {:?}", overlay_path);
+                tracing::info!("Spawning Slint overlay helper: {:?}", overlay_path);
                 match std::process::Command::new(&overlay_path)
                     .stdin(std::process::Stdio::piped())
                     .stdout(std::process::Stdio::inherit())
@@ -709,8 +709,12 @@ pub fn run() {
                         }
                         // Wait for child in background so it doesn't become a zombie
                         std::thread::spawn(move || {
-                            let _ = child.wait();
-                            println!("Slint overlay process exited.");
+                            let status = child.wait();
+                            // Logged on stderr (tracing) so it is visible even when
+                            // stdout is block-buffered behind a pipe. If this fires
+                            // after the first dictation, the overlay is crashing
+                            // rather than hitting a window-mapping issue.
+                            tracing::warn!("Slint overlay process exited: {:?}", status);
                         });
                     }
                     Err(e) => {
@@ -1010,47 +1014,45 @@ pub fn calculate_overlay_y(
 }
 
 pub fn get_overlay_path() -> Option<std::path::PathBuf> {
+    // Logged via tracing (stderr) so the resolved path is visible even when
+    // stdout is block-buffered behind a pipe.
     if let Ok(mut current_path) = std::env::current_exe() {
-        println!("get_overlay_path: current_exe = {:?}", current_path);
+        tracing::info!("get_overlay_path: current_exe = {:?}", current_path);
         current_path.pop(); // Pop binary name
         let bin_name = if cfg!(target_os = "windows") {
             "voxctrl-overlay.exe"
         } else {
             "voxctrl-overlay"
         };
-        // Check same dir
+        // Check same dir (where the bundled sidecar lives next to the main app)
         let p1 = current_path.join(bin_name);
-        println!("get_overlay_path: checking p1 = {:?}", p1);
         if p1.exists() {
-            println!("get_overlay_path: found p1!");
+            tracing::info!("get_overlay_path: found alongside main binary: {:?}", p1);
             return Some(p1);
         }
         // Check parent dir (if running in deps/)
         current_path.pop();
         let p2 = current_path.join(bin_name);
-        println!("get_overlay_path: checking p2 = {:?}", p2);
         if p2.exists() {
-            println!("get_overlay_path: found p2!");
+            tracing::info!("get_overlay_path: found in parent dir: {:?}", p2);
             return Some(p2);
         }
 
-        // Check relative to current working directory
+        // Dev-only fallback: relative to the current working directory.
         if let Ok(cwd) = std::env::current_dir() {
             let p3 = cwd.join("target").join("debug").join(bin_name);
-            println!("get_overlay_path: checking p3 = {:?}", p3);
             if p3.exists() {
-                println!("get_overlay_path: found p3!");
+                tracing::info!("get_overlay_path: found in target/debug: {:?}", p3);
                 return Some(p3);
             }
             let p4 = cwd.join("src-tauri").join("target").join("debug").join(bin_name);
-            println!("get_overlay_path: checking p4 = {:?}", p4);
             if p4.exists() {
-                println!("get_overlay_path: found p4!");
+                tracing::info!("get_overlay_path: found in src-tauri/target/debug: {:?}", p4);
                 return Some(p4);
             }
         }
     }
-    println!("get_overlay_path: failed to find overlay binary!");
+    tracing::error!("get_overlay_path: overlay binary not found");
     None
 }
 

--- a/src-tauri/src/overlay.rs
+++ b/src-tauri/src/overlay.rs
@@ -1387,12 +1387,29 @@ fn main() {
 
         loop {
             line.clear();
-            if reader.read_line(&mut line).is_err() || line.is_empty() {
-                // Pipe closed, exit
-                slint::invoke_from_event_loop(move || {
-                    let _ = slint::quit_event_loop();
-                }).unwrap();
-                break;
+            match reader.read_line(&mut line) {
+                Ok(0) => {
+                    // Clean EOF: the parent closed our stdin, so shut down.
+                    eprintln!("[overlay] stdin closed (EOF); exiting event loop");
+                    let _ = slint::invoke_from_event_loop(|| {
+                        let _ = slint::quit_event_loop();
+                    });
+                    break;
+                }
+                Ok(_) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {
+                    // Transient interruption (e.g. EINTR): keep reading instead
+                    // of tearing down the overlay for the rest of the session.
+                    eprintln!("[overlay] stdin read interrupted, retrying: {e}");
+                    continue;
+                }
+                Err(e) => {
+                    eprintln!("[overlay] stdin read error; exiting event loop: {e}");
+                    let _ = slint::invoke_from_event_loop(|| {
+                        let _ = slint::quit_event_loop();
+                    });
+                    break;
+                }
             }
 
             if let Ok(msg) = serde_json::from_str::<serde_json::Value>(&line) {
@@ -1510,6 +1527,7 @@ fn main() {
                 w.set_window_level(i_slint_backend_winit::winit::window::WindowLevel::AlwaysOnTop);
             });
             shown = true;
+            eprintln!("[overlay] window mapped (kept mapped for the session)");
         }
 
         // Nothing has needed the overlay yet — leave it unmapped.
@@ -1681,7 +1699,11 @@ fn main() {
         }
     });
 
-    slint::run_event_loop_until_quit().unwrap();
+    if let Err(e) = slint::run_event_loop_until_quit() {
+        eprintln!("[overlay] event loop ended with error: {e}");
+    } else {
+        eprintln!("[overlay] event loop ended");
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Addresses the two AppImage runtime issues — slow processing and the overlay-shows-once bug — confirmed on a Wayland + NVIDIA setup.

## 1. Portable GPU acceleration (the slowness)

The released AppImage is **CPU-only** by design: CUDA ships only in the `.deb` because its runtime is too heavy for `linuxdeploy` to bundle. So on a machine whose local build uses CUDA, the AppImage runs whisper on CPU and is several× slower — expected, but a poor out-of-box experience.

Add a **Vulkan** backend as a portable GPU option:
- `vulkan` feature on `voxctrl-inference` (`whisper-rs/vulkan`) and `voxctrl-app`.
- New `linux-vulkan` release matrix entry → a separate `…-linux-x86_64-vulkan.AppImage`. The plain CPU AppImage still ships for GPU-less machines (no regression).
- CI installs the LunarG Vulkan SDK (for `glslc`, which the ggml Vulkan backend needs at build time) only for that job.

Vulkan accelerates NVIDIA/AMD/Intel via the host driver, bundles cleanly (just `libvulkan`), and falls back to CPU when no device is present. `whisper-rs` 0.16 confirmed to expose the `vulkan` feature.

## 2. Overlay diagnostics + stdin robustness (the overlay-once bug)

Root cause still unconfirmed because the overlay's lifecycle logs used `println!` → **block-buffered stdout**, so they never showed up when piping to a log (the user's log had all the stderr `tracing` output but none of the overlay lines).

- Route `get_overlay_path`, the spawn line, and the **"overlay process exited"** line through `tracing` (stderr), and have the overlay log when it **maps** and when its **event loop ends**. After this, a single run's log tells us definitively whether the overlay is **crashing** (process exits after dictation #1) or it's a **Wayland map/redraw** issue (process alive, no redraw).
- Hardened the overlay's stdin reader: **retry on `EINTR`** instead of tearing down the overlay, log EOF vs error, and drop an `unwrap()` on `invoke_from_event_loop` that could panic. This also fixes one plausible cause of the silent once-only death.

## Validation notes

- Couldn't run a full `tauri build` here (no GTK/webkit), so the Vulkan job needs a CI run. Main risk points, all fail-fast: the LunarG apt repo/`vulkan-sdk` install, and `linuxdeploy` bundling `libvulkan` (occasionally needs the host loader instead — easy follow-up if the runtime can't see the GPU).
- The overlay change is intentionally **diagnostic-first**: it should make the next AppImage run's log conclusive about crash-vs-mapping, so the actual behavior fix is targeted rather than another blind guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RkpDbnQdrTEY56HaEzuKBK)_