### PR TITLE
Strip the host GLib/GIO/GStreamer dependency closure from the AppImage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,21 +229,35 @@ jobs:
             fi
           done
 
-          # GLib must be stripped together with GStreamer: the host's
-          # libgstreamer-1.0 (loaded because we delete the bundled copy) is
-          # compiled against the host's GLib and may reference symbols newer
-          # than the build host's GLib 2.72 (e.g. g_once_init_leave_pointer,
-          # GLib 2.80) — keeping a bundled GLib on LD_LIBRARY_PATH then aborts
-          # with a symbol lookup error. glib/gio are on the standard AppImage
-          # excludelist for exactly this reason; every bundled library only
-          # needs GLib >= 2.72, which any host able to run this AppImage has.
-          for pat in 'libwayland-*.so*' 'libEGL.so*' 'libGL.so*' 'libGLX.so*' \
-                     'libGLdispatch.so*' 'libOpenGL.so*' 'libglapi.so*' \
-                     'libgbm.so*' 'libdrm.so*' \
-                     'libxkbcommon.so*' 'libxkbcommon-x11.so*' \
-                     'libglib-2.0.so*' 'libgobject-2.0.so*' 'libgio-2.0.so*' \
-                     'libgmodule-2.0.so*' 'libgthread-2.0.so*' \
-                     'libgstreamer-*.so*' 'libgst*.so*'; do
+          # Everything below is deleted so the AppImage falls through to the
+          # host's copy. The rule: once a library comes from the host, every
+          # library it links against must come from the host too, or the
+          # host's copy resolves its symbols against our stale bundled one and
+          # aborts at startup (seen in the wild: GStreamer needing
+          # g_once_init_leave_pointer from GLib 2.80; GLib needing MOUNT_2_40
+          # from libmount; GIO's TLS module needing GNUTLS_3_8_x). A library
+          # may only be stripped if its soname is stable across distros —
+          # libxml2 (.so.2 vs .so.16 on Arch) and libunistring (.so.2 vs
+          # .so.5) are deliberately kept bundled for that reason. Everything
+          # still bundled only needs the build host's (Ubuntu 22.04) versions
+          # of these, so any newer host satisfies them.
+          for pat in \
+            'libwayland-*.so*' 'libEGL.so*' 'libGL.so*' 'libGLX.so*' \
+            'libGLdispatch.so*' 'libOpenGL.so*' 'libglapi.so*' \
+            'libgbm.so*' 'libdrm.so*' \
+            'libxkbcommon.so*' 'libxkbcommon-x11.so*' \
+            `# GLib family, and what the host's GLib/GIO link against` \
+            'libglib-2.0.so*' 'libgobject-2.0.so*' 'libgio-2.0.so*' \
+            'libgmodule-2.0.so*' 'libgthread-2.0.so*' \
+            'libpcre2-8.so*' 'libpcre.so*' 'libffi.so*' \
+            'libmount.so*' 'libblkid.so*' 'libselinux.so*' \
+            `# GIO loads the host's TLS module, which needs the host's gnutls stack` \
+            'libgiognutls.so' 'libgnutls.so*' 'libhogweed.so*' 'libnettle.so*' \
+            'libtasn1.so*' 'libp11-kit.so*' 'libidn2.so*' \
+            `# GStreamer, and what the host's GStreamer links against` \
+            'libgstreamer-*.so*' 'libgst*.so*' 'liborc-0.4.so*' \
+            'libunwind.so*' 'libdw.so*' 'libelf.so*' \
+            'libbz2.so*' 'liblzma.so*' 'libzstd.so*'; do
             find "$root" -name "$pat" -print -delete 2>/dev/null || true
           done
 

--- a/build_appimage.sh
+++ b/build_appimage.sh
@@ -337,22 +337,35 @@ done
 
 # Strip graphics, Wayland, input libraries, and host-dependent/security libraries
 # so the AppImage falls through to the host system's native versions at runtime.
-# GLib must go together with GStreamer: the host's libgstreamer-1.0 (used
-# because we delete the bundled copy) is compiled against the host's GLib and
-# may reference symbols newer than the bundled GLib (e.g.
-# g_once_init_leave_pointer, GLib 2.80), causing a symbol lookup error at
-# startup if a bundled GLib shadows the host's on LD_LIBRARY_PATH.
-for pat in 'libwayland-*.so*' 'libEGL.so*' 'libGL.so*' 'libGLX.so*' \
-           'libGLdispatch.so*' 'libOpenGL.so*' 'libglapi.so*' \
-           'libgbm.so*' 'libdrm.so*' \
-           'libxkbcommon.so*' 'libxkbcommon-x11.so*' \
-           'libglib-2.0.so*' 'libgobject-2.0.so*' 'libgio-2.0.so*' \
-           'libgmodule-2.0.so*' 'libgthread-2.0.so*' \
-           'libgstreamer-*.so*' 'libgst*.so*' \
-           'libvulkan.so*' 'libssl.so*' 'libcrypto.so*' \
-           'libcanberra-gtk3.so*' 'libcanberra.so*' \
-           'libcanberra-gtk-module.so' 'libcanberra-gtk3-module.so' \
-           'libcolorreload-gtk-module.so' 'libwindow-decorations-gtk-module.so'; do
+# The rule: once a library comes from the host, every library it links against
+# must come from the host too, or the host's copy resolves its symbols against
+# our stale bundled one and aborts at startup (seen in the wild: GStreamer
+# needing g_once_init_leave_pointer from GLib 2.80; GLib needing MOUNT_2_40 from
+# libmount; GIO's TLS module needing GNUTLS_3_8_x). Only strip libraries whose
+# soname is stable across distros — libxml2 (.so.2 vs .so.16 on Arch) and
+# libunistring (.so.2 vs .so.5) are deliberately kept bundled for that reason.
+# Keep this list in sync with .github/workflows/release.yml.
+for pat in \
+    'libwayland-*.so*' 'libEGL.so*' 'libGL.so*' 'libGLX.so*' \
+    'libGLdispatch.so*' 'libOpenGL.so*' 'libglapi.so*' \
+    'libgbm.so*' 'libdrm.so*' \
+    'libxkbcommon.so*' 'libxkbcommon-x11.so*' \
+    `# GLib family, and what the host's GLib/GIO link against` \
+    'libglib-2.0.so*' 'libgobject-2.0.so*' 'libgio-2.0.so*' \
+    'libgmodule-2.0.so*' 'libgthread-2.0.so*' \
+    'libpcre2-8.so*' 'libpcre.so*' 'libffi.so*' \
+    'libmount.so*' 'libblkid.so*' 'libselinux.so*' \
+    `# GIO loads the host's TLS module, which needs the host's gnutls stack` \
+    'libgiognutls.so' 'libgnutls.so*' 'libhogweed.so*' 'libnettle.so*' \
+    'libtasn1.so*' 'libp11-kit.so*' 'libidn2.so*' \
+    `# GStreamer, and what the host's GStreamer links against` \
+    'libgstreamer-*.so*' 'libgst*.so*' 'liborc-0.4.so*' \
+    'libunwind.so*' 'libdw.so*' 'libelf.so*' \
+    'libbz2.so*' 'liblzma.so*' 'libzstd.so*' \
+    'libvulkan.so*' 'libssl.so*' 'libcrypto.so*' \
+    'libcanberra-gtk3.so*' 'libcanberra.so*' \
+    'libcanberra-gtk-module.so' 'libcanberra-gtk3-module.so' \
+    'libcolorreload-gtk-module.so' 'libwindow-decorations-gtk-module.so'; do
     find "$root" -name "$pat" -print -delete 2>/dev/null || true
 done
 


### PR DESCRIPTION
Follow-up to #71.

## Problem

Handing GLib to the host fixed the `g_once_init_leave_pointer` abort, but exposed the next layer down — the host's GLib/GIO now resolved *their own* dependencies against stale bundled copies from the ubuntu-22.04 build host:

```
libpcre2-8.so.0: no version information available (required by /usr/lib/libglib-2.0.so.0)
libmount.so.1: version `MOUNT_2_40' not found (required by /usr/lib/libgio-2.0.so.0)
```

## Approach

The rule: **once a library comes from the host, everything it links against must come from the host too**, or the host's copy resolves symbols against our stale bundled one.

Rather than fix the two reported libraries and wait for the next one, I extracted the actual v0.3.7 release AppImage, mapped every bundled library's `NEEDED` entries, and intersected that with the dependency closure of a newer host's GLib / GIO / GIO-TLS / GStreamer / Mesa stack. That gives the complete set, now stripped in both `.github/workflows/release.yml` and `build_appimage.sh`:

| Pulled in by | Stripped |
|---|---|
| host GLib/GIO | `libpcre2-8`, `libpcre` (dead), `libffi`, `libmount`, `libblkid`, `libselinux` |
| host GIO TLS module | `libgiognutls` + `libgnutls`, `libhogweed`, `libnettle`, `libtasn1`, `libp11-kit`, `libidn2` — host gnutls 3.8 has `GNUTLS_3_8_x` version nodes the bundled 3.7.3 lacks, so this would have been the next failure |
| host GStreamer | `liborc-0.4`, `libunwind`, `libdw`, `libelf`, `libbz2`, `liblzma`, `libzstd` |

### Deliberately kept bundled
- `libxml2` and `libunistring`: their sonames are **not** stable across distros (`libxml2.so.16` on Arch, `libunistring.so.5` on newer hosts), so the host can't be relied on to provide the soname the bundled WebKit/librsvg need. Stripping them would break startup on exactly the newer hosts we're targeting.
- `libsystemd` / `libudev`: their symbol version nodes are unchanged (`LIBUDEV_247` max, both sides), and stripping them would break non-systemd hosts.

## Verification

- Ran the workflow's strip loop **verbatim** against the extracted release AppImage and confirmed the removed set is exactly the tested one (the inline backtick comments expand to nothing).
- Resolved every bundled ELF object (`voxctrl`, `voxctrl-overlay`, the WebKit helper processes, every `.so`) with `ldd -r` under the AppImage's own `LD_LIBRARY_PATH` on an Ubuntu 24.04 host (GLib 2.80, GStreamer 1.24): **no unresolved symbols or version references remain**. The same check on the current release reproduces the reported failure class.
- All remaining bundled libraries only require the build host's (22.04) versions of the newly host-provided libs, so any newer host satisfies them; every stripped library is a hard dependency of the host's own GLib/GStreamer/glib-networking, so it's guaranteed present wherever those are.
- Linux-only change: the Windows build and all non-AppImage packaging are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSVdZhh5D2rSX1eu9fzM25

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSVdZhh5D2rSX1eu9fzM25)_