### PR TITLE
Stop the TTS loaders changing cwd; it broke WebKitGTK's helper spawn

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,22 +212,34 @@ jobs:
             fi
           done
 
+          # The bundled libwebkit2gtk has its helper-process directory compiled
+          # in as /usr/lib/x86_64-linux-gnu/webkit2gtk-4.1, which the Tauri
+          # bundler rewrites to ././/lib/x86_64-linux-gnu/webkit2gtk-4.1 — a
+          # path relative to the working directory, which linuxdeploy's AppRun
+          # sets to $APPDIR/usr. Release builds of WebKitGTK honour no
+          # environment override for it (WEBKIT_EXEC_PATH exists only in
+          # developer-mode builds), so the helpers must sit at exactly that
+          # relative path. WEBKIT_INJECTED_BUNDLE_PATH is honoured, but as a
+          # single directory, not a colon-separated search path.
           if [ -n "$helper_dir" ]; then
             echo "Found WebKitGTK helper processes in $helper_dir, bundling into AppImage..."
-            mkdir -p "$root/usr/lib/webkit2gtk-4.1" \
-                     "$root/usr/lib/x86_64-linux-gnu/webkit2gtk-4.1" \
-                     "$root/lib/webkit2gtk-4.1"
-            cp -r "$helper_dir"/* "$root/usr/lib/webkit2gtk-4.1/"
+            mkdir -p "$root/usr/lib/x86_64-linux-gnu/webkit2gtk-4.1"
             cp -r "$helper_dir"/* "$root/usr/lib/x86_64-linux-gnu/webkit2gtk-4.1/"
-            cp -r "$helper_dir"/* "$root/lib/webkit2gtk-4.1/"
           fi
 
           for script in "$root/AppRun" "$root/apprun-hooks/linuxdeploy-plugin-gtk.sh"; do
-            if [ -f "$script" ] && ! grep -q "WEBKIT_EXEC_PATH" "$script"; then
-              sed -i '2i export WEBKIT_EXEC_PATH="${APPDIR}/usr/lib/webkit2gtk-4.1:${APPDIR}/usr/lib/x86_64-linux-gnu/webkit2gtk-4.1"' "$script"
-              sed -i '3i export WEBKIT_INJECTED_BUNDLE_PATH="${APPDIR}/usr/lib/webkit2gtk-4.1/injected-bundle:${APPDIR}/usr/lib/x86_64-linux-gnu/webkit2gtk-4.1/injected-bundle"' "$script"
-            fi
+            [ -f "$script" ] || continue
+            sed -i '/^export WEBKIT_EXEC_PATH=/d; /^export WEBKIT_INJECTED_BUNDLE_PATH=/d' "$script"
+            sed -i '2i export WEBKIT_EXEC_PATH="${APPDIR}/usr/lib/x86_64-linux-gnu/webkit2gtk-4.1"' "$script"
+            sed -i '3i export WEBKIT_INJECTED_BUNDLE_PATH="${APPDIR}/usr/lib/x86_64-linux-gnu/webkit2gtk-4.1/injected-bundle"' "$script"
           done
+
+          # pocket_tts (the Pocket-TTS and Breeze-TTS-2 engines) finds its model
+          # config at config/<variant>.yaml relative to the working directory.
+          # Bundle it at usr/config so those engines load without changing the
+          # process's cwd — which, per the note above, WebKitGTK depends on.
+          mkdir -p "$root/usr/config"
+          cp crates/voxctrl-tts/config/*.yaml "$root/usr/config/"
 
           # Everything below is deleted so the AppImage falls through to the
           # host's copy. The rule: once a library comes from the host, every

--- a/build_appimage.sh
+++ b/build_appimage.sh
@@ -317,23 +317,33 @@ for dir in "/usr/lib/x86_64-linux-gnu/webkit2gtk-4.1" "/usr/lib/webkit2gtk-4.1" 
     fi
 done
 
+# The bundled libwebkit2gtk has its helper-process directory compiled in as
+# /usr/lib/x86_64-linux-gnu/webkit2gtk-4.1, which the Tauri bundler rewrites to
+# ././/lib/x86_64-linux-gnu/webkit2gtk-4.1 — a path relative to the working
+# directory, which linuxdeploy's AppRun sets to $APPDIR/usr. Release builds of
+# WebKitGTK honour no environment override for it (WEBKIT_EXEC_PATH exists only
+# in developer-mode builds), so the helpers must sit at exactly that relative
+# path. WEBKIT_INJECTED_BUNDLE_PATH is honoured, but as a single directory, not
+# a colon-separated search path.
 if [ -n "$helper_dir" ]; then
     info "Found WebKitGTK helper processes in $helper_dir, bundling into AppImage..."
-    mkdir -p "$root/usr/lib/webkit2gtk-4.1" \
-             "$root/usr/lib/x86_64-linux-gnu/webkit2gtk-4.1" \
-             "$root/lib/webkit2gtk-4.1"
-    cp -r "$helper_dir"/* "$root/usr/lib/webkit2gtk-4.1/"
+    mkdir -p "$root/usr/lib/x86_64-linux-gnu/webkit2gtk-4.1"
     cp -r "$helper_dir"/* "$root/usr/lib/x86_64-linux-gnu/webkit2gtk-4.1/"
-    cp -r "$helper_dir"/* "$root/lib/webkit2gtk-4.1/"
 fi
 
-# Append WEBKIT_EXEC_PATH export into linuxdeploy GTK apprun hook and AppRun
 for script in "$root/AppRun" "$root/apprun-hooks/linuxdeploy-plugin-gtk.sh"; do
-    if [ -f "$script" ] && ! grep -q "WEBKIT_EXEC_PATH" "$script"; then
-        sed -i '2i export WEBKIT_EXEC_PATH="${APPDIR}/usr/lib/webkit2gtk-4.1:${APPDIR}/usr/lib/x86_64-linux-gnu/webkit2gtk-4.1"' "$script"
-        sed -i '3i export WEBKIT_INJECTED_BUNDLE_PATH="${APPDIR}/usr/lib/webkit2gtk-4.1/injected-bundle:${APPDIR}/usr/lib/x86_64-linux-gnu/webkit2gtk-4.1/injected-bundle"' "$script"
-    fi
+    [ -f "$script" ] || continue
+    sed -i '/^export WEBKIT_EXEC_PATH=/d; /^export WEBKIT_INJECTED_BUNDLE_PATH=/d' "$script"
+    sed -i '2i export WEBKIT_EXEC_PATH="${APPDIR}/usr/lib/x86_64-linux-gnu/webkit2gtk-4.1"' "$script"
+    sed -i '3i export WEBKIT_INJECTED_BUNDLE_PATH="${APPDIR}/usr/lib/x86_64-linux-gnu/webkit2gtk-4.1/injected-bundle"' "$script"
 done
+
+# pocket_tts (the Pocket-TTS and Breeze-TTS-2 engines) finds its model config at
+# config/<variant>.yaml relative to the working directory. Bundle it at
+# usr/config so those engines load without changing the process's cwd — which,
+# per the note above, WebKitGTK depends on.
+mkdir -p "$root/usr/config"
+cp "$ROOT_DIR"/crates/voxctrl-tts/config/*.yaml "$root/usr/config/"
 
 # Strip graphics, Wayland, input libraries, and host-dependent/security libraries
 # so the AppImage falls through to the host system's native versions at runtime.

--- a/crates/voxctrl-tts/src/breeze.rs
+++ b/crates/voxctrl-tts/src/breeze.rs
@@ -12,7 +12,7 @@ use voxctrl_config::TtsConfig;
 
 use crate::engine::{PlaybackCallback, Utterance};
 use crate::piper::expand_tilde;
-use crate::pocket::{ensure_pocket_tts_config, POCKET_TTS_VARIANT};
+use crate::pocket::{load_pocket_tts_model, POCKET_TTS_VARIANT};
 
 pub const BREEZE_TTS_2_SAMPLE_RATE: u32 = 24_000;
 const BREEZE_TTS_2_REPO: &str = "BreezeBlue/Breeze-TTS-2";
@@ -133,23 +133,9 @@ pub(crate) fn speak_breeze_tts_2(
 
     if model.is_none() {
         info!("Loading Breeze-TTS-2 neural speech model session in pure Rust...");
-        ensure_pocket_tts_config().context("ensure breeze config file")?;
-
-        let app_dir = dirs::data_local_dir()
-            .unwrap_or_else(|| PathBuf::from("."))
-            .join("voxctrl");
-        let orig_cwd = std::env::current_dir().ok();
-        if app_dir.exists() {
-            let _ = std::env::set_current_dir(&app_dir);
-        }
-
-        let load_res = pocket_tts::TTSModel::load(POCKET_TTS_VARIANT);
-
-        if let Some(ref orig) = orig_cwd {
-            let _ = std::env::set_current_dir(orig);
-        }
-
-        *model = Some(load_res.context("load Breeze-TTS-2 neural model")?);
+        *model = Some(
+            load_pocket_tts_model(POCKET_TTS_VARIANT).context("load Breeze-TTS-2 neural model")?,
+        );
     }
     let tts_model = model.as_ref().unwrap();
 

--- a/crates/voxctrl-tts/src/pocket.rs
+++ b/crates/voxctrl-tts/src/pocket.rs
@@ -137,62 +137,10 @@ const POCKET_TTS_TOKENIZER_REPO: &str = "kyutai/pocket-tts-without-voice-cloning
 const POCKET_TTS_TOKENIZER_REVISION: &str = "d4fdd22ae8c8e1cb3634e150ebeff1dab2d16df3";
 const POCKET_TTS_TOKENIZER_FILE: &str = "tokenizer.model";
 
-pub const POCKET_TTS_CONFIG_YAML: &str = r#"# sig: b6369a24
-
-weights_path: hf://kyutai/pocket-tts/tts_b6369a24.safetensors@427e3d61b276ed69fdd03de0d185fa8a8d97fc5b
-weights_path_without_voice_cloning: hf://kyutai/pocket-tts-without-voice-cloning/tts_b6369a24.safetensors@d4fdd22ae8c8e1cb3634e150ebeff1dab2d16df3
-
-flow_lm:
-  dtype: float32
-  flow:
-    depth: 6
-    dim: 512
-  transformer:
-    d_model: 1024
-    hidden_scale: 4
-    max_period: 10000
-    num_heads: 16
-    num_layers: 6
-  lookup_table:
-    dim: 1024
-    n_bins: 4000
-    tokenizer: sentencepiece
-    tokenizer_path: hf://kyutai/pocket-tts-without-voice-cloning/tokenizer.model@d4fdd22ae8c8e1cb3634e150ebeff1dab2d16df3
-
-mimi:
-  dtype: float32
-  sample_rate: 24000
-  channels: 1
-  frame_rate: 12.5
-  seanet:
-    dimension: 512
-    channels: 1
-    n_filters: 64
-    n_residual_layers: 1
-    ratios:
-    - 6
-    - 5
-    - 4
-    kernel_size: 7
-    residual_kernel_size: 3
-    last_kernel_size: 3
-    dilation_base: 2
-    pad_mode: constant
-    compress: 2
-  transformer:
-    d_model: 512
-    num_heads: 8
-    num_layers: 2
-    layer_scale: 0.01
-    context: 250
-    dim_feedforward: 2048
-    input_dimension: 512
-    output_dimensions:
-    - 512
-  quantizer:
-    dimension: 32
-    output_dimension: 512
-"#;
+/// Architecture config for the pocket-tts model variant, shared with the AppImage
+/// packaging (which bundles the same file at `usr/config/`, see
+/// `load_pocket_tts_model`).
+pub const POCKET_TTS_CONFIG_YAML: &str = include_str!("../config/b6369a24.yaml");
 
 /// Ensures `config/<variant>.yaml` exists relative to the current working directory,
 /// as well as in the user's local data directory (`~/.local/share/voxctrl/config/<variant>.yaml`),
@@ -220,6 +168,43 @@ pub fn ensure_pocket_tts_config() -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Loads the pocket-tts model for `variant` without leaving the process's working
+/// directory changed.
+///
+/// `pocket_tts::TTSModel::load` only finds its architecture config at
+/// `config/<variant>.yaml` relative to the current working directory. When that
+/// file is already reachable from the cwd — the AppImage bundles it at `usr/config/`
+/// and AppRun starts the app in `usr/`; a dev checkout gets one written by
+/// `ensure_pocket_tts_config` — load directly. Only otherwise fall back to
+/// temporarily switching into the user's data directory, where
+/// `ensure_pocket_tts_config` also wrote a copy.
+///
+/// Avoiding the switch matters: the cwd is process-wide, and inside the AppImage
+/// WebKitGTK locates its helper processes (WebKitNetworkProcess, ...) through a
+/// path relative to the cwd. Swapping it from the TTS worker thread while the
+/// webview was spawning a helper aborted the whole app at startup.
+pub(crate) fn load_pocket_tts_model(variant: &str) -> Result<pocket_tts::TTSModel> {
+    ensure_pocket_tts_config().context("ensure pocket-tts config file")?;
+
+    let cwd_config = Path::new("config").join(format!("{variant}.yaml"));
+    if cwd_config.exists() {
+        return pocket_tts::TTSModel::load(variant);
+    }
+
+    let app_dir = dirs::data_local_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("voxctrl");
+    let orig_cwd = std::env::current_dir().ok();
+    if app_dir.exists() {
+        let _ = std::env::set_current_dir(&app_dir);
+    }
+    let load_res = pocket_tts::TTSModel::load(variant);
+    if let Some(ref orig) = orig_cwd {
+        let _ = std::env::set_current_dir(orig);
+    }
+    load_res
 }
 
 /// Best-effort, network-free check for whether the model weights, tokenizer, and the
@@ -339,26 +324,8 @@ pub(crate) fn speak_pocket_tts(
     // Lazily load the model — stays alive for the worker thread lifetime.
     if model.is_none() {
         info!("Loading pocket-tts model (variant={POCKET_TTS_VARIANT})");
-        ensure_pocket_tts_config().context("ensure pocket-tts config file")?;
-
-        // pocket_tts::TTSModel::load searches for `config/b6369a24.yaml` relative to CWD.
-        // In read-only environments like AppImages, CWD (inside squashfs mount) cannot be written to.
-        // Temporarily switch CWD to the user's writable app data directory where config/b6369a24.yaml lives.
-        let app_dir = dirs::data_local_dir()
-            .unwrap_or_else(|| PathBuf::from("."))
-            .join("voxctrl");
-        let orig_cwd = std::env::current_dir().ok();
-        if app_dir.exists() {
-            let _ = std::env::set_current_dir(&app_dir);
-        }
-
-        let load_res = pocket_tts::TTSModel::load(POCKET_TTS_VARIANT);
-
-        if let Some(ref orig) = orig_cwd {
-            let _ = std::env::set_current_dir(orig);
-        }
-
-        *model = Some(load_res.context("load pocket-tts model")?);
+        *model =
+            Some(load_pocket_tts_model(POCKET_TTS_VARIANT).context("load pocket-tts model")?);
     }
     let model = model.as_ref().unwrap();
 

--- a/docs/appimage_build_process.md
+++ b/docs/appimage_build_process.md
@@ -183,6 +183,50 @@ the files — bump the files instead of overriding the tag.
 
 ---
 
+## 🧩 AppImage Runtime Library Policy
+
+The AppImage is deliberately **not** self-contained. The slimming step in
+`build_appimage.sh` and `.github/workflows/release.yml` (keep the two in sync)
+deletes bundled copies of libraries that must come from the host at runtime,
+and `ldd -r` of every bundled object under the AppImage's own library path must
+stay clean on a newer host. The rules, each learned from a startup crash:
+
+1. **Graphics, Wayland and input libraries come from the host** (Mesa, EGL,
+   libdrm, libwayland, libxkbcommon). Bundled copies from the Ubuntu 22.04
+   build host break the Slint overlay's Wayland frame callbacks and xkbcommon.
+2. **Once a library comes from the host, everything it links against must
+   come from the host too.** The host's copy resolves its symbols against
+   whatever is first on `LD_LIBRARY_PATH`; a stale bundled dependency makes it
+   abort with `undefined symbol` / `version ... not found`. This is why the
+   GLib family, GStreamer, the GIO TLS module and gnutls stack, and their
+   dependencies (pcre2, libffi, libmount, libblkid, libselinux, liborc,
+   libunwind, libdw, libelf, bz2, lzma, zstd) are all stripped together.
+   Everything still bundled only needs the Ubuntu 22.04 versions of these, so
+   any newer host satisfies it.
+3. **Only strip a library whose soname is stable across distributions.**
+   `libxml2` (`.so.16` on Arch) and `libunistring` (`.so.5` on newer hosts)
+   stay bundled for that reason.
+4. **`libsystemd` / `libudev` are host-first with a fallback.** Arch's
+   `libmount` links `libsystemd`, so a bundled copy must not shadow the
+   host's; but non-systemd distributions may not have them at all and the
+   bundled WebKitGTK needs them. They live in `usr/lib/fallback/`, and the
+   `scripts/appimage-hooks/host-first-fallback.sh` AppRun hook exposes each
+   one only when the host has no library of that soname.
+5. **WebKitGTK finds its helper processes relative to the working
+   directory.** The Tauri bundler rewrites the compiled-in
+   `/usr/lib/x86_64-linux-gnu/webkit2gtk-4.1` to
+   `././/lib/x86_64-linux-gnu/webkit2gtk-4.1`, and linuxdeploy's AppRun starts
+   the app in `$APPDIR/usr` so that resolves. Release builds of WebKitGTK
+   honour no environment override for this (`WEBKIT_EXEC_PATH` only exists in
+   developer-mode builds), so the helpers must sit at exactly that relative
+   path, **and nothing in the app may change the process's working
+   directory.** The pocket-tts model config is bundled at `usr/config/` for
+   that reason — `pocket_tts::TTSModel::load` looks for it relative to the
+   cwd, and the old workaround of temporarily switching cwd from the TTS
+   worker raced WebKit's helper spawn and aborted the app.
+
+---
+
 ## 📋 Build Flags & Config Reference
 
 * **Tauri Config (`src-tauri/tauri.conf.json`)**:


### PR DESCRIPTION
Follow-up to #71–#73. With the library layers fixed, the AppImage gets through startup and hotkey registration, then aborts:

```
** (voxctrl): ERROR **: Unable to spawn a new child process: Failed to spawn child process
"././/lib/x86_64-linux-gnu/webkit2gtk-4.1/WebKitNetworkProcess" (No such file or directory)
```

## Root cause

The bundled `libwebkit2gtk` has its helper-process directory compiled in as `/usr/lib/x86_64-linux-gnu/webkit2gtk-4.1`, which the Tauri bundler rewrites to `././/lib/x86_64-linux-gnu/webkit2gtk-4.1` — a path **relative to the working directory**. linuxdeploy's AppRun `chdir`s into `$APPDIR/usr`, so normally that resolves (verified: the helpers are there and the path resolves from AppRun's cwd).

But the Pocket-TTS and Breeze-TTS-2 loaders temporarily switch the *process-wide* cwd to `~/.local/share/voxctrl` while loading the model, because `pocket_tts::TTSModel::load` only finds `config/<variant>.yaml` relative to the cwd. With prewarm on, that happens at startup on the TTS worker thread — concurrently with WebKit spawning its helper processes. Any spawn landing in that window resolves the relative path against the data directory and WebKit aborts the app. This lines up with Breeze-TTS-2 landing in v0.3.7.

**Why the env-var approach couldn't work:** I checked WebKit's source and the bundled binary. Release builds honour no environment override for the helper directory — `WEBKIT_EXEC_PATH` exists only under `ENABLE(DEVELOPER_MODE)`, and the string is absent from the bundled `libwebkit2gtk`. `WEBKIT_INJECTED_BUNDLE_PATH` *is* honoured, but as a single directory (`g_file_test(..., IS_DIR)`), so the colon-joined pair that was set was silently ignored.

## Fix

- **Bundle `crates/voxctrl-tts/config/b6369a24.yaml` at `usr/config/`** in the AppImage, and make the `POCKET_TTS_CONFIG_YAML` const `include_str!` that same file (single source of truth; the file was already byte-identical).
- **`load_pocket_tts_model`** replaces the two copy-pasted load blocks in `pocket.rs` / `breeze.rs`: it loads directly when `config/<variant>.yaml` is reachable from the cwd (AppImage, dev checkout) and only otherwise falls back to the temporary cwd switch (e.g. a `.deb` install, where WebKit uses absolute host paths and the switch is harmless).
- Copy the WebKit helpers only to the relocated path, set both `WEBKIT_*` variables to single directories, and make their insertion idempotent (stale lines are removed first).
- Document the AppImage runtime library policy in `docs/appimage_build_process.md` so these constraints don't get reintroduced.

## Verification

- Ran the workflow's slimming step **verbatim** on the current v0.3.7 release AppImage and launched through `AppRun` with a stub binary: cwd is `$APPDIR/usr`; `config/b6369a24.yaml` is visible from it; the relocated helper path resolves; `WEBKIT_INJECTED_BUNDLE_PATH` is a single existing directory containing `libwebkit2gtkinjectedbundle.so`; the host-first fallback from #73 still works; `ldd -r` over every bundled object is clean.
- `cargo check -p voxctrl-tts --tests` passes.

Linux-only; Windows build untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSVdZhh5D2rSX1eu9fzM25

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSVdZhh5D2rSX1eu9fzM25)_