### PR TITLE
Expose bundled libsystemd/libudev only when the host has no copy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,6 +261,23 @@ jobs:
             find "$root" -name "$pat" -print -delete 2>/dev/null || true
           done
 
+          # libsystemd/libudev can be neither stripped nor left on the library
+          # path: the host's own libmount (Arch) links libsystemd and needs a
+          # newer LIBSYSTEMD_* version node than the build host's copy, while
+          # non-systemd distributions may not ship them at all and the bundled
+          # WebKitGTK needs them. Park them in usr/lib/fallback; the AppRun
+          # hook exposes each one only when the host has no copy of that soname.
+          mkdir -p "$root/usr/lib/fallback"
+          for pat in 'libsystemd.so*' 'libudev.so*'; do
+            find "$root" -name "$pat" -not -path '*/fallback/*' -print \
+              -exec mv -t "$root/usr/lib/fallback/" {} + 2>/dev/null || true
+          done
+          cp scripts/appimage-hooks/host-first-fallback.sh "$root/apprun-hooks/"
+          chmod +x "$root/apprun-hooks/host-first-fallback.sh"
+          if ! grep -q "host-first-fallback.sh" "$root/AppRun"; then
+            sed -i '/^exec /i source "$this_dir"/apprun-hooks/host-first-fallback.sh' "$root/AppRun"
+          fi
+
           rm -f "$appimage"
           ARCH=x86_64 ./appimagetool.bin "$root" "$appimage"
           echo "Repackaged $appimage ($(du -h "$appimage" | cut -f1))"

--- a/build_appimage.sh
+++ b/build_appimage.sh
@@ -369,6 +369,23 @@ for pat in \
     find "$root" -name "$pat" -print -delete 2>/dev/null || true
 done
 
+# libsystemd/libudev can be neither stripped nor left on the library path: the
+# host's own libmount (Arch) links libsystemd and needs a newer LIBSYSTEMD_*
+# version node than the build host's copy, while non-systemd distributions may
+# not ship them at all and the bundled WebKitGTK needs them. Park them in
+# usr/lib/fallback; the AppRun hook exposes each one only when the host has no
+# copy of that soname.
+mkdir -p "$root/usr/lib/fallback"
+for pat in 'libsystemd.so*' 'libudev.so*'; do
+    find "$root" -name "$pat" -not -path '*/fallback/*' -print \
+        -exec mv -t "$root/usr/lib/fallback/" {} + 2>/dev/null || true
+done
+cp "$ROOT_DIR/scripts/appimage-hooks/host-first-fallback.sh" "$root/apprun-hooks/"
+chmod +x "$root/apprun-hooks/host-first-fallback.sh"
+if ! grep -q "host-first-fallback.sh" "$root/AppRun"; then
+    sed -i '/^exec /i source "$this_dir"/apprun-hooks/host-first-fallback.sh' "$root/AppRun"
+fi
+
 # Repackage the AppImage
 rm -f "$LATEST_BUNDLE"
 ARCH=x86_64 ./appimagetool.bin "$root" "$LATEST_BUNDLE" >/dev/null

--- a/scripts/appimage-hooks/host-first-fallback.sh
+++ b/scripts/appimage-hooks/host-first-fallback.sh
@@ -1,0 +1,45 @@
+#! /usr/bin/env bash
+# AppRun hook: host-first fallback libraries.
+#
+# Libraries under usr/lib/fallback are ones the bundled WebKitGTK needs but
+# that must NOT shadow a host copy when the host has one: the host's own
+# libraries link against them (Arch's libmount links libsystemd, and needs
+# LIBSYSTEMD_251, newer than the copy the ubuntu-22.04 build host bundles),
+# so a bundled copy on LD_LIBRARY_PATH aborts the host library at startup.
+# They can't simply be stripped either: non-systemd distributions may not
+# ship them at all, and WebKitGTK would then fail to load.
+#
+# So for each fallback library, expose our copy only when the host has no
+# library of that soname. The symlinks live in a per-user runtime directory
+# because the AppImage mount is read-only.
+#
+# This file is installed into the AppDir by the AppImage slimming step in
+# build_appimage.sh and .github/workflows/release.yml, and sourced by AppRun
+# before it hands over to the linuxdeploy AppRun, which prepends the AppDir
+# library directories to whatever LD_LIBRARY_PATH we export here.
+
+fallback_src="${APPDIR:-$(dirname "$(realpath "$0")")}/usr/lib/fallback"
+if [ -d "$fallback_src" ]; then
+    fallback_dir="${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}/voxctrl-fallback-libs-$(id -u)"
+    rm -rf "$fallback_dir" 2>/dev/null || true
+    if mkdir -p "$fallback_dir" 2>/dev/null; then
+        host_libs="$(ldconfig -p 2>/dev/null || /sbin/ldconfig -p 2>/dev/null || true)"
+        for lib in "$fallback_src"/*.so*; do
+            [ -e "$lib" ] || continue
+            name="$(basename "$lib")"
+            host_has=false
+            if printf '%s\n' "$host_libs" | grep -qF "$name"; then
+                host_has=true
+            else
+                for dir in /usr/lib /usr/lib64 /lib /lib64 \
+                           /usr/lib/x86_64-linux-gnu /lib/x86_64-linux-gnu; do
+                    if [ -e "$dir/$name" ]; then host_has=true; break; fi
+                done
+            fi
+            if [ "$host_has" = false ]; then
+                ln -sf "$lib" "$fallback_dir/$name"
+            fi
+        done
+        export LD_LIBRARY_PATH="$fallback_dir${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+    fi
+fi


### PR DESCRIPTION
Follow-up to #71 and #72 — third layer of the same AppImage problem, this one Arch-specific.

## Problem

```
voxctrl: /tmp/.mount_.../usr/lib/libsystemd.so.0: version `LIBSYSTEMD_251' not found (required by /usr/lib/libmount.so.1)
```

Arch's `libmount` links `libsystemd`. Now that `libmount` comes from the host (#72), it needs the host's `libsystemd` too — but the bundled copy from the ubuntu-22.04 build host only carries the `LIBSYSTEMD_249` and `LIBSYSTEMD_252` version nodes, not 251.

## Why this one can't just be stripped

Unlike the previous layers, `libsystemd`/`libudev` are needed by the bundled WebKitGTK, JavaScriptCore and libdbus, and **non-systemd distributions (Void, Gentoo/OpenRC) don't ship them at all**. Stripping would trade an Arch failure for a Void failure.

## Fix: host-first fallback

- The slimming step (in both `release.yml` and `build_appimage.sh`) moves `libsystemd.so*` and `libudev.so*` into `usr/lib/fallback/`, off the library path.
- A new AppRun hook, `scripts/appimage-hooks/host-first-fallback.sh`, runs at launch and symlinks each fallback library into a per-user runtime directory **only if no library of that soname exists on the host** (checked via `ldconfig -p` plus the standard lib dirs), then puts that directory on `LD_LIBRARY_PATH`. linuxdeploy's AppRun prepends the AppDir paths to whatever we export, so ordering is preserved.
- Result: hosts that have them use their own copies (nothing shadows the host's `libmount`); hosts without them still get ours for WebKitGTK.

I also checked what the host's `libsystemd` links against (`libcap`, `liblz4`, `libgcrypt`) — those bundled copies have no symbol version nodes, so they can't trigger this class of failure.

## Verification

Ran the workflow's slimming step verbatim on the current v0.3.7 release AppImage:
- `libsystemd`/`libudev` end up only in `usr/lib/fallback` (zero copies elsewhere); `AppRun` sources the hook before `exec`.
- Launching through `AppRun` (with a stub in place of the real binary) on a host that has both: fallback runtime dir is empty and `voxctrl` resolves both from `/lib/x86_64-linux-gnu`.
- With a soname the host lacks placed in the fallback dir: it is symlinked in and the dir is first on `LD_LIBRARY_PATH`.
- `ldd -r` on every bundled ELF object under the AppImage's library path: no unresolved symbols or version references.

Linux-only; Windows build untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSVdZhh5D2rSX1eu9fzM25

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSVdZhh5D2rSX1eu9fzM25)_