### PR TITLE
Split the X11 event selection, or the server refuses every key (0.3.10)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,8 @@ jobs:
             squashfs-tools \
             pkg-config \
             build-essential \
-            espeak-ng
+            espeak-ng \
+            xvfb
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -96,8 +97,16 @@ jobs:
       # voxctrl-tts's phoneme-frontend tests exercise the real `espeak-ng`
       # binary when it is present, and skip cleanly when it isn't — it is
       # installed above so they actually run here.
+      #
+      # Under xvfb-run for the same reason: the X11 hotkey backend's tests talk
+      # to a real X server when DISPLAY is set, and skip when it isn't. Only a
+      # real server rejects a malformed XISelectEvents request, and a version
+      # of that backend shipped selecting raw and hierarchy events in one mask
+      # — which every server refuses, so no key ever arrived — with the whole
+      # suite passing. Without a display here those tests silently skip and the
+      # gap reopens.
       - name: cargo test
-        run: cargo test -p voxctrl-config -p voxctrl-routing -p voxctrl-hotkeys -p voxctrl-tts -p voxctrl-app
+        run: xvfb-run -a cargo test -p voxctrl-config -p voxctrl-routing -p voxctrl-hotkeys -p voxctrl-tts -p voxctrl-app
 
   # ── Frontend type check ───────────────────────────────────────────────────────
   frontend-check:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -427,66 +427,44 @@ jobs:
           # "## Downloads" is evergreen, and GitHub appends its own generated
           # "What's Changed" list of merged PRs beneath all of this.
           body: |
-            ## What's new in 0.3.9
+            ## What's new in 0.3.10
 
-            **Global shortcuts now work on Linux Mint, Cinnamon, MATE and
-            Xfce.** On those desktops 0.3.8 could not receive its own hotkeys at
-            all — the app ran, and holding a keybind did nothing.
+            **Fixes the X11 shortcut backend that 0.3.9 shipped broken.** On
+            Cinnamon, MATE and Xfce, 0.3.9 asked the X server for its key events
+            in a way the protocol does not allow, the server refused the whole
+            request, and no key ever arrived. The setup window reported it —
 
-            ### Why they did not work
+            ```
+            X11 shortcuts: the X server refused raw key events:
+            ... bad_value: 11 ... request_name: Some("XISelectEvents")
+            ```
 
-            Cinnamon and MATE serve no XDG `GlobalShortcuts` portal, so VoxCtrl
-            fell through to reading input devices — which needs `input` group
-            membership VoxCtrl deliberately will not grant itself. That left a
-            native Cinnamon shortcut as the last resort, and it could not work
-            either: the command it registered named a D-Bus method that does not
-            exist (`toggle_recording`, where the service publishes
-            `ToggleRecording`). Registration looked healthy and the shortcut did
-            nothing. Worse, the setup window reported **"VoxCtrl is ready"**
-            throughout, because it only checked that a shortcut had been listed
-            — never that a key was bound to it.
+            — and fell back to a native desktop shortcut, which serves only
+            tap-to-start/tap-to-stop. So on those desktops 0.3.9 delivered none
+            of the hold or double-tap styles it was written to deliver.
 
-            ### X11 shortcuts, with no permissions and no setup
+            The cause: VoxCtrl asked for raw key events and device-hotplug
+            notifications in a single request. Hotplug notifications may only be
+            requested for "all devices" and raw key events only for "all master
+            devices", and mixing them makes the server reject both. They are two
+            requests now, and only the first has to succeed.
 
-            0.3.9 adds an X11 backend using XInput2 raw key events. Any X client
-            may ask the server for these: there is no group to join, no udev
-            rule, and nothing to change about your machine. It covers Cinnamon,
-            MATE and Xfce, and because it sees each key going down *and* coming
-            back up, every gesture style works — hold, toggle, double-tap,
-            double-tap-and-hold — as do bare-modifier triggers like
-            double-tapping Super, which no accelerator-based backend can
-            express.
+            0.3.9's other fixes were sound and are unchanged — the native
+            Cinnamon/MATE shortcut route, the setup window no longer claiming
+            shortcuts work when nothing is bound, and gesture styles the running
+            backend cannot deliver no longer being offered. What 0.3.10 adds is
+            that the X11 backend those fixes were the fallback *for* now
+            actually runs.
 
-            Like the existing device-reading fallback, this mode sees every
-            keystroke, not only VoxCtrl's shortcuts. Nothing is logged, stored,
-            or transmitted, and the Hotkeys tab says plainly which backend is
-            running. A desktop with a shortcuts portal (KDE Plasma, GNOME 48+,
-            Hyprland) still avoids it entirely.
+            ### How this got past 0.3.9, and what stops it next time
 
-            ### Gesture styles you cannot use are no longer offered
-
-            On a Wayland Cinnamon session VoxCtrl falls back to a native desktop
-            shortcut, and a desktop shortcut only reports the key going *down*.
-            A hold has no end, and a tap cannot be told from a hold. The Hotkeys
-            tab now offers exactly the styles the running backend can deliver
-            and explains what is missing, instead of offering four and silently
-            doing nothing for three of them. A binding you already saved keeps
-            its gesture, flagged rather than rewritten.
-
-            ### Also in this release
-
-            - The native Cinnamon/MATE shortcut route is repaired for Wayland
-              sessions: correct D-Bus method, one shortcut per binding (so text
-              reaches that binding's targets), numbered `customN` slots
-              allocated around your existing shortcuts so nothing is
-              overwritten and Cinnamon's Keyboard panel actually lists them.
-            - `gsettings` and `dbus-send` are now run with your desktop's
-              environment rather than the AppImage's. Inside the bundle they
-              were looking for Cinnamon's settings schemas in the AppDir and
-              concluding your desktop had no keyboard settings at all.
-            - The setup window no longer claims shortcuts are working when
-              nothing is bound, and reports why the X11 path was unavailable
-              when it was.
+            Only a real X server rejects a malformed request; no unit test can.
+            The suite passed in full while the backend could not select a single
+            key event. VoxCtrl's tests now talk to a real X server when one is
+            present — including a test that runs the backend's own startup path
+            end to end, and one that pins the exact malformed request as an
+            error — and CI runs them under a virtual display so they cannot
+            silently skip.
 
             ### Requirements
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9362,7 +9362,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voxctrl-app"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9402,7 +9402,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-audio"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "anyhow",
  "cpal",
@@ -9417,7 +9417,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-config"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "dirs 5.0.1",
  "serde",
@@ -9430,7 +9430,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-dbus"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "anyhow",
  "serde",
@@ -9442,7 +9442,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-hotkeys"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "anyhow",
  "ashpd",
@@ -9463,7 +9463,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-inference"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "anyhow",
  "cc",
@@ -9488,7 +9488,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-inject"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9501,7 +9501,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-llm"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "anyhow",
  "reqwest 0.12.28",
@@ -9515,7 +9515,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-mcp"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "anyhow",
  "serde",
@@ -9527,7 +9527,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-routing"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9551,14 +9551,14 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-text"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "regex",
 ]
 
 [[package]]
 name = "voxctrl-tts"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "anyhow",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.9"
+version = "0.3.10"
 edition = "2021"
 authors = ["VoxCtrl Contributors"]
 license = "MIT"

--- a/crates/voxctrl-hotkeys/src/x11.rs
+++ b/crates/voxctrl-hotkeys/src/x11.rs
@@ -46,8 +46,9 @@ use crate::{
 /// on every hotplug.
 const XI_ALL_MASTER_DEVICES: xinput::DeviceId = 1;
 
-/// `XIAllDevices`, for querying the device list — the slave keyboards that
-/// `sourceid` refers to are not master devices.
+/// `XIAllDevices`. Used to query the device list — the slave keyboards that
+/// `sourceid` refers to are not master devices — and to select hierarchy
+/// events, which the protocol permits on this device and no other.
 const XI_ALL_DEVICES: xinput::DeviceId = 0;
 
 /// X11 keycodes are evdev codes offset by 8, fixed by the X11 protocol.
@@ -144,25 +145,40 @@ pub fn start(
         )));
     }
 
-    let mask = xinput::EventMask {
+    // Raw events go on XIAllMasterDevices. Hierarchy events CANNOT: the protocol
+    // allows them only on XIAllDevices, and asking for both in one mask makes
+    // the server reject the whole request with BadValue — which selects
+    // nothing, so no key ever arrives. They are two requests for that reason,
+    // and because only the first one matters: raw key events are the backend,
+    // while hierarchy is a refresh hint for the XTEST filter.
+    let raw_mask = xinput::EventMask {
         deviceid: XI_ALL_MASTER_DEVICES,
-        mask: vec![
-            xinput::XIEventMask::RAW_KEY_PRESS
-                | xinput::XIEventMask::RAW_KEY_RELEASE
-                // Hotplug: a keyboard added later, or a new XTEST device, changes
-                // which source ids are worth listening to.
-                | xinput::XIEventMask::HIERARCHY,
-        ],
+        mask: vec![xinput::XIEventMask::RAW_KEY_PRESS | xinput::XIEventMask::RAW_KEY_RELEASE],
+    };
+    let hierarchy_mask = xinput::EventMask {
+        deviceid: XI_ALL_DEVICES,
+        mask: vec![xinput::XIEventMask::HIERARCHY],
     };
 
     // Raw events may only be selected on a root window. Every screen gets its
     // own selection so a multi-screen (not multi-monitor) display still works.
     let roots: Vec<u32> = conn.setup().roots.iter().map(|s| s.root).collect();
     for root in &roots {
-        conn.xinput_xi_select_events(*root, std::slice::from_ref(&mask))
+        conn.xinput_xi_select_events(*root, std::slice::from_ref(&raw_mask))
             .map_err(|e| X11Error::Select(format!("{e}")))?
             .check()
             .map_err(|e| X11Error::Select(format!("{e}")))?;
+
+        // Best-effort: without it a keyboard or XTEST device added later is not
+        // noticed until the next restart, which is worth a log line and not
+        // worth giving up working hotkeys over.
+        let hotplug = conn
+            .xinput_xi_select_events(*root, std::slice::from_ref(&hierarchy_mask))
+            .map_err(|e| format!("{e}"))
+            .and_then(|cookie| cookie.check().map_err(|e| format!("{e}")));
+        if let Err(e) = hotplug {
+            tracing::debug!("X11 device-hotplug notifications unavailable: {e}");
+        }
     }
     conn.flush().map_err(|e| X11Error::Select(format!("{e}")))?;
 
@@ -306,6 +322,138 @@ mod tests {
         // evdev's Debug renders these as "unknown key: N", which must never
         // reach a binding as if it were a key name.
         assert_eq!(key_name(60000), None);
+    }
+
+    /// The selection sequence `start` performs, against whatever X server
+    /// `DISPLAY` points at.
+    ///
+    /// Skips when there is no server. Run it under `xvfb-run -a cargo test` to
+    /// exercise it in CI or a container.
+    ///
+    /// This exists because the unit tests below cannot catch a protocol
+    /// violation: only a real server rejects one. The first shipped version of
+    /// this backend selected raw and hierarchy events in a single mask, which
+    /// every server refuses with BadValue, and nothing in the suite noticed.
+    #[test]
+    fn the_real_selection_sequence_is_accepted_by_an_x_server() {
+        let Ok(display) = std::env::var("DISPLAY") else {
+            eprintln!("skipped: no DISPLAY (run under xvfb-run to exercise this)");
+            return;
+        };
+
+        let (conn, _screen) = match RustConnection::connect(None) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("skipped: DISPLAY={display} is not connectable: {e}");
+                return;
+            }
+        };
+
+        let version = conn
+            .xinput_xi_query_version(MIN_XI_MAJOR, MIN_XI_MINOR)
+            .expect("XIQueryVersion should be sendable")
+            .reply()
+            .expect("this server should serve XInput2");
+        assert!(
+            supports_reliable_raw_events(version.major_version, version.minor_version),
+            "server offers XInput {}.{}",
+            version.major_version,
+            version.minor_version
+        );
+
+        let raw_mask = xinput::EventMask {
+            deviceid: XI_ALL_MASTER_DEVICES,
+            mask: vec![xinput::XIEventMask::RAW_KEY_PRESS | xinput::XIEventMask::RAW_KEY_RELEASE],
+        };
+        let hierarchy_mask = xinput::EventMask {
+            deviceid: XI_ALL_DEVICES,
+            mask: vec![xinput::XIEventMask::HIERARCHY],
+        };
+        let root = conn.setup().roots[0].root;
+
+        conn.xinput_xi_select_events(root, std::slice::from_ref(&raw_mask))
+            .expect("XISelectEvents should be sendable")
+            .check()
+            .expect("the server must accept raw key events on XIAllMasterDevices");
+
+        conn.xinput_xi_select_events(root, std::slice::from_ref(&hierarchy_mask))
+            .expect("XISelectEvents should be sendable")
+            .check()
+            .expect("the server must accept hierarchy events on XIAllDevices");
+
+        // The combination that shipped broken, pinned as an error so a future
+        // edit that merges the masks fails here instead of on a user's desktop.
+        let merged = xinput::EventMask {
+            deviceid: XI_ALL_MASTER_DEVICES,
+            mask: vec![
+                xinput::XIEventMask::RAW_KEY_PRESS
+                    | xinput::XIEventMask::RAW_KEY_RELEASE
+                    | xinput::XIEventMask::HIERARCHY,
+            ],
+        };
+        let merged_result = conn
+            .xinput_xi_select_events(root, std::slice::from_ref(&merged))
+            .expect("XISelectEvents should be sendable")
+            .check();
+        assert!(
+            merged_result.is_err(),
+            "selecting HIERARCHY on XIAllMasterDevices must be refused; if a \
+             server ever accepts it, this backend's split is still correct but \
+             this test's premise has changed"
+        );
+
+        // And the device query the XTEST filter is built from.
+        let devices = conn
+            .xinput_xi_query_device(XI_ALL_DEVICES)
+            .expect("XIQueryDevice should be sendable")
+            .reply()
+            .expect("the server must answer a device query");
+        assert!(!devices.infos.is_empty(), "a server always has core devices");
+    }
+
+    /// `start` itself, end to end, against a real server.
+    ///
+    /// The narrower test above checks the protocol requests in isolation; this
+    /// one runs the function the app actually calls, so a mistake anywhere in
+    /// its setup — version negotiation, either selection, thread spawning —
+    /// shows up as `Err` here rather than as "the app runs and no key works".
+    #[tokio::test]
+    async fn start_succeeds_and_claims_the_backend_on_a_real_server() {
+        if std::env::var("DISPLAY").is_err() {
+            eprintln!("skipped: no DISPLAY (run under xvfb-run to exercise this)");
+            return;
+        }
+
+        let (tx, _rx) = crate::channel();
+        let (_reload_tx, reload_rx) = crossbeam_channel::unbounded();
+        let health = Arc::new(ListenerHealth::default());
+
+        let result = start(Vec::new(), tx, reload_rx, health.clone());
+
+        assert!(result.is_ok(), "start must succeed on a real X server: {result:?}");
+        assert_eq!(health.backend(), Backend::X11);
+        assert!(health.is_active());
+    }
+
+    #[test]
+    fn hierarchy_events_are_never_selected_alongside_raw_events() {
+        // XI_HierarchyChanged may only be selected on XIAllDevices. Asking for
+        // it on XIAllMasterDevices — which is where raw events must go — makes
+        // the server reject the entire XISelectEvents request with BadValue, so
+        // nothing at all is selected and not one key ever arrives. That shipped
+        // once: "the X server refused raw key events ... bad_value: 11", 11
+        // being this very mask bit.
+        assert_ne!(
+            XI_ALL_DEVICES, XI_ALL_MASTER_DEVICES,
+            "the two selections must target different devices"
+        );
+
+        let raw = xinput::XIEventMask::RAW_KEY_PRESS | xinput::XIEventMask::RAW_KEY_RELEASE;
+        assert_eq!(
+            u32::from(raw) & u32::from(xinput::XIEventMask::HIERARCHY),
+            0,
+            "the raw-event mask must not carry HIERARCHY"
+        );
     }
 
     #[test]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "voxctrl",
   "private": true,
-  "version": "0.3.9",
+  "version": "0.3.10",
   "type": "module",
   "scripts": {
     "predev": "pkill -x voxctrl 2>/dev/null || true; fuser -k 5173/tcp 2>/dev/null || true",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VoxCtrl",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "identifier": "ai.voxctrl.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
0.3.9's X11 backend could not select a single key event. Reported from a Mint 21 Cinnamon desktop, and the setup window printed the cause verbatim:

```
X11 shortcuts: the X server refused raw key events: X11Error {
  error_kind: Value, error_code: 2, bad_value: 11,
  minor_opcode: 46, major_opcode: 131,
  extension_name: Some("XInputExtension"),
  request_name: Some("XISelectEvents") }
```

## The bug

The backend asked for raw key events and device-hotplug notifications in a **single** `XISelectEvents` request. The protocol does not allow that combination:

- `XI_HierarchyChanged` may only be selected on `XIAllDevices`
- raw key events must be selected on `XIAllMasterDevices`

Mixing them makes the server reject the **entire request** with `BadValue` — so nothing at all is selected, and not one key event ever arrives. `bad_value: 11` is the `HIERARCHY` mask bit (1 << 11), which is the server naming the offending bit.

VoxCtrl then fell through to the native Cinnamon shortcut route, which serves `toggle` alone. So on Cinnamon, MATE and Xfce, 0.3.9 delivered none of the hold or double-tap styles the X11 backend exists to provide — while the setup window read "VoxCtrl is ready".

## The fix

Two requests. Only the raw-event one is fatal: hotplug notification is a refresh hint for the XTEST `sourceid` filter, not something worth giving up working hotkeys over, so it degrades to a debug log.

## Why the tests missed it, and what stops it next time

Only a real X server rejects a malformed request — no unit test can. The whole suite passed while the backend was incapable of selecting a key event. That gap is now closed:

- `start_succeeds_and_claims_the_backend_on_a_real_server` drives the backend's actual startup path end to end and asserts it claims `Backend::X11`. This would have failed on the original bug.
- `the_real_selection_sequence_is_accepted_by_an_x_server` checks each request in isolation **and pins the merged mask as an error**, so a future edit that recombines them fails here instead of on a user's desktop.
- Both skip cleanly when `DISPLAY` is unset, so local runs without a display still work.
- **CI now runs the suite under `xvfb-run`** — otherwise those tests would silently skip in CI and the gap would reopen immediately.

## Verification

Run against Xvfb in the dev container, not just asserted:

- The merged mask reproduces the reported production error **byte for byte** — `error_kind: Value, error_code: 2, bad_value: 11, minor_opcode: 46, major_opcode: 131, XISelectEvents`.
- The split selection is accepted, and `start()` returns `Ok` with `Backend::X11` claimed.
- `xvfb-run -a cargo test -p voxctrl-hotkeys` — 67 pass
- `npx vitest run` — 62 pass
- `cargo clippy -p voxctrl-hotkeys` — no new warnings
- Both workflow files re-validated as YAML

Version bumped to 0.3.10 via `scripts/bump_version.sh` with the release notes rewritten in the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tu6NtkoVPE4g371mcQZRyB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tu6NtkoVPE4g371mcQZRyB)_