### PR TITLE
Fix AppImage startup crash: GLib/GStreamer version mismatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,10 +229,20 @@ jobs:
             fi
           done
 
+          # GLib must be stripped together with GStreamer: the host's
+          # libgstreamer-1.0 (loaded because we delete the bundled copy) is
+          # compiled against the host's GLib and may reference symbols newer
+          # than the build host's GLib 2.72 (e.g. g_once_init_leave_pointer,
+          # GLib 2.80) — keeping a bundled GLib on LD_LIBRARY_PATH then aborts
+          # with a symbol lookup error. glib/gio are on the standard AppImage
+          # excludelist for exactly this reason; every bundled library only
+          # needs GLib >= 2.72, which any host able to run this AppImage has.
           for pat in 'libwayland-*.so*' 'libEGL.so*' 'libGL.so*' 'libGLX.so*' \
                      'libGLdispatch.so*' 'libOpenGL.so*' 'libglapi.so*' \
                      'libgbm.so*' 'libdrm.so*' \
                      'libxkbcommon.so*' 'libxkbcommon-x11.so*' \
+                     'libglib-2.0.so*' 'libgobject-2.0.so*' 'libgio-2.0.so*' \
+                     'libgmodule-2.0.so*' 'libgthread-2.0.so*' \
                      'libgstreamer-*.so*' 'libgst*.so*'; do
             find "$root" -name "$pat" -print -delete 2>/dev/null || true
           done

--- a/build_appimage.sh
+++ b/build_appimage.sh
@@ -337,10 +337,17 @@ done
 
 # Strip graphics, Wayland, input libraries, and host-dependent/security libraries
 # so the AppImage falls through to the host system's native versions at runtime.
+# GLib must go together with GStreamer: the host's libgstreamer-1.0 (used
+# because we delete the bundled copy) is compiled against the host's GLib and
+# may reference symbols newer than the bundled GLib (e.g.
+# g_once_init_leave_pointer, GLib 2.80), causing a symbol lookup error at
+# startup if a bundled GLib shadows the host's on LD_LIBRARY_PATH.
 for pat in 'libwayland-*.so*' 'libEGL.so*' 'libGL.so*' 'libGLX.so*' \
            'libGLdispatch.so*' 'libOpenGL.so*' 'libglapi.so*' \
            'libgbm.so*' 'libdrm.so*' \
            'libxkbcommon.so*' 'libxkbcommon-x11.so*' \
+           'libglib-2.0.so*' 'libgobject-2.0.so*' 'libgio-2.0.so*' \
+           'libgmodule-2.0.so*' 'libgthread-2.0.so*' \
            'libgstreamer-*.so*' 'libgst*.so*' \
            'libvulkan.so*' 'libssl.so*' 'libcrypto.so*' \
            'libcanberra-gtk3.so*' 'libcanberra.so*' \


### PR DESCRIPTION
## Problem

Running the released AppImage on a modern distro (e.g. Arch) aborts at startup:

```
voxctrl: symbol lookup error: /usr/lib/libgstreamer-1.0.so.0: undefined symbol: g_once_init_leave_pointer
```

## Root cause

The AppImage "slimming" step deliberately deletes the bundled `libgstreamer*` so the **host's** GStreamer is used at runtime — but it left the bundled **GLib** in place. The release AppImage is built on `ubuntu-22.04`, so the bundled GLib is 2.72, and linuxdeploy's AppRun hook puts the AppDir first on `LD_LIBRARY_PATH`.

On a host whose GStreamer is compiled against GLib ≥ 2.80, `libgstreamer-1.0.so.0` references `g_once_init_leave_pointer` (added in GLib 2.80). That symbol gets resolved against the shadowing bundled GLib 2.72 and doesn't exist → the crash above.

## Fix

Strip the GLib family (`libglib-2.0`, `libgobject-2.0`, `libgio-2.0`, `libgmodule-2.0`, `libgthread-2.0`) alongside GStreamer, in both places the strip list is duplicated:

- `.github/workflows/release.yml` (the CI build users download)
- `build_appimage.sh` (local builds)

so the host's GStreamer and GLib always come from the same place. `libglib-2.0.so.0` / `libgio-2.0.so.0` are on the standard AppImage excludelist for exactly this reason (host GStreamer and GIO modules load into the process and must match the host's GLib).

## Compatibility

- **Safe direction:** all remaining bundled libraries (GTK, WebKitGTK helpers, pango, etc.) were compiled against GLib 2.72, so any host with GLib ≥ 2.72 (the Ubuntu 22.04 build base — already the effective floor, since the AppImage relies on host GL/Wayland/GStreamer) satisfies them. GLib is ABI forward-compatible, so newer host GLib works fine.
- **Other OSes:** Linux-only change — only the AppImage slimming steps are touched; the Windows build and all non-AppImage packaging are unmodified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSVdZhh5D2rSX1eu9fzM25

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSVdZhh5D2rSX1eu9fzM25)_