### PR TITLE
Sync the lockfile's recorded version with package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "voxctrl",
-  "version": "0.3.10",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "voxctrl",
-      "version": "0.3.10",
+      "version": "0.4.0",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2",


### PR DESCRIPTION
`package.json` declares 0.4.0, but `package-lock.json` still recorded 0.3.10 in both its top-level `version` and the root package entry. npm rewrites those two fields on the first `npm install` in a clean checkout, so anyone building the frontend picks up a modified lockfile they never edited — and CI or a pre-commit check that insists on a clean tree fails on it.

This records the version the manifest actually declares. No dependency resolution changes: the diff is the two version strings.

Noticed while running the frontend to capture v0.4.0 UI screenshots — `npm install` left the tree dirty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJqrDy1bMU8sPt8oR8GBCh


---
_Generated by [Claude Code](https://claude.ai/code/session_01BJqrDy1bMU8sPt8oR8GBCh)_