### PR TITLE
Begin macOS port: platform code paths + testable build process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, windows-latest]
+        # macos-14 = Apple Silicon (arm64). It runs the full-workspace check
+        # (same branch as Linux, since runner.os != 'Windows'), so macOS-specific
+        # platform code and the whisper.cpp/C++ crates are compile-checked here.
+        os: [ubuntu-22.04, windows-latest, macos-14]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -1,0 +1,115 @@
+name: macOS Build (preview)
+
+# Standalone macOS build used to validate the macOS port BEFORE it is merged to
+# master. It intentionally does not touch the release workflow: it just builds
+# the .app/.dmg on an Apple-Silicon runner and uploads them as workflow
+# artifacts you can download and run.
+#
+# How to test the port without merging:
+#   * Push to the `claude/macos-port-build` branch (or any `macos-**` branch) —
+#     this workflow runs automatically on that push.
+#   * Or open a PR targeting `development`/`master` that changes macOS-relevant
+#     files — it runs on the PR.
+#   * Once this file is on the default branch, you can also trigger it manually
+#     from the Actions tab ("Run workflow"), optionally enabling Moonshine.
+#
+# Download the built app from the run's "Artifacts" section. Unsigned builds
+# require a right-click → Open (or `xattr -dr com.apple.quarantine VoxCtrl.app`)
+# the first time, since they are not notarized.
+
+on:
+  push:
+    branches:
+      - "claude/macos-port-build"
+      - "macos-**"
+  pull_request:
+    branches: [development, master]
+    paths:
+      - ".github/workflows/macos-build.yml"
+      - "src-tauri/**"
+      - "crates/**"
+      - "src/**"
+      - "scripts/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "package.json"
+      - "package-lock.json"
+  workflow_dispatch:
+    inputs:
+      moonshine:
+        description: "Also bundle the Moonshine ONNX backend (fetches ONNX Runtime at build time)"
+        type: boolean
+        default: false
+
+env:
+  CARGO_HTTP_MULTIPLEXING: false
+  CARGO_HTTP_HTTP2: false
+
+concurrency:
+  group: macos-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-macos:
+    name: Build macOS .app + .dmg (Apple Silicon)
+    runs-on: macos-14
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: macos-build
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - run: npm install
+
+      # whisper.cpp links Metal/Accelerate automatically on macOS — no extra
+      # system dependencies are needed beyond the Xcode toolchain that ships on
+      # the runner. beforeBuildCommand (in tauri.conf.json) builds the overlay
+      # sidecar, stages it for the host triple, and runs the Vite build.
+      - name: Build .app + .dmg (macOS)
+        run: |
+          set -euo pipefail
+          if [ "${{ inputs.moonshine }}" = "true" ]; then
+            echo "Building with Moonshine backend"
+            npx tauri build --bundles app,dmg -- --features moonshine
+          else
+            echo "Building CPU/Metal build (no Moonshine)"
+            npx tauri build --bundles app,dmg
+          fi
+
+      - name: Collect macOS artifacts
+        run: |
+          set -euo pipefail
+          mkdir -p upload
+
+          # DMG(s)
+          find . -path '*/bundle/dmg/*.dmg' ! -path '*/.cargo/*' -exec cp {} upload/ \; || true
+
+          # .app bundle — zip it so the artifact preserves the bundle structure
+          appdir=$(find . -path '*/bundle/macos/*.app' -type d ! -path '*/.cargo/*' | head -1)
+          if [ -n "${appdir:-}" ]; then
+            ( cd "$(dirname "$appdir")" && ditto -c -k --sequesterRsrc --keepParent \
+              "$(basename "$appdir")" "$OLDPWD/upload/$(basename "${appdir%.app}")-macos-arm64.app.zip" )
+          fi
+
+          echo "Collected:"
+          ls -lh upload/
+          if [ -z "$(ls -A upload/)" ]; then
+            echo "::error::No macOS bundle artifacts were produced"
+            exit 1
+          fi
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: voxctrl-macos-arm64
+          path: upload/*
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,18 @@ jobs:
             artifact_label: windows-x86_64
             cuda: false
 
+          # ── macOS (Apple Silicon) ──────────────────────────────────────────
+          # Native arm64 build; whisper.cpp links Metal/Accelerate automatically.
+          # Moonshine is intentionally left off this row for now — validate it
+          # via the standalone "macOS Build (preview)" workflow first, then add
+          # `--features moonshine` here. fail-fast:false keeps the other
+          # platforms publishing even if this variant needs iteration.
+          - name: macos-arm64
+            os: macos-14
+            features: ""
+            artifact_label: macos-arm64
+            cuda: false
+
     steps:
       - uses: actions/checkout@v4
 
@@ -228,6 +240,15 @@ jobs:
         if: runner.os == 'Windows'
         run: npx tauri build --bundles nsis -- --features moonshine
 
+      # ── Tauri build (macOS) ─────────────────────────────────────────────────
+      # Native .app + .dmg on the Apple-Silicon runner. No system deps needed —
+      # whisper.cpp links Metal/Accelerate via the runner's Xcode toolchain.
+      # Builds unsigned/un-notarized for now; add signing env + entitlements once
+      # a Developer ID certificate is available in repo secrets.
+      - name: Build .app + .dmg (macOS)
+        if: runner.os == 'macOS'
+        run: npx tauri build --bundles app,dmg
+
       # ── Collect and rename Linux artifacts ──────────────────────────────────
       # Search the whole workspace so the path is correct regardless of whether
       # cargo uses a workspace-level or package-level target directory.
@@ -271,6 +292,25 @@ jobs:
               Select-Object -ExpandProperty FullName
             exit 1
           }
+
+      # ── Collect and rename macOS artifacts ──────────────────────────────────
+      - name: Collect macOS artifacts
+        if: runner.os == 'macOS'
+        run: |
+          set -euo pipefail
+          mkdir -p upload
+          found=0
+          while IFS= read -r f; do
+            cp "$f" "upload/VoxCtrl-${{ matrix.artifact_label }}.dmg"
+            echo "Collected: upload/VoxCtrl-${{ matrix.artifact_label }}.dmg ($(du -sh "$f" | cut -f1))"
+            found=1
+            break
+          done < <(find . -path '*/bundle/dmg/*.dmg' ! -path '*/.cargo/*')
+          if [ "$found" -eq 0 ]; then
+            echo "::error::No .dmg found under bundle/dmg"
+            exit 1
+          fi
+          ls -lh upload/
 
       # ── Upload to Actions (picked up by publish job) ─────────────────────────
       - uses: actions/upload-artifact@v4
@@ -332,6 +372,7 @@ jobs:
             | Linux | `-linux-x86_64.AppImage` | None |
             | Linux (GPU) | `-linux-x86_64-vulkan.AppImage` | Any Vulkan GPU |
             | Windows | `-windows-x86_64-setup.exe` | None |
+            | macOS (Apple Silicon) | `-macos-arm64.dmg` | None (uses Metal) |
 
             **The Vulkan AppImage** is a portable GPU build: it accelerates any
             NVIDIA/AMD/Intel GPU via the host Vulkan driver, and falls back to
@@ -347,3 +388,14 @@ jobs:
             # Launch the application
             ./VoxCtrl_*-linux-x86_64*.AppImage
             ```
+
+            ### macOS (Apple Silicon) — first run
+            The macOS build is currently **unsigned / un-notarized**, so
+            Gatekeeper blocks it on first launch. Open the `.dmg`, drag VoxCtrl
+            to Applications, then either right-click the app → **Open**, or run:
+            ```bash
+            xattr -dr com.apple.quarantine /Applications/VoxCtrl.app
+            ```
+            On first use, grant VoxCtrl **Microphone**, **Accessibility**, and
+            **Input Monitoring** under System Settings → Privacy & Security so
+            dictation and global hotkeys work.

--- a/crates/voxctrl-hotkeys/Cargo.toml
+++ b/crates/voxctrl-hotkeys/Cargo.toml
@@ -17,6 +17,7 @@ crossbeam-channel = { workspace = true }
 [target.'cfg(target_os = "linux")'.dependencies]
 evdev = "0.12"
 
-[target.'cfg(target_os = "windows")'.dependencies]
-# rdev provides global hotkey listening on Windows
+[target.'cfg(any(target_os = "windows", target_os = "macos"))'.dependencies]
+# rdev provides global hotkey listening on Windows and macOS (CGEventTap on
+# macOS — requires the Input Monitoring / Accessibility permissions at runtime).
 rdev = "0.5"

--- a/crates/voxctrl-hotkeys/src/lib.rs
+++ b/crates/voxctrl-hotkeys/src/lib.rs
@@ -2,8 +2,10 @@ pub mod gestures;
 
 #[cfg(target_os = "linux")]
 mod linux;
-#[cfg(target_os = "windows")]
-mod windows;
+// rdev-based listener shared by Windows and macOS (both lack a raw evdev
+// equivalent; rdev taps the OS input event stream on each).
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+mod rdev_backend;
 
 use tokio::sync::mpsc;
 use voxctrl_routing::HotkeyBinding;
@@ -34,11 +36,11 @@ pub fn start_listener(
     {
         linux::start(bindings, tx, device_path, reloader_rx);
     }
-    #[cfg(target_os = "windows")]
+    #[cfg(any(target_os = "windows", target_os = "macos"))]
     {
-        windows::start(bindings, tx, reloader_rx);
+        rdev_backend::start(bindings, tx, reloader_rx);
     }
-    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+    #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
     {
         tracing::warn!("Hotkey listener not supported on this platform");
     }

--- a/crates/voxctrl-hotkeys/src/rdev_backend.rs
+++ b/crates/voxctrl-hotkeys/src/rdev_backend.rs
@@ -16,7 +16,7 @@ pub fn start(bindings: Vec<HotkeyBinding>, tx: GestureSender, rx_reload: crate::
 }
 
 fn run(bindings: Vec<HotkeyBinding>, tx: GestureSender, rx_reload: crate::ReloaderReceiver) {
-    info!("rdev hotkey listener active (Windows)");
+    info!("rdev hotkey listener active");
 
     let mut states: Vec<BindingState> =
         bindings.into_iter().map(BindingState::new).collect();

--- a/crates/voxctrl-inject/src/lib.rs
+++ b/crates/voxctrl-inject/src/lib.rs
@@ -10,7 +10,10 @@ pub async fn inject_text(text: &str) -> Result<()> {
     #[cfg(target_os = "windows")]
     return inject_windows(text).await;
 
-    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+    #[cfg(target_os = "macos")]
+    return inject_macos(text).await;
+
+    #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
     anyhow::bail!("Text injection not supported on this platform");
 }
 
@@ -68,6 +71,35 @@ async fn clipboard_paste(text: &str) -> Result<()> {
         run_cmd("wtype", &["-M", "ctrl", "v", "-m", "ctrl"]).await;
     } else if voxctrl_config::find_in_path("xdotool").is_some() {
         run_cmd("xdotool", &["key", "--clearmodifiers", "ctrl+v"]).await;
+    }
+    Ok(())
+}
+
+// ── macOS ─────────────────────────────────────────────────────────────────────
+
+#[cfg(target_os = "macos")]
+async fn inject_macos(text: &str) -> Result<()> {
+    // Copy to the pasteboard, then synthesize Cmd+V via AppleScript. Requires
+    // the Accessibility permission (System Settings → Privacy & Security).
+    let t = text.to_string();
+    tokio::task::spawn_blocking(move || {
+        let mut cb = arboard::Clipboard::new()?;
+        cb.set_text(&t)?;
+        anyhow::Ok(())
+    })
+    .await??;
+
+    let ok = tokio::process::Command::new("osascript")
+        .args([
+            "-e",
+            "tell application \"System Events\" to keystroke \"v\" using command down",
+        ])
+        .status()
+        .await
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !ok {
+        warn!("osascript paste failed; grant Accessibility permission to VoxCtrl");
     }
     Ok(())
 }

--- a/crates/voxctrl-mcp/src/lib.rs
+++ b/crates/voxctrl-mcp/src/lib.rs
@@ -1,4 +1,4 @@
-//! JSON-RPC 2.0 MCP server over a Unix domain socket (Linux) or a named pipe (Windows).
+//! JSON-RPC 2.0 MCP server over a Unix domain socket (Linux/macOS) or a named pipe (Windows).
 //!
 //! Exposed tools:
 //!   - transcribe_voice(timeout_seconds) → {text}
@@ -81,18 +81,24 @@ pub trait McpCallbacks: Send + Sync + 'static {
 // ── Server ────────────────────────────────────────────────────────────────────
 
 pub async fn run_server<C: McpCallbacks>(callbacks: Arc<C>) -> Result<()> {
-    #[cfg(target_os = "linux")]
+    #[cfg(unix)]
     run_unix_server(callbacks).await?;
 
     #[cfg(target_os = "windows")]
     run_named_pipe_server(callbacks).await?;
 
+    #[cfg(not(any(unix, target_os = "windows")))]
+    {
+        let _ = callbacks;
+        warn!("MCP server not supported on this platform");
+    }
+
     Ok(())
 }
 
-// ── Unix socket server (Linux) ────────────────────────────────────────────────
+// ── Unix socket server (Linux/macOS) ──────────────────────────────────────────
 
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 async fn run_unix_server<C: McpCallbacks>(callbacks: Arc<C>) -> Result<()> {
     use tokio::net::UnixListener;
 

--- a/crates/voxctrl-routing/src/targets.rs
+++ b/crates/voxctrl-routing/src/targets.rs
@@ -144,6 +144,41 @@ impl DeliveryTarget for InjectTarget {
             };
         }
 
+        #[cfg(target_os = "macos")]
+        {
+            // macOS has no direct "type this string" primitive comparable to
+            // wtype/xdotool without extra native APIs. Mirror the clipboard-paste
+            // fallback: put the text on the pasteboard, then synthesize Cmd+V via
+            // AppleScript (System Events). This requires the app to have been
+            // granted the Accessibility permission in
+            // System Settings → Privacy & Security → Accessibility.
+            let p = payload.clone();
+            let set = tokio::task::spawn_blocking(move || {
+                arboard::Clipboard::new()
+                    .context("open clipboard")?
+                    .set_text(&p)
+                    .context("set text")
+            })
+            .await;
+            if !matches!(set, Ok(Ok(()))) {
+                return DeliveryResult::err("Failed to set clipboard for macOS paste injection");
+            }
+            let ok = tokio::process::Command::new("osascript")
+                .args(["-e", "tell application \"System Events\" to keystroke \"v\" using command down"])
+                .status()
+                .await
+                .map(|s| s.success())
+                .unwrap_or(false);
+            return if ok {
+                DeliveryResult::ok(payload)
+            } else {
+                DeliveryResult::err(
+                    "osascript paste failed — grant VoxCtrl the Accessibility permission \
+                     in System Settings → Privacy & Security → Accessibility",
+                )
+            };
+        }
+
         #[allow(unreachable_code)]
         DeliveryResult::err("Text injection not supported on this platform")
     }
@@ -164,6 +199,11 @@ impl DeliveryTarget for InjectTarget {
         }
         #[cfg(target_os = "windows")]
         return TestResult { reachable: true, detail: "PowerShell SendKeys available".into() };
+        #[cfg(target_os = "macos")]
+        return TestResult {
+            reachable: which("osascript"),
+            detail: "macOS paste via osascript (Accessibility permission required)".into(),
+        };
         #[allow(unreachable_code)]
         TestResult { reachable: false, detail: "Platform not supported".into() }
     }
@@ -624,7 +664,7 @@ impl DeliveryTarget for McpTarget {
         let tool = self.0.mcp_tool.as_deref().unwrap_or("speak_text");
         let args = build_json_payload(&self.0.mcp_args, text);
 
-        #[cfg(target_os = "linux")]
+        #[cfg(unix)]
         let s = {
             let path = self.0.mcp_path.as_deref().unwrap_or("/tmp/voxctrl-mcp.sock");
             match UnixStream::connect(path).await {
@@ -643,7 +683,7 @@ impl DeliveryTarget for McpTarget {
             }
         };
 
-        #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+        #[cfg(not(any(unix, target_os = "windows")))]
         return DeliveryResult::err("MCP target not supported on this platform");
 
         use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -741,7 +781,7 @@ impl DeliveryTarget for McpTarget {
     }
 
     async fn test(&self) -> TestResult {
-        #[cfg(target_os = "linux")]
+        #[cfg(unix)]
         {
             let path = self.0.mcp_path.as_deref().unwrap_or("/tmp/voxctrl-mcp.sock");
             match UnixStream::connect(path).await {
@@ -758,7 +798,7 @@ impl DeliveryTarget for McpTarget {
                 Err(e) => TestResult { reachable: false, detail: e.to_string() },
             }
         }
-        #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+        #[cfg(not(any(unix, target_os = "windows")))]
         TestResult { reachable: false, detail: "Platform not supported".into() }
     }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ VoxCtrl is a high-performance, privacy-first voice-to-text dictation application
 | [Configuration](./configuration.md) | All config files, schemas, and options |
 | [Installation & Setup](./installation.md) | Dependencies, building, running |
 | [Development Guide](./development.md) | Dev environment, build system, crate structure |
+| [Building on macOS](./macos_build.md) | macOS (Apple Silicon) build, permissions, signing, CI |
 
 ---
 

--- a/docs/macos_build.md
+++ b/docs/macos_build.md
@@ -1,0 +1,145 @@
+# Building VoxCtrl on macOS
+
+> **Status: in progress.** macOS is a new target. The core paths (UI, audio,
+> whisper inference, clipboard, tray, notifications, MCP server, text injection,
+> global hotkeys) have macOS code, but the port has not yet had the same
+> real-hardware soak testing as Linux/KDE. Treat macOS builds as preview
+> quality and file issues for anything that misbehaves. See
+> [Cross-Platform UI Testing](./cross_platform_ui_testing.md) for the testing
+> strategy this port follows.
+
+## Supported hardware
+
+- **Apple Silicon (arm64)** — the primary target. CI builds it on `macos-14`.
+- **Intel (x86_64)** — buildable on `macos-13`, not shipped by default. Add a
+  matching matrix row if you need it.
+
+Whisper inference uses **Metal** acceleration automatically on macOS (via
+`whisper-rs`/whisper.cpp); no CUDA/Vulkan flags apply.
+
+---
+
+## Prerequisites
+
+| Tool | Version | Notes |
+|---|---|---|
+| Rust (via rustup) | 1.75+ | `stable-aarch64-apple-darwin` on Apple Silicon |
+| Node.js | 18+ | Frontend build (Vite/Svelte) |
+| Xcode Command Line Tools | current | `xcode-select --install` — provides `clang`, Metal, and the SDK |
+| Tauri CLI | 2.x | `cargo install tauri-cli`, or use the bundled `npx tauri` |
+
+No Homebrew system libraries are required for a standard build — unlike Linux,
+there is no WebKitGTK/PortAudio/appindicator to install. macOS provides
+`WKWebView`, CoreAudio, and the menu-bar tray natively.
+
+---
+
+## Development build
+
+```bash
+npm install
+npm run tauri dev
+```
+
+## Production build
+
+```bash
+npm install
+npx tauri build --bundles app,dmg
+```
+
+Artifacts land in `src-tauri/target/release/bundle/`:
+- `macos/VoxCtrl.app` — the application bundle
+- `dmg/VoxCtrl_<version>_aarch64.dmg` — the disk image
+
+To also compile the Moonshine ONNX backend (fetches ONNX Runtime at build
+time, so it needs network access during the build):
+
+```bash
+npx tauri build --bundles app,dmg -- --features moonshine
+```
+
+---
+
+## Permissions (TCC)
+
+macOS gates the capabilities VoxCtrl relies on behind per-app user consent.
+The bundle ships usage-description strings (`src-tauri/Info.plist`) so the
+prompts appear; the user must grant, under **System Settings → Privacy &
+Security**:
+
+| Permission | Why VoxCtrl needs it |
+|---|---|
+| **Microphone** | Recording audio for transcription |
+| **Accessibility** | Synthesizing the paste keystroke that inserts dictated text |
+| **Input Monitoring** | The global hotkey listener (`rdev` event tap) |
+
+If dictation types nothing, or hotkeys never fire, an ungranted permission is
+the first thing to check.
+
+---
+
+## Platform notes / current limitations
+
+- **Text injection** copies the text to the pasteboard and synthesizes
+  **Cmd+V** via AppleScript (`osascript` → System Events). This mirrors the
+  clipboard-paste fallback used elsewhere and requires the Accessibility
+  permission. A native `CGEvent`/`SendInput`-equivalent path may replace it
+  later for speed/reliability.
+- **Global hotkeys** use the `rdev` event tap (the same backend as Windows),
+  which requires Input Monitoring + Accessibility. The raw-evdev Linux path
+  does not apply.
+- **MCP server** listens on the same Unix domain socket as Linux
+  (`/tmp/voxctrl-mcp.sock`).
+- **DBus** output targets are **Linux-only** and are inert on macOS; use
+  `exec`, `http`, `webhook`, `socket`, or `pipe` instead for automation.
+
+---
+
+## Signing & notarization (for distribution)
+
+Unsigned builds are fine for local testing but Gatekeeper blocks them on other
+machines, and TCC permission grants are tied to the code signature (so an
+unsigned app can lose granted permissions on rebuild). For distribution:
+
+1. Obtain an Apple **Developer ID Application** certificate (Apple Developer
+   Program, $99/yr).
+2. Add the certificate and an App Store Connect API key to the repo secrets,
+   and wire Tauri's signing/notarization env vars
+   (`APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_SIGNING_IDENTITY`,
+   `APPLE_API_ISSUER`, `APPLE_API_KEY`, `APPLE_API_KEY_PATH`) in the release
+   job.
+3. Add an `entitlements.plist` (with `com.apple.security.device.audio-input`)
+   and reference it from `bundle.macOS.entitlements` in `tauri.conf.json`.
+
+See the [Tauri macOS signing docs](https://tauri.app/distribute/sign/macos/).
+
+---
+
+## Building on GitHub Actions
+
+Two workflows cover macOS:
+
+- **`.github/workflows/macos-build.yml` — "macOS Build (preview)".** A
+  standalone build that runs on pushes to the `claude/macos-port-build`
+  branch (or any `macos-**` branch), on PRs touching macOS-relevant files, and
+  via manual dispatch. It uploads the `.app` (zipped) and `.dmg` as run
+  artifacts. **This is how the port is validated without merging to master.**
+- **`.github/workflows/release.yml`.** The macOS row (`macos-14`) is part of
+  the release matrix and produces `VoxCtrl-macos-arm64.dmg` alongside the Linux
+  and Windows artifacts. It only runs on pushes to `master`.
+
+The `cargo check` CI job (`.github/workflows/ci.yml`) also runs on `macos-14`,
+so macOS compile breakage is caught on every PR.
+
+### Troubleshooting
+
+- **`No .dmg found under bundle/dmg`** — the bundle step failed earlier; scroll
+  up in the build step log. A common cause is a Rust compile error in a
+  macOS-gated code path.
+- **App won't open ("damaged / unidentified developer")** — expected for
+  unsigned builds. Right-click → Open, or
+  `xattr -dr com.apple.quarantine /Applications/VoxCtrl.app`.
+- **Overlay sidecar missing at runtime** — the `beforeBuildCommand` stages
+  `voxctrl-overlay` for the host triple; ensure the build ran it (a native
+  build where the runner arch matches the target handles this automatically).

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!--
+    Merged into the generated macOS Info.plist at bundle time (Tauri reads
+    src-tauri/Info.plist). These usage-description strings are mandatory on
+    macOS: the OS terminates the app the first time it touches the microphone
+    or drives another app via Apple Events if the corresponding key is absent.
+  -->
+  <key>NSMicrophoneUsageDescription</key>
+  <string>VoxCtrl records from your microphone to transcribe speech to text on-device. Audio never leaves your machine.</string>
+  <key>NSAppleEventsUsageDescription</key>
+  <string>VoxCtrl sends a paste keystroke to the focused app to insert your dictated text.</string>
+</dict>
+</plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -79,6 +79,9 @@
       "webviewInstallMode": {
         "type": "embedBootstrapper"
       }
+    },
+    "macOS": {
+      "minimumSystemVersion": "11.0"
     }
   }
 }


### PR DESCRIPTION
## Summary

Starts the macOS (Apple Silicon) port and — importantly — wires up a way to **build and test it in CI without merging to `master`**. All Rust changes are additive and `cfg`-gated, so Linux and Windows behavior is unchanged (verified: the four touched crates `cargo check` clean and `voxctrl-routing`/`voxctrl-hotkeys` tests pass on Linux).

Base branch is `development` (there is no `dev` branch; `development` is currently identical to `master`).

## How to test without merging to main

The new **`.github/workflows/macos-build.yml` ("macOS Build (preview)")** builds the `.app` + `.dmg` on a `macos-14` runner and uploads them as run artifacts. It triggers on:
- pushes to `claude/macos-port-build` (or any `macos-**` branch) — already runs from this PR's pushes,
- PRs touching macOS-relevant files,
- manual dispatch (once the file reaches the default branch), with an optional Moonshine toggle.

Download the built app from the run's **Artifacts** section. Nothing in `release.yml` (which only runs on `master`) is required to validate the port.

## Code paths added for macOS (all `cfg`-gated)

- **`voxctrl-mcp`** — bind the Unix-domain-socket server on any `unix` (macOS included) instead of Linux-only; added a non-unix/non-windows fallback.
- **`voxctrl-routing`** — widened the `mcp` delivery client to `unix`; added a macOS text-injection path (pasteboard + `osascript` Cmd+V, mirroring the existing clipboard-paste fallback). `InjectTarget` is the real dictation path, which previously returned "not supported" on macOS.
- **`voxctrl-inject`** — added a macOS `inject_text` path (`arboard` + `osascript`).
- **`voxctrl-hotkeys`** — renamed the rdev listener (`windows.rs` → `rdev_backend.rs`) and reused it on macOS; `rdev` (already the Windows backend, supports macOS via `CGEventTap`) added to the macOS target deps.

## Build config

- **`tauri.conf.json`** — added `bundle.macOS` (`minimumSystemVersion`).
- **`src-tauri/Info.plist`** — `NSMicrophoneUsageDescription` + `NSAppleEventsUsageDescription` (macOS terminates the app on mic access / Apple Events without these).

## CI / release

- **`ci.yml`** — added `macos-14` to the `cargo check` matrix (full-workspace check, so the whisper.cpp/C++ crates and macOS platform code are compile-checked on every PR).
- **`release.yml`** — added a `macos-arm64` row producing `VoxCtrl-macos-arm64.dmg`, a downloads-table entry, and unsigned first-run instructions. Built without Moonshine for now (validate via the preview workflow first); `fail-fast: false` keeps the other platforms publishing.

## Docs

- **`docs/macos_build.md`** — build steps, TCC permissions (Microphone / Accessibility / Input Monitoring), signing & notarization, and CI. Linked from the docs index.

## Known follow-ups (not in this PR)

- Runtime behavioral testing on real Mac hardware (overlay always-on-top across Spaces/full-screen, injection into native/Electron apps, permission-denied degradation).
- Code signing + notarization (needs a Developer ID cert in repo secrets) and an `entitlements.plist`.
- Optional: enable Moonshine on the macOS release row once validated; optional Intel (`macos-13`) row.

## Test plan
- [ ] `macOS Build (preview)` workflow goes green and produces a runnable `.dmg`/`.app` artifact
- [ ] `cargo check` job passes on `macos-14`
- [ ] Existing Linux/Windows CI unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxShw1N7j26vQKfJnmWTu5)_