### PR TITLE
ci: stop bundling host graphics/Wayland libs in the AppImage (fixes overlay-once)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,6 +223,43 @@ jobs:
           QT_QPA_PLATFORM: offscreen
         run: npm run tauri build -- --features vulkan
 
+      # linuxdeploy bundles whatever graphics/Wayland/input libraries exist on
+      # the build host. On ubuntu-22.04 those are older than modern desktops, and
+      # loading them instead of the host's copies breaks the Slint overlay's
+      # Wayland frame callbacks (it renders once, then the compositor never sends
+      # another frame) and trips "unrecognized keysym" xkbcommon errors. Strip
+      # them so the AppImage falls through to the host's libraries at runtime —
+      # this is what the AppImage excludelist exists for, and why a local
+      # build_appimage.sh (which bundles the user's own newer libs) works while
+      # the CI build did not. libvulkan is intentionally left bundled.
+      - name: Slim AppImage to host graphics/input libraries (Linux)
+        if: runner.os == 'Linux' && !matrix.cuda
+        env:
+          APPIMAGE_EXTRACT_AND_RUN: 1
+        run: |
+          set -euo pipefail
+          appimage=$(find . -path '*/bundle/appimage/*.AppImage' ! -name '*.zsync' | head -1)
+          if [ -z "${appimage:-}" ]; then echo "No AppImage found to slim"; exit 1; fi
+          echo "Slimming $appimage"
+          chmod +x ./appimagetool.bin
+
+          work=$(mktemp -d)
+          cp "$appimage" "$work/in.AppImage"
+          chmod +x "$work/in.AppImage"
+          ( cd "$work" && ./in.AppImage --appimage-extract >/dev/null )
+
+          root="$work/squashfs-root"
+          for pat in 'libwayland-*.so*' 'libEGL.so*' 'libGL.so*' 'libGLX.so*' \
+                     'libGLdispatch.so*' 'libOpenGL.so*' 'libglapi.so*' \
+                     'libgbm.so*' 'libdrm.so*' \
+                     'libxkbcommon.so*' 'libxkbcommon-x11.so*'; do
+            find "$root" -name "$pat" -print -delete 2>/dev/null || true
+          done
+
+          rm -f "$appimage"
+          ARCH=x86_64 ./appimagetool.bin "$root" "$appimage"
+          echo "Repackaged $appimage ($(du -h "$appimage" | cut -f1))"
+
       # CUDA build uses --bundles deb only: the CUDA toolkit populates system
       # library paths with hundreds of CUDA .so files that linuxdeploy tries to
       # bundle into the AppImage, causing it to OOM or fail. deb packaging does

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "voxctrl",
   "private": true,
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "module",
   "scripts": {
     "predev": "pkill -x voxctrl || true",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VoxCtrl",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "identifier": "ai.voxctrl.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Why the local AppImage works but the CI one doesn't

`build_appimage.sh` isn't doing anything special in its *logic* — it runs the same `npx tauri build`. The difference is **where it runs**: on your machine, so `linuxdeploy` bundles **your own** (modern, matching) graphics/Wayland/input libraries. CI runs on **ubuntu-22.04** and bundles *its* older copies, which get loaded instead of your host's and break the Slint overlay's **Wayland frame-callback loop** — it renders once, then the compositor never delivers another frame.

The smoking gun is already in your logs from the CI build:
```
xkbcommon: ERROR: …/Compose:1661:1: unrecognized keysym "dead_hamza"
```
That's the bundled `libxkbcommon` being too old for your system's Compose file — proof the AppImage is shipping stale host-coupled libraries.

## Fix
After the Tauri build, strip the host-coupled libraries from the AppImage and repackage with the repo's own `appimagetool.bin` (the same tool `build_appimage.sh` uses), so the AppImage falls through to the **host's** copies at runtime — exactly what the AppImage "excludelist" is for:

- removed: `libwayland-*`, `libEGL`/`libGL`/`libGLX`/`libGLdispatch`/`libOpenGL`/`libglapi`, `libgbm`, `libdrm`, `libxkbcommon`/`libxkbcommon-x11`
- **kept:** `libvulkan` (needed for the GPU build)
- applies to both Linux AppImage jobs (CPU + Vulkan); the CUDA `.deb` job is untouched.

Version bumped to **0.2.6** so the fixed artifact is unmistakable.

## Honesty / risk
I can't run a GTK/Wayland AppImage in this sandbox, so this is validated by reasoning + your evidence, not a local run. The library list is the standard excludelist set (these libs exist on every Linux desktop, so removing them from the bundle is safe). If repackaging hiccups in CI, it'll fail loudly at that step and I'll adjust.

This stacks on the v0.2.5 idle-redraw change (harmless either way). Merging triggers an auto **v0.2.6** build; grab `…0.2.6…-vulkan.AppImage` and the overlay should persist across dictations (and the xkbcommon errors should disappear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RkpDbnQdrTEY56HaEzuKBK)_