### PR TITLE
Stop playback when dictation starts

### DIFF
--- a/docs/tts.md
+++ b/docs/tts.md
@@ -292,6 +292,8 @@ The `stop_key` config field lists keys that interrupt current TTS playback when 
 
 Sending `None` through the TTS engine channel (via `TtsEngineHandle::stop()`) clears the current utterance.
 
+**Starting dictation also stops playback.** Every path that begins capture — the hotkey gesture, the settings window, the D-Bus service behind a native desktop shortcut, and MCP voice capture — goes through `AppState::begin_recording`, which interrupts the current response first. Talking over a spoken reply means interrupting it, and recording while the speakers are still going would feed VoxCtrl's own voice back into the microphone.
+
 **Escape and the desktop portal.** The default stop key is Escape, and it works as it reads: press it and playback stops. How VoxCtrl registers it depends on the backend. Where VoxCtrl watches the key stream itself (X11, evdev, the Windows hook) nothing is grabbed, every app still receives Escape, and the binding is simply registered for the whole session. Where the desktop owns the grab (the XDG `GlobalShortcuts` portal), a standing registration would be *exclusive* — no other app would see Escape while VoxCtrl ran — so VoxCtrl holds it only while it is speaking and gives it back two seconds after playback ends. A stop key with a modifier (`Ctrl+Escape`) is an ordinary shortcut everywhere and is held throughout. See [hotkeys.md](hotkeys.md#bare-escape-and-the-exclusive-grab).
 
 ---

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -55,7 +55,7 @@ pub struct StatusPayload {
 #[tauri::command]
 pub async fn start_recording(state: State<'_, Arc<AppState>>) -> Result<(), String> {
     *state.active_binding_id.lock().await = String::new();
-    state.set_recording(true);
+    state.begin_recording().await;
     info!("Recording started via command");
     Ok(())
 }

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -167,7 +167,7 @@ pub fn spawn_hotkey_gesture_handler(
                     *state_for_gesture.active_binding_label.lock().await =
                         event.binding_label.clone();
                     *state_for_gesture.active_binding_id.lock().await = event.binding_id.clone();
-                    state_for_gesture.set_recording(true);
+                    state_for_gesture.begin_recording().await;
 
                     // The user just tried to dictate. If the install is not
                     // finished, say so now — otherwise the shortcut records

--- a/src-tauri/src/services.rs
+++ b/src-tauri/src/services.rs
@@ -22,8 +22,8 @@ impl McpCallbacks for AppState {
 
             self.set_mcp_recording(true);
 
-            // Start recording.
-            self.set_recording(true);
+            // Start recording, interrupting any response being spoken.
+            self.begin_recording().await;
 
             // Spawn a timer to automatically stop recording after timeout_secs.
             let recording = self.recording.clone();
@@ -123,7 +123,7 @@ pub fn start_dbus_service(app_state: Arc<AppState>) {
                     // shortcut would dictate into the default target no matter
                     // which one the user pressed.
                     apply_dbus_binding(&app_state_dbus, &binding_id).await;
-                    app_state_dbus.set_recording(true);
+                    app_state_dbus.begin_recording().await;
                     let mut st = dbus_state_clone.lock().await;
                     st.status = voxctrl_dbus::DictationStatus::Recording;
                 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -161,6 +161,27 @@ impl AppState {
         self.gain.store(v.to_bits(), Ordering::SeqCst);
     }
 
+    /// Start capturing, and stop anything VoxCtrl is saying while it does.
+    ///
+    /// Every path that starts dictation goes through this rather than
+    /// `set_recording(true)`: the hotkey gesture, the settings window, the D-Bus
+    /// service a desktop shortcut pokes, and MCP voice capture. A user who
+    /// starts talking over a spoken response means to interrupt it — and
+    /// capturing while the speakers are still going also feeds VoxCtrl's own
+    /// voice back into the microphone.
+    ///
+    /// `TtsEngineHandle::stop` rather than the raw sink stop, so the generation
+    /// counter is bumped: a streaming engine would otherwise keep appending the
+    /// frames it already had in flight and pick the sentence back up.
+    pub async fn begin_recording(&self) {
+        if let Some(tts) = self.tts_handle.lock().await.as_ref() {
+            tts.stop();
+        }
+        self.set_recording(true);
+    }
+
+    /// Prefer `begin_recording` to start dictation — it also interrupts
+    /// playback. This is the plain flag, and the only way to clear it.
     pub fn set_recording(&self, v: bool) {
         self.recording.store(v, Ordering::SeqCst);
         if !v {

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -96,6 +96,21 @@ fn make_test_state() -> AppState {
 }
 
 #[tokio::test]
+async fn starting_dictation_interrupts_a_spoken_response() {
+    // Talking over a response means interrupting it, not being talked over —
+    // and capturing while the speakers are still going feeds VoxCtrl's own
+    // voice back into the microphone. Every path that starts dictation goes
+    // through `begin_recording` for that reason; with no engine attached it
+    // still has to start the capture rather than fail.
+    let state = make_test_state();
+    assert!(state.tts_handle.lock().await.is_none());
+
+    state.begin_recording().await;
+
+    assert!(state.is_recording());
+}
+
+#[tokio::test]
 async fn test_app_state_initial_values() {
     let state = make_test_state();
     assert!(!state.is_recording());


### PR DESCRIPTION
## The problem

Pressing the dictation key while a response was being read out left VoxCtrl talking over the user. Only two things interrupted playback: the TTS stop key (`pipeline.rs`) and the `stop_tts` command. Starting a recording did neither.

Beyond the obvious — someone who starts dictating means to interrupt — recording while the speakers are still going feeds VoxCtrl's own voice back into the microphone and into the transcription.

## The change

`AppState::begin_recording` stops the current utterance and then starts the capture. Every path that begins dictation now goes through it:

- the hotkey gesture (`pipeline.rs`)
- the settings window's `start_recording` command
- the D-Bus service behind a native Cinnamon/MATE desktop shortcut
- MCP voice capture (`transcribe_voice`)

It calls `TtsEngineHandle::stop` rather than the raw `stop_current_playback()`, for the same reason the stop-key path does: `stop` bumps the generation counter, so a streaming engine drops the frames it already had in flight instead of picking the sentence back up. (The engine's own test pins that distinction.)

`set_recording` keeps its old meaning — the plain flag, and the only way to clear it — with a doc comment pointing future call sites at `begin_recording`.

## Tests

`cargo test -p voxctrl-app --lib` — 76 passed, including a new test that `begin_recording` starts the capture when no TTS engine is attached (the common case: TTS disabled).

Built with `--no-default-features --features custom-protocol`; the default build fetches ONNX Runtime, which this sandbox's proxy blocks.

Documented in `docs/tts.md` under Stopping Playback.

## Note

This commit is currently also present on `claude/escape-key-propagation-fhfwt7` ([#83](https://github.com/JRufer/VoxCtrl/pull/83)), where it was originally written. This PR is based directly on `master` and stands alone; whichever merges first, the other's diff simply shrinks. Say the word if you'd like it dropped from #83 so the two are disjoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5G6fAvwSwHCd9JUSV8L2P

---
_Generated by [Claude Code](https://claude.ai/code/session_01B5G6fAvwSwHCd9JUSV8L2P)_