### PR TITLE
AppImage: start on stock Mint 21 / Ubuntu 22.04 desktops

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -421,7 +421,71 @@ jobs:
           generate_release_notes: true
           fail_on_unmatched_files: true
           files: release-artifacts/*
+          # The "What's new" section below is version-specific: update it in the
+          # same commit that bumps the version (scripts/bump_version.sh), so a
+          # release never ships the previous version's notes. Everything under
+          # "## Downloads" is evergreen, and GitHub appends its own generated
+          # "What's Changed" list of merged PRs beneath all of this.
           body: |
+            ## What's new in 0.3.8
+
+            A Linux packaging and compatibility release: **no app behaviour
+            changes** — the AppImage now starts on desktops where 0.3.7 could
+            not.
+
+            ### The AppImage no longer needs `libfuse2`
+
+            Its runtime linked FUSE 2 and looked for a `fusermount` binary.
+            Ubuntu 22.04, Linux Mint 21 and everything newer ship fuse3
+            (`fusermount3`) and no `libfuse2`, so 0.3.7 died before it started:
+
+            ```
+            Error: No suitable fusermount binary found on the $PATH
+            ```
+
+            0.3.8 ships [uruntime](https://github.com/VHSgunzo/uruntime), which
+            uses FUSE 3 and extracts-and-runs itself when FUSE is unavailable
+            entirely. Nothing has to be installed first. (On 0.3.7 the
+            workarounds were `sudo apt install libfuse2` or launching with
+            `--appimage-extract-and-run`.)
+
+            ### Two libraries the AppImage assumed every desktop had
+
+            The bundled WebKitGTK links `libgstgl-1.0.so.0` and
+            `libwayland-server.so.0` directly, and both were stripped in favour
+            of the host's copies. `libgstgl-1.0.so.0` ships in
+            `libgstreamer-gl1.0-0`, which `gstreamer1.0-plugins-base` does not
+            pull in — so a desktop with no WebKit of its own had none, and the
+            app died with `error while loading shared libraries`. Both are now
+            carried as host-first fallbacks: your system's copy is used when you
+            have one, ours only when you do not.
+
+            ### Also since v0.3.7
+
+            - The GLib / GIO / GStreamer dependency closure is stripped as a
+              unit, so the host's libraries resolve against each other instead
+              of stale bundled ones (`g_once_init_leave_pointer`, `MOUNT_2_40`
+              and `GNUTLS_3_8_x` startup aborts).
+            - `libsystemd` / `libudev` are exposed host-first, fixing the
+              `LIBSYSTEMD_251` abort on Arch while still working on
+              distributions that ship neither.
+            - WebKitGTK's helper processes are bundled and found where WebKit
+              looks for them, fixing the `WebKitNetworkProcess` spawn crash.
+            - The TTS engines no longer change the process's working directory
+              to find their model config — that raced WebKit's helper spawn and
+              aborted the app. The config is bundled at `usr/config/` instead.
+            - Packaging now verifies the AppImage it produced can unpack itself
+              before a release is published.
+
+            ### Requirements
+
+            glibc 2.35 or newer and a GCC 12 libstdc++ — Ubuntu 22.04+, Linux
+            Mint 21+, Debian 12+, Fedora 36+, Arch, openSUSE Tumbleweed. Ubuntu
+            20.04, Mint 20, Debian 11 and RHEL 9 are below that baseline; build
+            from source there.
+
+            ---
+
             ## Downloads
 
             Pick the build for your platform and GPU:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,6 +241,32 @@ jobs:
           mkdir -p "$root/usr/config"
           cp crates/voxctrl-tts/config/*.yaml "$root/usr/config/"
 
+          # Some libraries can be neither stripped nor left on the library path, so
+          # they are parked in usr/lib/fallback instead: the AppRun hook exposes each
+          # one only when the host has no library of that soname, so a host with its
+          # own copy always wins.
+          #
+          #   libsystemd / libudev — the host's own libmount (Arch) links libsystemd
+          #     and needs a newer LIBSYSTEMD_* version node than the build host's
+          #     copy, while non-systemd distributions may not ship them at all and the
+          #     bundled WebKitGTK needs them.
+          #   libgstgl-1.0 / libwayland-server — the bundled WebKitGTK links both
+          #     directly, and the strip patterns below would delete them.
+          #     libgstgl-1.0.so.0 ships in libgstreamer-gl1.0-0, which
+          #     gstreamer1.0-plugins-base does not depend on, so a desktop with no
+          #     WebKit of its own can be missing it entirely and the app then dies
+          #     with "error while loading shared libraries: libgstgl-1.0.so.0".
+          #
+          # This has to run before the strip loop below, which skips usr/lib/fallback.
+          # Keep this list in sync with build_appimage.sh.
+          mkdir -p "$root/usr/lib/fallback"
+          for pat in 'libsystemd.so*' 'libudev.so*' \
+                     'libgstgl-1.0.so*' 'libwayland-server.so*'; do
+            find "$root" -name "$pat" -not -path '*/fallback/*' -print \
+              -exec mv -t "$root/usr/lib/fallback/" {} + 2>/dev/null || true
+          done
+          echo "Host-first fallback libraries:"; ls -la "$root/usr/lib/fallback"
+
           # Everything below is deleted so the AppImage falls through to the
           # host's copy. The rule: once a library comes from the host, every
           # library it links against must come from the host too, or the
@@ -270,28 +296,21 @@ jobs:
             'libgstreamer-*.so*' 'libgst*.so*' 'liborc-0.4.so*' \
             'libunwind.so*' 'libdw.so*' 'libelf.so*' \
             'libbz2.so*' 'liblzma.so*' 'libzstd.so*'; do
-            find "$root" -name "$pat" -print -delete 2>/dev/null || true
+            find "$root" -name "$pat" -not -path '*/fallback/*' -print -delete 2>/dev/null || true
           done
 
-          # libsystemd/libudev can be neither stripped nor left on the library
-          # path: the host's own libmount (Arch) links libsystemd and needs a
-          # newer LIBSYSTEMD_* version node than the build host's copy, while
-          # non-systemd distributions may not ship them at all and the bundled
-          # WebKitGTK needs them. Park them in usr/lib/fallback; the AppRun
-          # hook exposes each one only when the host has no copy of that soname.
-          mkdir -p "$root/usr/lib/fallback"
-          for pat in 'libsystemd.so*' 'libudev.so*'; do
-            find "$root" -name "$pat" -not -path '*/fallback/*' -print \
-              -exec mv -t "$root/usr/lib/fallback/" {} + 2>/dev/null || true
-          done
+          # Install the AppRun hook that exposes usr/lib/fallback host-first.
           cp scripts/appimage-hooks/host-first-fallback.sh "$root/apprun-hooks/"
           chmod +x "$root/apprun-hooks/host-first-fallback.sh"
           if ! grep -q "host-first-fallback.sh" "$root/AppRun"; then
             sed -i '/^exec /i source "$this_dir"/apprun-hooks/host-first-fallback.sh' "$root/AppRun"
           fi
 
-          rm -f "$appimage"
-          ARCH=x86_64 ./appimagetool.bin "$root" "$appimage"
+          # Repackage. appimage-pack.sh embeds a runtime that also works on
+          # hosts without libfuse2 (Ubuntu 22.04 / Linux Mint 21 and newer ship
+          # fuse3 only), falling back to appimagetool's own runtime if it
+          # cannot fetch one, and verifies the result unpacks before returning.
+          ./scripts/appimage-pack.sh "$root" "$appimage" ./appimagetool.bin
           echo "Repackaged $appimage ($(du -h "$appimage" | cut -f1))"
 
       # CUDA build uses --bundles deb only: the CUDA toolkit populates system
@@ -420,6 +439,11 @@ jobs:
             **CPU builds** run on any hardware, including AMD, Intel, and ARM.
 
             ### Linux CPU / GPU — first run
+
+            Needs glibc 2.35 or newer (Ubuntu 22.04+, Linux Mint 21+, Debian
+            12+, Fedora 36+, Arch). Nothing has to be installed first — not
+            even `libfuse2`.
+
             ```bash
             chmod +x VoxCtrl_*-linux-x86_64*.AppImage
             # Optional: installs the desktop entry and text-injection helpers.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9362,7 +9362,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voxctrl-app"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9402,7 +9402,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-audio"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "cpal",
@@ -9417,7 +9417,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-config"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "dirs 5.0.1",
  "serde",
@@ -9430,7 +9430,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-dbus"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "serde",
@@ -9442,7 +9442,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-hotkeys"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "ashpd",
@@ -9462,7 +9462,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-inference"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "cc",
@@ -9487,7 +9487,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-inject"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9500,7 +9500,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-llm"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "reqwest 0.12.28",
@@ -9514,7 +9514,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-mcp"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "serde",
@@ -9526,7 +9526,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-routing"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9550,14 +9550,14 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-text"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "regex",
 ]
 
 [[package]]
 name = "voxctrl-tts"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 authors = ["VoxCtrl Contributors"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -224,6 +224,11 @@ That is the whole installation. Global shortcuts need no permissions, and
 VoxCtrl registers its own `.desktop` entry and icon under `~/.local/share/` on
 every Linux launch — no privileges, no install step.
 
+Nothing has to be installed first — not even `libfuse2`: the AppImage's runtime
+uses your system's FUSE 3, and extracts and runs itself when FUSE is
+unavailable. It needs glibc 2.35 or newer (Ubuntu 22.04+, Linux Mint 21+,
+Debian 12+, Fedora 36+, Arch); older distributions have to build from source.
+
 The only thing that can need a package manager is the helper that types text
 into other windows (`wtype` on Wayland, `xdotool` on X11). If it is missing, the
 setup window says so and offers to install it, or shows you the command. You can

--- a/build_appimage.sh
+++ b/build_appimage.sh
@@ -345,6 +345,32 @@ done
 mkdir -p "$root/usr/config"
 cp "$ROOT_DIR"/crates/voxctrl-tts/config/*.yaml "$root/usr/config/"
 
+# Some libraries can be neither stripped nor left on the library path, so they
+# are parked in usr/lib/fallback instead: the AppRun hook exposes each one only
+# when the host has no library of that soname, so a host with its own copy
+# always wins.
+#
+#   libsystemd / libudev — the host's own libmount (Arch) links libsystemd and
+#     needs a newer LIBSYSTEMD_* version node than the build host's copy, while
+#     non-systemd distributions may not ship them at all and the bundled
+#     WebKitGTK needs them.
+#   libgstgl-1.0 / libwayland-server — the bundled WebKitGTK links both
+#     directly, and the strip patterns below would delete them.
+#     libgstgl-1.0.so.0 ships in libgstreamer-gl1.0-0, which
+#     gstreamer1.0-plugins-base does not depend on, so a desktop with no
+#     WebKit of its own can be missing it entirely and the app then dies with
+#     "error while loading shared libraries: libgstgl-1.0.so.0".
+#
+# This has to run before the strip loop below, which skips usr/lib/fallback.
+# Keep this list in sync with .github/workflows/release.yml.
+mkdir -p "$root/usr/lib/fallback"
+for pat in 'libsystemd.so*' 'libudev.so*' \
+           'libgstgl-1.0.so*' 'libwayland-server.so*'; do
+    find "$root" -name "$pat" -not -path '*/fallback/*' -print \
+        -exec mv -t "$root/usr/lib/fallback/" {} + 2>/dev/null || true
+done
+info "Host-first fallback libraries: $(ls "$root/usr/lib/fallback" | tr '\n' ' ')"
+
 # Strip graphics, Wayland, input libraries, and host-dependent/security libraries
 # so the AppImage falls through to the host system's native versions at runtime.
 # The rule: once a library comes from the host, every library it links against
@@ -376,29 +402,20 @@ for pat in \
     'libcanberra-gtk3.so*' 'libcanberra.so*' \
     'libcanberra-gtk-module.so' 'libcanberra-gtk3-module.so' \
     'libcolorreload-gtk-module.so' 'libwindow-decorations-gtk-module.so'; do
-    find "$root" -name "$pat" -print -delete 2>/dev/null || true
+    find "$root" -name "$pat" -not -path '*/fallback/*' -print -delete 2>/dev/null || true
 done
 
-# libsystemd/libudev can be neither stripped nor left on the library path: the
-# host's own libmount (Arch) links libsystemd and needs a newer LIBSYSTEMD_*
-# version node than the build host's copy, while non-systemd distributions may
-# not ship them at all and the bundled WebKitGTK needs them. Park them in
-# usr/lib/fallback; the AppRun hook exposes each one only when the host has no
-# copy of that soname.
-mkdir -p "$root/usr/lib/fallback"
-for pat in 'libsystemd.so*' 'libudev.so*'; do
-    find "$root" -name "$pat" -not -path '*/fallback/*' -print \
-        -exec mv -t "$root/usr/lib/fallback/" {} + 2>/dev/null || true
-done
+# Install the AppRun hook that exposes usr/lib/fallback host-first.
 cp "$ROOT_DIR/scripts/appimage-hooks/host-first-fallback.sh" "$root/apprun-hooks/"
 chmod +x "$root/apprun-hooks/host-first-fallback.sh"
 if ! grep -q "host-first-fallback.sh" "$root/AppRun"; then
     sed -i '/^exec /i source "$this_dir"/apprun-hooks/host-first-fallback.sh' "$root/AppRun"
 fi
 
-# Repackage the AppImage
-rm -f "$LATEST_BUNDLE"
-ARCH=x86_64 ./appimagetool.bin "$root" "$LATEST_BUNDLE" >/dev/null
+# Repackage the AppImage. appimage-pack.sh embeds a runtime that also works on
+# hosts without libfuse2 (Ubuntu 22.04 / Linux Mint 21 and newer ship fuse3
+# only), falling back to appimagetool's own runtime if it cannot fetch one.
+"$ROOT_DIR/scripts/appimage-pack.sh" "$root" "$LATEST_BUNDLE" "$ROOT_DIR/appimagetool.bin" >/dev/null
 
 rm -rf "$work"
 ok "AppImage successfully slimmed."

--- a/docs/appimage_build_process.md
+++ b/docs/appimage_build_process.md
@@ -206,12 +206,20 @@ stay clean on a newer host. The rules, each learned from a startup crash:
 3. **Only strip a library whose soname is stable across distributions.**
    `libxml2` (`.so.16` on Arch) and `libunistring` (`.so.5` on newer hosts)
    stay bundled for that reason.
-4. **`libsystemd` / `libudev` are host-first with a fallback.** Arch's
-   `libmount` links `libsystemd`, so a bundled copy must not shadow the
-   host's; but non-systemd distributions may not have them at all and the
-   bundled WebKitGTK needs them. They live in `usr/lib/fallback/`, and the
+4. **Some libraries are host-first with a bundled fallback.** They live in
+   `usr/lib/fallback/`, and the
    `scripts/appimage-hooks/host-first-fallback.sh` AppRun hook exposes each
-   one only when the host has no library of that soname.
+   one only when the host has no library of that soname — so a host that has
+   its own copy always wins, and a host that has none still starts.
+   * `libsystemd` / `libudev`: Arch's `libmount` links `libsystemd`, so a
+     bundled copy must not shadow the host's; but non-systemd distributions
+     may not have them at all and the bundled WebKitGTK needs them.
+   * `libgstgl-1.0` / `libwayland-server`: the bundled WebKitGTK links both
+     directly, and rules 1 and 2 would otherwise delete them.
+     `libgstgl-1.0.so.0` ships in `libgstreamer-gl1.0-0`, which
+     `gstreamer1.0-plugins-base` does **not** depend on, so a desktop with no
+     WebKit of its own can be missing it and the app dies with
+     `error while loading shared libraries: libgstgl-1.0.so.0`.
 5. **WebKitGTK finds its helper processes relative to the working
    directory.** The Tauri bundler rewrites the compiled-in
    `/usr/lib/x86_64-linux-gnu/webkit2gtk-4.1` to
@@ -224,6 +232,28 @@ stay clean on a newer host. The rules, each learned from a startup crash:
    that reason — `pocket_tts::TTSModel::load` looks for it relative to the
    cwd, and the old workaround of temporarily switching cwd from the TTS
    worker raced WebKit's helper spawn and aborted the app.
+6. **The AppImage runtime must not need FUSE 2.** appimagetool's built-in
+   type-2 runtime statically links libfuse 2 and looks for a `fusermount`
+   binary; Ubuntu 22.04 / Linux Mint 21 and newer ship fuse3 (`fusermount3`)
+   and no `libfuse2`, so such an AppImage aborts with
+   `Error: No suitable fusermount binary found on the $PATH` before it ever
+   reaches `AppRun`. `scripts/appimage-pack.sh` therefore packages with
+   [uruntime](https://github.com/VHSgunzo/uruntime), which speaks FUSE 3 and
+   extracts-and-runs itself when no `fusermount` is usable. If that runtime
+   cannot be fetched, or the AppImage built with it does not unpack again,
+   packaging falls back to appimagetool's own runtime, so a build is never
+   left worse off than before.
+
+### Host baseline
+
+The release AppImages are built on the `ubuntu-22.04` runner, which sets the
+floor for what they run on: **glibc 2.35** (`hypot@GLIBC_2.35` in the overlay,
+WebKitGTK and cairo) and **`GLIBCXX_3.4.30`** (GCC 12's libstdc++, needed by
+`usr/bin/voxctrl` and WebKitGTK). Ubuntu 22.04+, Linux Mint 21+, Debian 12+ and
+Fedora 36+ satisfy both; Ubuntu 20.04, Mint 20, Debian 11 and RHEL 9 do not.
+Building locally with `build_appimage.sh` produces an AppImage with *your*
+distribution's baseline — on a rolling distro that is far higher than 22.04's,
+so ship CI artifacts, not local builds.
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,11 +3,21 @@
 ## System Requirements
 
 ### Linux
-- **OS:** Any modern Linux distro (Ubuntu 20.04+, Fedora 36+, Arch, etc.)
+- **OS:** Any modern Linux distro — Ubuntu 22.04+, Linux Mint 21+, Debian 12+,
+  Fedora 36+, Arch, openSUSE Tumbleweed
+- **glibc 2.35 or newer**, with a libstdc++ from GCC 12 or newer. The AppImage
+  is built on Ubuntu 22.04, so that is the floor: Ubuntu 20.04 / Mint 20 /
+  Debian 11 / RHEL 9 are too old and the AppImage will not start on them.
 - **Display:** X11 or Wayland
 - **Audio:** PulseAudio or PipeWire (ALSA fallback supported)
 - **Required packages:** `libwebkit2gtk-4.1`, `libayatana-appindicator3` or `libappindicator3`
 - **Optional:** `wtype` (Wayland injection), `xdotool` (X11 injection)
+- **No `libfuse2` needed.** The AppImage ships a runtime that uses your
+  system's FUSE 3, and extracts and runs itself when FUSE is unavailable
+  entirely — so it starts on a stock Ubuntu 22.04 / Mint 21 desktop with
+  nothing installed first. (Releases up to and including 0.3.7 used a runtime
+  that needed `libfuse2`; on those, either `sudo apt install libfuse2` or run
+  the AppImage with `--appimage-extract-and-run`.)
 - **For Pocket-TTS:** a HuggingFace account with the [`kyutai/pocket-tts`](https://huggingface.co/kyutai/pocket-tts) license accepted and an access token (see [Pocket-TTS](#pocket-tts) below)
 
 ### Windows
@@ -330,7 +340,19 @@ end to end. Its steps say which. The two it cannot fix for you:
 - Use a larger model for better non-English accuracy
 
 ### AppImage won't launch
-- Install FUSE: `sudo apt install fuse libfuse2`
+- `Error: No suitable fusermount binary found on the $PATH` — an older release
+  (0.3.7 or earlier), whose runtime needed FUSE 2. Either run it with
+  `./VoxCtrl.AppImage --appimage-extract-and-run`, install FUSE 2
+  (`sudo apt install libfuse2`), or download a newer release, whose runtime
+  uses FUSE 3 and needs nothing installed.
+- `version 'GLIBC_2.35' not found` or `GLIBCXX_3.4.30 not found` — the distro
+  is older than the AppImage's baseline (see [System Requirements](#linux)).
+  Ubuntu 20.04, Mint 20, Debian 11 and RHEL 9 cannot run it; build from source
+  on those.
+- `error while loading shared libraries: <name>` — a library your desktop is
+  missing. `libEGL.so.1`/`libGL.so.1` come from your graphics drivers
+  (`libegl1`, `libgl1` on Debian/Ubuntu); `libgtk-3.so.0`, `libglib-2.0.so.0`
+  and the GStreamer libraries come with any GTK desktop.
 - Or extract and run directly: `./VoxCtrl.AppImage --appimage-extract && squashfs-root/AppRun`
 
 ### Debugging & Crash Logs

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "voxctrl",
   "private": true,
-  "version": "0.3.7",
+  "version": "0.3.8",
   "type": "module",
   "scripts": {
     "predev": "pkill -x voxctrl 2>/dev/null || true; fuser -k 5173/tcp 2>/dev/null || true",

--- a/scripts/appimage-hooks/host-first-fallback.sh
+++ b/scripts/appimage-hooks/host-first-fallback.sh
@@ -6,8 +6,11 @@
 # libraries link against them (Arch's libmount links libsystemd, and needs
 # LIBSYSTEMD_251, newer than the copy the ubuntu-22.04 build host bundles),
 # so a bundled copy on LD_LIBRARY_PATH aborts the host library at startup.
-# They can't simply be stripped either: non-systemd distributions may not
-# ship them at all, and WebKitGTK would then fail to load.
+# They can't simply be stripped either: a host may not ship them at all, and
+# WebKitGTK would then fail to load — non-systemd distributions have no
+# libsystemd/libudev, and libgstgl-1.0.so.0 lives in libgstreamer-gl1.0-0,
+# which gstreamer1.0-plugins-base does not pull in, so a desktop with no
+# WebKit of its own can be missing it entirely.
 #
 # So for each fallback library, expose our copy only when the host has no
 # library of that soname. The symlinks live in a per-user runtime directory

--- a/scripts/appimage-pack.sh
+++ b/scripts/appimage-pack.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Package an AppDir into an AppImage, preferring the uruntime runtime.
+#
+# Why not just call appimagetool: its built-in runtime needs a libfuse 2
+# `fusermount` binary that Ubuntu 22.04 / Linux Mint 21 and newer do not install
+# (see scripts/fetch-uruntime.sh). uruntime speaks FUSE3 and falls back to
+# extract-and-run, so the AppImage starts on a stock desktop.
+#
+# Usage: appimage-pack.sh <AppDir> <output.AppImage> [appimagetool]
+#
+# If uruntime cannot be fetched, or the AppImage built with it does not verify,
+# this falls back to appimagetool's built-in runtime — the packaging run is
+# never left worse off than before.
+set -euo pipefail
+
+appdir="${1:?usage: appimage-pack.sh <AppDir> <output.AppImage> [appimagetool]}"
+out="${2:?usage: appimage-pack.sh <AppDir> <output.AppImage> [appimagetool]}"
+appimagetool="${3:-./appimagetool.bin}"
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+pack() { # $1: runtime file to embed, or "" for appimagetool's built-in one
+    rm -f "$out"
+    if [ -n "${1:-}" ]; then
+        ARCH=x86_64 "$appimagetool" --runtime-file "$1" "$appdir" "$out"
+    else
+        ARCH=x86_64 "$appimagetool" "$appdir" "$out"
+    fi
+}
+
+# A packaged AppImage has to unpack itself and carry a launcher. --appimage-extract
+# needs no FUSE, so this works on CI runners and in containers.
+verify() {
+    local img work ok=1
+    img="$(readlink -f "$out")"
+    [ -f "$img" ] || return 1
+    chmod +x "$img"
+    work="$(mktemp -d)"
+    ( cd "$work" && "$img" --appimage-extract >/dev/null 2>&1 ) || ok=0
+    # The extraction directory is squashfs-root for both runtimes; accept any
+    # extracted AppDir so a future runtime that names it differently still
+    # verifies instead of silently falling back.
+    [ -n "$(find "$work" -maxdepth 2 -name AppRun -type f -print -quit)" ] || ok=0
+    rm -rf "$work"
+    [ "$ok" = 1 ]
+}
+
+runtime_dir="$(mktemp -d)"
+trap 'rm -rf "$runtime_dir"' EXIT
+
+if "$script_dir/fetch-uruntime.sh" "$runtime_dir/uruntime"; then
+    echo "appimage-pack: packaging with uruntime"
+    if pack "$runtime_dir/uruntime" && verify; then
+        echo "appimage-pack: packaged and verified $out (uruntime)"
+        exit 0
+    fi
+    echo "appimage-pack: WARNING uruntime packaging did not verify; falling back to appimagetool's built-in runtime" >&2
+else
+    echo "appimage-pack: WARNING uruntime unavailable; using appimagetool's built-in runtime" >&2
+fi
+
+pack ""
+if ! verify; then
+    echo "appimage-pack: ERROR packaged AppImage failed verification" >&2
+    exit 1
+fi
+echo "appimage-pack: packaged and verified $out (appimagetool runtime)"

--- a/scripts/fetch-uruntime.sh
+++ b/scripts/fetch-uruntime.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Fetch the uruntime AppImage runtime.
+#
+# appimagetool's stock type-2 runtime statically links libfuse 2 and looks for a
+# `fusermount` binary on $PATH. Ubuntu 22.04 / Linux Mint 21 and newer ship
+# fuse3 (`fusermount3`) and no longer install libfuse2, so an AppImage built
+# with that runtime aborts on a stock desktop with
+#
+#   Error: No suitable fusermount binary found on the $PATH
+#
+# uruntime (https://github.com/VHSgunzo/uruntime) is a drop-in replacement that
+# speaks FUSE3 and, when no fusermount is usable at all, extracts and runs
+# itself instead of aborting.
+#
+# Usage: fetch-uruntime.sh <destination-path>
+#
+# Exits non-zero (without leaving a usable file behind) if the runtime could not
+# be fetched or does not look like a working runtime, so callers can fall back
+# to appimagetool's built-in runtime rather than failing the build.
+set -euo pipefail
+
+dest="${1:?usage: fetch-uruntime.sh <destination-path>}"
+url="https://github.com/VHSgunzo/uruntime/releases/latest/download/uruntime-appimage-squashfs-x86_64"
+
+mkdir -p "$(dirname "$dest")"
+
+if ! curl -fsSL --retry 3 --retry-delay 2 --connect-timeout 30 -o "$dest" "$url"; then
+    echo "fetch-uruntime: download failed ($url)" >&2
+    rm -f "$dest"
+    exit 1
+fi
+chmod +x "$dest"
+
+# It must be a self-contained x86-64 ELF: anything else (an HTML error page, a
+# redirect stub, a wrong-architecture asset) would produce an AppImage that
+# cannot start.
+if ! file -b "$dest" | grep -q 'ELF 64-bit.*x86-64'; then
+    echo "fetch-uruntime: downloaded file is not an x86-64 ELF binary" >&2
+    rm -f "$dest"
+    exit 1
+fi
+
+# And it must answer as an AppImage runtime. Either flag is enough; the point is
+# to catch a file that downloaded cleanly but does not behave like a runtime.
+if ! "$dest" --appimage-version >/dev/null 2>&1 \
+   && ! "$dest" --appimage-help >/dev/null 2>&1; then
+    echo "fetch-uruntime: downloaded runtime did not answer --appimage-version/--appimage-help" >&2
+    rm -f "$dest"
+    exit 1
+fi
+
+echo "fetch-uruntime: using $url" >&2

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VoxCtrl",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "identifier": "ai.voxctrl.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Audited the released `VoxCtrl_0.3.7_amd64-linux-x86_64-vulkan.AppImage` (every one of its 138 ELF objects, its `DT_NEEDED` closure and its symbol-version needs) against a clean host. Nothing in it is distro-specific — it is built on `ubuntu-22.04`, so every bundled library is a Jammy library — but three things stop it from "just running" on a stock Linux Mint 21.

## 1. The runtime needed FUSE 2 (blocking on Mint 21)

The embedded `type2-runtime` statically links **libfuse 2** and looks for exactly one helper, `fusermount` — no `fusermount3` fallback:

```
Error: No suitable fusermount binary found on the $PATH
```

Ubuntu 22.04 / Mint 21 and newer ship fuse3 (`fusermount3`) and do not install `libfuse2`, so the AppImage aborted before ever reaching `AppRun`.

`scripts/appimage-pack.sh` now packages with [uruntime](https://github.com/VHSgunzo/uruntime) (`--runtime-file`), which speaks FUSE 3 and extracts-and-runs itself when no `fusermount` is usable at all. `scripts/fetch-uruntime.sh` fetches and sanity-checks it; if the download fails, the file is not an x86-64 ELF, it does not answer as a runtime, or the AppImage built with it does not unpack again, packaging **falls back to appimagetool's own runtime** — a build is never left worse off than it is today.

## 2. Two stripped libraries that aren't universally present

The slimming step's `libgst*.so*` / `libwayland-*.so*` patterns deleted `libgstgl-1.0.so.0` and `libwayland-server.so.0`, both linked **directly** by the bundled WebKitGTK. `libgstgl-1.0.so.0` ships in `libgstreamer-gl1.0-0`, which `gstreamer1.0-plugins-base` does *not* depend on — so a desktop with no WebKit of its own has no copy, and the app dies with `error while loading shared libraries: libgstgl-1.0.so.0`. (Mint 21 does have it, via `libwebkit2gtk-4.0-37`.)

Both now join `libsystemd`/`libudev` in `usr/lib/fallback`, where the existing `host-first-fallback.sh` AppRun hook exposes a library **only when the host has none of that soname** — hosts with their own copy behave exactly as before. The fallback move now runs *before* the strip loop, and the strip loop skips `usr/lib/fallback` so it cannot undo it.

## 3. The documented baseline was wrong

Highest requirements across the bundle: **`GLIBC_2.35`** (`hypot`/`hypotf` in `voxctrl-overlay`, WebKitGTK, JavaScriptCore, cairo) and **`GLIBCXX_3.4.30`** (`usr/bin/voxctrl`, WebKitGTK). `docs/installation.md` claimed "Ubuntu 20.04+", which cannot work. Docs, README and the release-notes body now state glibc 2.35 / Ubuntu 22.04+ / Mint 21+ / Debian 12+ / Fedora 36+, and `docs/appimage_build_process.md` records both the runtime rule and the baseline alongside the existing library-policy rules.

## Verification

Done end-to-end against the real released artifact on a host with **no `fusermount` at all** and no `libgstgl`/`libwayland-server`:

1. Repacked the extracted 0.3.7 AppDir with `scripts/appimage-pack.sh` → uruntime fetched, packaged, verified; launching it got all the way to executing the app (extract-and-run fallback) instead of the fusermount abort.
2. It then failed on `libgstgl-1.0.so.0` — exactly the bug in §2. With that library placed in `usr/lib/fallback`, it got past it and failed on `libwayland-server.so.0`; with that one added too, it got past both and stopped at `libEGL.so.1`, which is a genuine graphics-driver library that any desktop (Mint 21 included) has and this headless container does not.
3. Sourced the hook directly: it symlinked only the two libraries the host lacks and correctly skipped `libsystemd`/`libudev`, which the host has.
4. Replayed the reordered fallback/strip loops on a synthetic AppDir — the four fallback libraries survive, everything else is stripped as before.
5. `bash -n` on every touched script; the workflow parses as YAML and its slim step was re-read in full.

The two packaging paths (`build_appimage.sh` and `.github/workflows/release.yml`) are kept in sync, as their comments require.

Not changed: the strip policy itself, the WebKit helper bundling, the pocket-tts config bundling, artifact naming, or anything in the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfrTZZgGhuhnegses7Fe4n

---
_Generated by [Claude Code](https://claude.ai/code/session_01LfrTZZgGhuhnegses7Fe4n)_