### PR TITLE
Require XInput 2.1 for the X11 backend, and release 0.3.9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -427,55 +427,66 @@ jobs:
           # "## Downloads" is evergreen, and GitHub appends its own generated
           # "What's Changed" list of merged PRs beneath all of this.
           body: |
-            ## What's new in 0.3.8
+            ## What's new in 0.3.9
 
-            A Linux packaging and compatibility release: **no app behaviour
-            changes** — the AppImage now starts on desktops where 0.3.7 could
-            not.
+            **Global shortcuts now work on Linux Mint, Cinnamon, MATE and
+            Xfce.** On those desktops 0.3.8 could not receive its own hotkeys at
+            all — the app ran, and holding a keybind did nothing.
 
-            ### The AppImage no longer needs `libfuse2`
+            ### Why they did not work
 
-            Its runtime linked FUSE 2 and looked for a `fusermount` binary.
-            Ubuntu 22.04, Linux Mint 21 and everything newer ship fuse3
-            (`fusermount3`) and no `libfuse2`, so 0.3.7 died before it started:
+            Cinnamon and MATE serve no XDG `GlobalShortcuts` portal, so VoxCtrl
+            fell through to reading input devices — which needs `input` group
+            membership VoxCtrl deliberately will not grant itself. That left a
+            native Cinnamon shortcut as the last resort, and it could not work
+            either: the command it registered named a D-Bus method that does not
+            exist (`toggle_recording`, where the service publishes
+            `ToggleRecording`). Registration looked healthy and the shortcut did
+            nothing. Worse, the setup window reported **"VoxCtrl is ready"**
+            throughout, because it only checked that a shortcut had been listed
+            — never that a key was bound to it.
 
-            ```
-            Error: No suitable fusermount binary found on the $PATH
-            ```
+            ### X11 shortcuts, with no permissions and no setup
 
-            0.3.8 ships [uruntime](https://github.com/VHSgunzo/uruntime), which
-            uses FUSE 3 and extracts-and-runs itself when FUSE is unavailable
-            entirely. Nothing has to be installed first. (On 0.3.7 the
-            workarounds were `sudo apt install libfuse2` or launching with
-            `--appimage-extract-and-run`.)
+            0.3.9 adds an X11 backend using XInput2 raw key events. Any X client
+            may ask the server for these: there is no group to join, no udev
+            rule, and nothing to change about your machine. It covers Cinnamon,
+            MATE and Xfce, and because it sees each key going down *and* coming
+            back up, every gesture style works — hold, toggle, double-tap,
+            double-tap-and-hold — as do bare-modifier triggers like
+            double-tapping Super, which no accelerator-based backend can
+            express.
 
-            ### Two libraries the AppImage assumed every desktop had
+            Like the existing device-reading fallback, this mode sees every
+            keystroke, not only VoxCtrl's shortcuts. Nothing is logged, stored,
+            or transmitted, and the Hotkeys tab says plainly which backend is
+            running. A desktop with a shortcuts portal (KDE Plasma, GNOME 48+,
+            Hyprland) still avoids it entirely.
 
-            The bundled WebKitGTK links `libgstgl-1.0.so.0` and
-            `libwayland-server.so.0` directly, and both were stripped in favour
-            of the host's copies. `libgstgl-1.0.so.0` ships in
-            `libgstreamer-gl1.0-0`, which `gstreamer1.0-plugins-base` does not
-            pull in — so a desktop with no WebKit of its own had none, and the
-            app died with `error while loading shared libraries`. Both are now
-            carried as host-first fallbacks: your system's copy is used when you
-            have one, ours only when you do not.
+            ### Gesture styles you cannot use are no longer offered
 
-            ### Also since v0.3.7
+            On a Wayland Cinnamon session VoxCtrl falls back to a native desktop
+            shortcut, and a desktop shortcut only reports the key going *down*.
+            A hold has no end, and a tap cannot be told from a hold. The Hotkeys
+            tab now offers exactly the styles the running backend can deliver
+            and explains what is missing, instead of offering four and silently
+            doing nothing for three of them. A binding you already saved keeps
+            its gesture, flagged rather than rewritten.
 
-            - The GLib / GIO / GStreamer dependency closure is stripped as a
-              unit, so the host's libraries resolve against each other instead
-              of stale bundled ones (`g_once_init_leave_pointer`, `MOUNT_2_40`
-              and `GNUTLS_3_8_x` startup aborts).
-            - `libsystemd` / `libudev` are exposed host-first, fixing the
-              `LIBSYSTEMD_251` abort on Arch while still working on
-              distributions that ship neither.
-            - WebKitGTK's helper processes are bundled and found where WebKit
-              looks for them, fixing the `WebKitNetworkProcess` spawn crash.
-            - The TTS engines no longer change the process's working directory
-              to find their model config — that raced WebKit's helper spawn and
-              aborted the app. The config is bundled at `usr/config/` instead.
-            - Packaging now verifies the AppImage it produced can unpack itself
-              before a release is published.
+            ### Also in this release
+
+            - The native Cinnamon/MATE shortcut route is repaired for Wayland
+              sessions: correct D-Bus method, one shortcut per binding (so text
+              reaches that binding's targets), numbered `customN` slots
+              allocated around your existing shortcuts so nothing is
+              overwritten and Cinnamon's Keyboard panel actually lists them.
+            - `gsettings` and `dbus-send` are now run with your desktop's
+              environment rather than the AppImage's. Inside the bundle they
+              were looking for Cinnamon's settings schemas in the AppDir and
+              concluding your desktop had no keyboard settings at all.
+            - The setup window no longer claims shortcuts are working when
+              nothing is bound, and reports why the X11 path was unavailable
+              when it was.
 
             ### Requirements
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9362,7 +9362,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voxctrl-app"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9402,7 +9402,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-audio"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "cpal",
@@ -9417,7 +9417,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-config"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "dirs 5.0.1",
  "serde",
@@ -9430,7 +9430,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-dbus"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "serde",
@@ -9442,7 +9442,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-hotkeys"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "ashpd",
@@ -9463,7 +9463,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-inference"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "cc",
@@ -9488,7 +9488,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-inject"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9501,7 +9501,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-llm"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "reqwest 0.12.28",
@@ -9515,7 +9515,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-mcp"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "serde",
@@ -9527,7 +9527,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-routing"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9551,14 +9551,14 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-text"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "regex",
 ]
 
 [[package]]
 name = "voxctrl-tts"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.8"
+version = "0.3.9"
 edition = "2021"
 authors = ["VoxCtrl Contributors"]
 license = "MIT"

--- a/crates/voxctrl-hotkeys/src/x11.rs
+++ b/crates/voxctrl-hotkeys/src/x11.rs
@@ -11,6 +11,9 @@
 //! udev rule to install, and nothing for VoxCtrl to change about the machine.
 //! That is what makes this backend usable where the evdev one is not.
 //!
+//! The version this declares to the server is load-bearing: see
+//! `MIN_XI_MINOR`.
+//!
 //! It carries the same privacy cost as evdev, though: raw events are every key
 //! the user presses, not just VoxCtrl's own shortcuts, so it ranks below the
 //! portal and the app says which one it is running on.
@@ -49,6 +52,33 @@ const XI_ALL_DEVICES: xinput::DeviceId = 0;
 
 /// X11 keycodes are evdev codes offset by 8, fixed by the X11 protocol.
 const X11_KEYCODE_OFFSET: u8 = 8;
+
+/// XInput 2.1 is the floor, and not for a feature — for two behaviours that
+/// this backend is unusable without.
+///
+/// Under XI 2.0 a raw event goes to the root window *or* to the grabbing
+/// client, never both. Grabs are everywhere on a desktop: a compositor's own
+/// key handling, and a passive grab every time a menu or dropdown opens. On
+/// Cinnamon that means a hotkey pressed with any menu on screen is simply lost.
+/// XI 2.1 delivers raw events to the root window at all times, whatever holds a
+/// grab.
+///
+/// XI 2.1 is also where `sourceid` starts being set on raw events. Without it
+/// every event claims to come from device 0, the XTEST filter below matches
+/// nothing, and VoxCtrl reads back the transcription it just typed — retriggering
+/// the hotkey inside its own output.
+///
+/// The server applies whichever semantics the client announces, so asking for
+/// 2.0 would opt into both problems on a server that supports neither. A server
+/// too old to offer 2.1 (pre-X.Org 1.11, 2011) is left to the evdev fallback
+/// rather than silently given a backend that mis-handles its own keystrokes.
+const MIN_XI_MINOR: u16 = 1;
+const MIN_XI_MAJOR: u16 = 2;
+
+/// Does a negotiated XInput version deliver raw events this backend can trust?
+fn supports_reliable_raw_events(major: u16, minor: u16) -> bool {
+    (major, minor) >= (MIN_XI_MAJOR, MIN_XI_MINOR)
+}
 
 /// Why the X11 backend could not be used. Never fatal: the caller falls through
 /// to evdev.
@@ -99,17 +129,17 @@ pub fn start(
     let (conn, _screen) = RustConnection::connect(None)
         .map_err(|e| X11Error::Connect(format!("{e}")))?;
 
-    // 2.0 is where raw events were introduced; asking for exactly what is used
-    // keeps this working on the older servers that are the whole point of the
-    // backend.
+    // The announced version decides the server's raw-event semantics, so this
+    // asks for the lowest one whose semantics are correct — see `MIN_XI_MINOR`.
     let version = conn
-        .xinput_xi_query_version(2, 0)
+        .xinput_xi_query_version(MIN_XI_MAJOR, MIN_XI_MINOR)
         .map_err(|e| X11Error::NoXInput(format!("{e}")))?
         .reply()
         .map_err(|e| X11Error::NoXInput(format!("{e}")))?;
-    if version.major_version < 2 {
+    if !supports_reliable_raw_events(version.major_version, version.minor_version) {
         return Err(X11Error::NoXInput(format!(
-            "the server offers XInput {}.{}, and raw key events need 2.0",
+            "the server offers XInput {}.{}, and reliable raw key events need \
+             {MIN_XI_MAJOR}.{MIN_XI_MINOR}",
             version.major_version, version.minor_version
         )));
     }
@@ -276,6 +306,21 @@ mod tests {
         // evdev's Debug renders these as "unknown key: N", which must never
         // reach a binding as if it were a key name.
         assert_eq!(key_name(60000), None);
+    }
+
+    #[test]
+    fn xinput_2_0_is_refused_because_its_raw_events_cannot_be_trusted() {
+        // Under 2.0 a raw event reaches the root window or the grabbing client,
+        // never both — so every hotkey pressed with a menu open is lost — and
+        // `sourceid` is unset, so the XTEST filter matches nothing and VoxCtrl
+        // reads back its own injected text. Accepting 2.0 would look like it
+        // worked right up until either bit us.
+        assert!(!supports_reliable_raw_events(2, 0));
+        assert!(!supports_reliable_raw_events(1, 9));
+
+        assert!(supports_reliable_raw_events(2, 1));
+        assert!(supports_reliable_raw_events(2, 4));
+        assert!(supports_reliable_raw_events(3, 0));
     }
 
     #[test]

--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -173,6 +173,26 @@ backend keeps working under the other. Synthetic devices (`XTEST`, `uinput`,
 anything named "virtual") are filtered by `sourceid`, so VoxCtrl never reads
 back the transcription it types out.
 
+**The XInput version VoxCtrl announces is load-bearing, and 2.1 is the floor.**
+The server applies whichever semantics the client asks for, and XI 2.0 has two
+that make this backend unusable:
+
+- A raw event under 2.0 goes to the root window *or* to the grabbing client,
+  never both. Grabs are everywhere on a desktop — a compositor's own key
+  handling, and a **passive grab every time a menu or dropdown opens**. On
+  Cinnamon that means a hotkey pressed with any menu on screen is silently
+  dropped. XI 2.1 delivers raw events to the root window at all times,
+  whatever holds a grab.
+- `sourceid` is only set on raw events from 2.1. Without it every event claims
+  to come from device 0, the XTEST filter matches nothing, and VoxCtrl reads
+  back the text it just injected — retriggering the hotkey inside its own
+  output.
+
+A server too old to offer 2.1 (pre-X.Org 1.11, 2011) falls through to evdev
+rather than being handed a backend that mishandles its own keystrokes.
+`supports_reliable_raw_events` is the single check, with a test pinning 2.0 as
+refused.
+
 To disable this path for testing, set `VOXCTRL_DISABLE_X11_HOTKEYS=1`.
 
 ### Linux Mint (Cinnamon / MATE) — Native D-Bus Shortcut Integration

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "voxctrl",
   "private": true,
-  "version": "0.3.8",
+  "version": "0.3.9",
   "type": "module",
   "scripts": {
     "predev": "pkill -x voxctrl 2>/dev/null || true; fuser -k 5173/tcp 2>/dev/null || true",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VoxCtrl",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "identifier": "ai.voxctrl.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Follow-up to #77, which merged at `c6d94fe` before these two commits existed. **Master currently ships the X11 backend with a bug that makes it drop hotkeys on Cinnamon**, so this is not just a version bump.

## 1. The X11 backend must announce XInput 2.1, not 2.0

The backend asked the server for XInput 2.0. The server applies whichever semantics the client announces, and 2.0 has two that make this backend unusable on exactly the desktop it was written for:

- **Raw events during grabs.** Under XI 2.0 a raw event goes to the root window *or* to the grabbing client, never both. Grabs are everywhere on a desktop — a compositor's own key handling, and a passive grab every time a menu or dropdown opens. On Cinnamon that means a hotkey pressed with any menu on screen is silently dropped, which would read as "the hotkey works, mostly, except when it doesn't". XI 2.1 delivers raw events to the root window at all times, whatever holds a grab.
- **`sourceid` is unset before 2.1.** The XTEST filter — the thing that stops VoxCtrl reading back the text it injects via `xdotool` — matches on `sourceid`. Under 2.0 every event reports device 0, the filter matches nothing, and dictating text containing your own hotkey retriggers the hotkey. A feedback loop.

XI 2.1 has shipped since X.Org 1.11 (2011); Mint 21 has Xorg 21.1. A server too old to offer it now falls through to evdev rather than being handed a backend that mishandles its own keystrokes. `supports_reliable_raw_events` is the single check, with a test pinning 2.0 as refused.

Sources: [Who-T: What's new in XI 2.1 — raw events](http://who-t.blogspot.com/2011/09/whats-new-in-xi-21-raw-events.html) (Peter Hutterer, XI2 maintainer), [xorg list: XInput2 raw events only for root window](https://lists.freedesktop.org/archives/xorg/2020-May/060269.html).

## 2. Release 0.3.9

`scripts/bump_version.sh 0.3.9` across `package.json`, `src-tauri/tauri.conf.json` and the workspace `Cargo.toml`, with `Cargo.lock` refreshed, so the release workflow's version-sync gate passes. The version-specific "What's new" body in `release.yml` is rewritten in the same commit, per the note above it — otherwise 0.3.9 would ship 0.3.8's notes.

Merging this to master triggers the release workflow, which builds all variants and creates the **draft** `v0.3.9` release.

## Testing

- `cargo test -p voxctrl-hotkeys` — 64 pass (one new: the XI version gate)
- `npx vitest run` — 62 pass
- `cargo clippy -p voxctrl-hotkeys` — no new warnings
- `release.yml` re-parsed as valid YAML after the notes rewrite
- Version sync verified across all three files

Still not validated against a live X server — this container has none. The two things worth trying first on the Mint 21 box, because they are exactly what the XI 2.1 fix addresses: **hold a bind with the Cinnamon menu open** (the passive-grab case), and **dictate text containing your own hotkey's key** (the injection-loop case). Settings → Hotkeys should report backend `x11`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tu6NtkoVPE4g371mcQZRyB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tu6NtkoVPE4g371mcQZRyB)_