### PR TITLE
Version bump to v0.2.4 + build releases on push to master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,25 @@
 name: Release
 
-# Trigger: push a version tag (e.g. git tag v0.1.4 && git push --tags)
-# Can also be triggered manually from the Actions tab to re-run a failed build.
+# Trigger: every push to master builds and (re)creates the release for the
+# current app version (read from src-tauri/tauri.conf.json). Bump the version
+# there to start a fresh release; pushes at the same version refresh it.
+# Can also be triggered manually with an explicit tag to (re-)build.
 on:
   push:
-    tags:
-      - "v*.*.*"
+    branches:
+      - master
   workflow_dispatch:
     inputs:
       tag:
-        description: "Existing tag to (re-)build (e.g. v0.1.4)"
-        required: true
+        description: "Tag to (re-)build (e.g. v0.1.4). Defaults to the app version in tauri.conf.json."
+        required: false
         type: string
+
+# Only one release build per branch at a time; a newer push cancels an
+# in-progress one so the release reflects the latest commit.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: write   # needed to create/update GitHub releases
@@ -310,13 +318,19 @@ jobs:
     if: always() && contains(needs.build.result, 'success')
 
     steps:
+      # Needed to read the app version for the default tag name.
+      - uses: actions/checkout@v4
+
       - name: Resolve tag name
         id: tag
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          # Manual dispatch may override the tag; otherwise derive it from the
+          # app version (e.g. 0.2.4 -> v0.2.4).
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.tag }}" ]]; then
             echo "name=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
           else
-            echo "name=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+            VERSION=$(jq -r '.version' src-tauri/tauri.conf.json)
+            echo "name=v${VERSION}" >> "$GITHUB_OUTPUT"
           fi
 
       # Download everything produced by the build matrix
@@ -345,12 +359,17 @@ jobs:
             | Platform | File suffix | GPU required |
             |---|---|---|
             | Linux | `-linux-x86_64.AppImage` | None |
+            | Linux (GPU) | `-linux-x86_64-vulkan.AppImage` | Any Vulkan GPU |
             | Linux (NVIDIA) | `-linux-x86_64-cuda.deb` | NVIDIA driver 520+ |
             | Windows | `-windows-x86_64-setup.exe` | None |
             | Windows (NVIDIA) | `-windows-x86_64-cuda-setup.exe` | NVIDIA driver 520+ |
 
             **CUDA builds** use your GPU for Whisper inference (~3–10× faster).
             They require an NVIDIA driver but **not** the CUDA Toolkit.
+
+            **The Vulkan AppImage** is a portable GPU build: it accelerates any
+            NVIDIA/AMD/Intel GPU via the host Vulkan driver, and falls back to
+            CPU when no GPU is present.
 
             **CPU builds** run on any hardware, including AMD, Intel, and ARM.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "voxctrl",
   "private": true,
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "scripts": {
     "predev": "pkill -x voxctrl || true",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VoxCtrl",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "identifier": "ai.voxctrl.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Two release-plumbing changes.

## 1. Version bump `0.2.3 → 0.2.4`
`package.json` + `tauri.conf.json`, following the existing "Version Bump" pattern, so artifacts are named `0.2.4`. This is the version for the first release that includes the bundled overlay sidecar, main-thread tray icon, the Vulkan AppImage, and overlay stderr diagnostics.

## 2. Release on every push to `master` (instead of on tags)
Per request, the Release workflow now triggers on pushes to `master` rather than version-tag pushes:
- The release tag/name is **derived from the app version** in `src-tauri/tauri.conf.json` (`0.2.4 → v0.2.4`). Bump that version to start a fresh release; same-version pushes refresh the current one.
- Added a **concurrency group** so a newer push cancels an in-progress release build.
- The publish job now checks out the repo (to read the version).
- `workflow_dispatch` still works, with an optional `tag` override.
- Updated the release-notes table to include the `-vulkan` AppImage.

### ⚠️ Worth knowing before merging
- **Every** push to `master` now runs all 5 build jobs, including the two ~20-min CUDA builds — noticeably more CI per merge than tag-triggered releases.
- Releases are still created as **drafts** (`draft: true`). To auto-publish on every master push instead, flip that to `draft: false` — say the word and I'll change it.
- Merging this PR will itself trigger a v0.2.4 release build (master push). Until the version is bumped again, subsequent master pushes refresh the v0.2.4 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)