### PR TITLE
fix(overlay): keep Wayland surface alive while idle so it re-shows (v0.2.5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "voxctrl",
   "private": true,
-  "version": "0.2.4",
+  "version": "0.2.5",
   "type": "module",
   "scripts": {
     "predev": "pkill -x voxctrl || true",

--- a/src-tauri/src/overlay.rs
+++ b/src-tauri/src/overlay.rs
@@ -1535,8 +1535,15 @@ fn main() {
             return;
         }
 
-        // Mapped but idle: push a single transparent frame, then stop updating
-        // so the window stays invisible without driving continuous redraws.
+        // Mapped but idle: keep the window invisible (reveal == 0 draws
+        // nothing) but DON'T stop driving the surface. On Wayland, a window
+        // that stops drawing entirely also stops receiving frame callbacks from
+        // some compositors (Mutter/KWin) — so when the next dictation arrives,
+        // Slint marks the window dirty but the compositor never delivers a
+        // frame and the overlay is never re-presented. The result is the
+        // overlay showing exactly once per session. Nudging winit to redraw on
+        // every idle tick keeps the frame-callback loop alive; the idle frame
+        // is essentially free since nothing is drawn.
         if !visible_needed {
             if !idle {
                 ui.set_reveal_main(0.0);
@@ -1544,6 +1551,7 @@ fn main() {
                 ui.set_level(0.0);
                 idle = true;
             }
+            ui.window().with_winit_window(|w| w.request_redraw());
             return;
         }
         idle = false;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VoxCtrl",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "identifier": "ai.voxctrl.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## The actual fix for the overlay-only-once bug (Wayland)

Your terminal log settled the diagnosis: the overlay **spawns and never exits** (`get_overlay_path: found p1!` → `Spawning Slint overlay helper` → no "overlay process exited" line). So it's not a crash — it's a **Wayland frame-callback stall**.

When the overlay went idle it stopped drawing entirely. On Wayland, Mutter/KWin stop delivering frame callbacks to a surface that isn't drawing, so on the next dictation Slint marks the window dirty but the compositor never sends a frame — and the overlay is never re-presented. Hence: shows once, then never.

**Fix:** keep the surface in the frame-callback loop while idle by nudging winit to redraw each idle tick (via the `with_winit_window` accessor we already use for click-through). The idle frame draws nothing (`reveal == 0`), so it's essentially free, and this does **not** reintroduce the focus theft the keep-mapped design avoids — that came from `hide()/show()` remapping, not from redrawing a mapped window.

Also bumps the version to **0.2.5** so the fixed AppImage is unmistakably distinct from 0.2.4.

## Note on what you were running
The log showed the **old `println!`** overlay diagnostics (`checking p1`, `found p1!`), not the `tracing` ones on `master` — so the AppImage you tested predates even the v0.2.4 instrumentation. Regardless, v0.2.4 only *instrumented* the overlay; this PR is the first to actually **fix** the behavior.

## After merge
Merging triggers an automatic **v0.2.5** release build (master push). Grab the fresh `…-0.2.5-…-vulkan.AppImage` and the overlay should re-appear on every dictation. Couldn't compile here (no GTK/webkit), so this needs the CI build + your confirmation on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RkpDbnQdrTEY56HaEzuKBK)_