### PR TITLE
Make the stop-key arming safe: own portal session, guarded reloads, supervised gesture loop

### DIFF
--- a/crates/voxctrl-hotkeys/src/portal.rs
+++ b/crates/voxctrl-hotkeys/src/portal.rs
@@ -17,7 +17,7 @@ use ashpd::desktop::{
     Session,
 };
 use futures_util::StreamExt;
-use voxctrl_routing::HotkeyBinding;
+use voxctrl_routing::{HotkeyBinding, TTS_STOP_BINDING_ID};
 
 use crate::{
     gestures::{GestureEngine, Transition},
@@ -49,11 +49,17 @@ impl std::fmt::Display for PortalError {
 /// accelerator twice — which it is entitled to refuse — and would break the
 /// `double_tap` / `double_tap_hold` pairing that depends on both gestures
 /// seeing the same press.
+#[derive(Clone)]
 struct ShortcutGroup {
     id: String,
     description: String,
     trigger: Option<String>,
     binding_ids: Vec<String>,
+    /// This shortcut is only registered for as long as VoxCtrl needs it — the
+    /// TTS stop key on bare Escape. It lives in its own portal session, so
+    /// taking it and giving it back never disturbs the session holding the
+    /// dictation shortcuts.
+    transient: bool,
 }
 
 fn group_bindings(bindings: &[HotkeyBinding]) -> Vec<ShortcutGroup> {
@@ -61,6 +67,12 @@ fn group_bindings(bindings: &[HotkeyBinding]) -> Vec<ShortcutGroup> {
     let mut groups: HashMap<String, ShortcutGroup> = HashMap::new();
 
     for b in bindings.iter().filter(|b| !b.disabled && !b.keys.is_empty()) {
+        // Only the app's own stop-key binding may be held transiently. A user
+        // who binds dictation to bare Escape shares this group with it, and
+        // their binding is a standing one — so the group is too, and the stop
+        // key rides along on a registration that is never given back.
+        let transient =
+            crate::trigger::is_reserved_for_the_desktop(&b.keys) && b.id == TTS_STOP_BINDING_ID;
         let signature = b.trigger_signature();
         let entry = groups.entry(signature.clone()).or_insert_with(|| {
             order.push(signature.clone());
@@ -69,8 +81,10 @@ fn group_bindings(bindings: &[HotkeyBinding]) -> Vec<ShortcutGroup> {
                 description: String::new(),
                 trigger: portal_trigger(&b.keys),
                 binding_ids: Vec::new(),
+                transient,
             }
         });
+        entry.transient = entry.transient && transient;
         if !entry.description.is_empty() {
             entry.description.push_str(" / ");
         }
@@ -191,8 +205,14 @@ pub async fn start(
         .await
         .map_err(|e| session_error(e, &registration))?;
 
-    let groups = group_bindings(&bindings);
-    let bound = bind_groups(&portal, &session, &groups).await?;
+    // The standing shortcuts — everything but a transiently-held stop key — are
+    // what this session carries, and it is never rebuilt for the stop key's
+    // sake. That separation is the point: re-registering these ids under a new
+    // session, then closing the old one, is what left the compositor with no
+    // working dictation shortcut at all.
+    let (groups, transient_groups) = split_groups(group_bindings(&bindings));
+    let known = [groups.clone(), transient_groups.clone()].concat();
+    let bound = bind_groups(&portal, &session, &groups, Some(&known)).await?;
     health.set_bound_shortcuts(bound);
     // Claimed here rather than by the caller after the await: the listener task
     // below can fail immediately, and a late `set_backend(Portal)` racing that
@@ -205,7 +225,17 @@ pub async fn start(
     );
 
     tokio::spawn(async move {
-        run(portal, session, bindings, groups, tx, rx_reload, health).await;
+        run(
+            portal,
+            session,
+            bindings,
+            groups,
+            transient_groups,
+            tx,
+            rx_reload,
+            health,
+        )
+        .await;
     });
 
     Ok(())
@@ -233,13 +263,24 @@ fn session_error(e: ashpd::Error, registration: &Result<(), String>) -> PortalEr
     })
 }
 
+/// Register `groups` on `session`.
+///
+/// `known` is every group VoxCtrl currently has across all of its sessions, and
+/// only matters for the KDE housekeeping: pruning is keyed on "an id VoxCtrl no
+/// longer uses", so it has to see the whole picture rather than the subset this
+/// session happens to carry. Pass `None` to skip that housekeeping entirely —
+/// arming the stop key changes no user-visible binding, and rewriting the user's
+/// shortcut store every time VoxCtrl speaks would be pure churn.
 async fn bind_groups(
     portal: &GlobalShortcuts,
     session: &Session<GlobalShortcuts>,
     groups: &[ShortcutGroup],
+    known: Option<&[ShortcutGroup]>,
 ) -> Result<Vec<BoundShortcut>, PortalError> {
     // Sync shortcut names in KDE settings and unregister any deleted shortcuts.
-    sync_kde_shortcuts(groups).await;
+    if let Some(known) = known {
+        sync_kde_shortcuts(known).await;
+    }
 
     let shortcuts: Vec<NewShortcut> = groups
         .iter()
@@ -441,6 +482,58 @@ async fn update_kglobalshortcutsrc(
     }
 }
 
+/// Split the registered groups into the ones held for the session and the ones
+/// VoxCtrl only holds while it needs them.
+fn split_groups(groups: Vec<ShortcutGroup>) -> (Vec<ShortcutGroup>, Vec<ShortcutGroup>) {
+    groups.into_iter().partition(|g| !g.transient)
+}
+
+/// Do these two sets ask the compositor for the same thing? Ids, names and
+/// triggers are what a registration carries; anything else changed in a binding
+/// is the gesture engine's business, not the portal's.
+fn same_groups(a: &[ShortcutGroup], b: &[ShortcutGroup]) -> bool {
+    a.len() == b.len()
+        && a.iter().zip(b.iter()).all(|(a, b)| {
+            a.id == b.id && a.description == b.description && a.trigger == b.trigger
+        })
+}
+
+/// Which bindings each shortcut id fires, across every session.
+fn shortcut_map(
+    standing: &[ShortcutGroup],
+    transient: &[ShortcutGroup],
+) -> HashMap<String, Vec<String>> {
+    standing
+        .iter()
+        .chain(transient.iter())
+        .map(|g| (g.id.clone(), g.binding_ids.clone()))
+        .collect()
+}
+
+/// A fresh session carrying `groups`, or the reason there is not one.
+///
+/// The caller closes whatever the new session replaces — and, for a set of ids
+/// that is moving between sessions, closes it *first*: two sessions registering
+/// the same id under the same app id, one of them then closing, is how a
+/// desktop ends up holding neither.
+async fn rebind(
+    portal: &GlobalShortcuts,
+    groups: &[ShortcutGroup],
+    known: Option<&[ShortcutGroup]>,
+) -> Result<(Session<GlobalShortcuts>, Vec<BoundShortcut>), PortalError> {
+    let session = portal
+        .create_session(Default::default())
+        .await
+        .map_err(|e| PortalError::Rejected(format!("{e}")))?;
+    match bind_groups(portal, &session, groups, known).await {
+        Ok(bound) => Ok((session, bound)),
+        Err(e) => {
+            let _ = session.close().await;
+            Err(e)
+        }
+    }
+}
+
 /// What the compositor actually bound, so the UI can show the real shortcut
 /// rather than the one VoxCtrl asked for.
 fn describe(groups: &[ShortcutGroup], shortcuts: &[Shortcut]) -> Vec<BoundShortcut> {
@@ -466,15 +559,24 @@ async fn run(
     mut session: Session<GlobalShortcuts>,
     bindings: Vec<HotkeyBinding>,
     mut groups: Vec<ShortcutGroup>,
+    mut transient_groups: Vec<ShortcutGroup>,
     tx: GestureSender,
     rx_reload: ReloaderReceiver,
     health: Arc<ListenerHealth>,
 ) {
     let mut engine = GestureEngine::new(bindings);
-    let mut by_shortcut: HashMap<String, Vec<String>> = groups
-        .iter()
-        .map(|g| (g.id.clone(), g.binding_ids.clone()))
-        .collect();
+    // Transient shortcuts get their own session so arming and releasing them
+    // leaves the standing one — the dictation shortcuts — untouched.
+    let mut transient_session: Option<Session<GlobalShortcuts>> = None;
+    if !transient_groups.is_empty() {
+        // Only reachable when the listener starts while VoxCtrl is already
+        // speaking, which the "Approve shortcuts" button can do.
+        match rebind(&portal, &transient_groups, None).await {
+            Ok((session, _)) => transient_session = Some(session),
+            Err(e) => tracing::warn!("Could not register the stop key: {e}"),
+        }
+    }
+    let mut by_shortcut = shortcut_map(&groups, &transient_groups);
 
     let (mut activated, mut deactivated, mut changed) = match futures_util::try_join!(
         portal.receive_activated(),
@@ -518,47 +620,62 @@ async fn run(
             event = changed.next() => {
                 let Some(event) = event else { break };
                 // The user re-assigned a shortcut in the desktop's settings.
-                health.set_bound_shortcuts(describe(&groups, event.shortcuts()));
+                let known = [groups.clone(), transient_groups.clone()].concat();
+                health.set_bound_shortcuts(describe(&known, event.shortcuts()));
             }
             new_bindings = next_reload(&rx_reload) => {
                 let Some(new_bindings) = new_bindings else { break };
                 tracing::info!("portal hotkeys: reloading {} bindings", new_bindings.len());
-                let new_groups = group_bindings(&new_bindings);
-                let same_groups = new_groups.len() == groups.len() && new_groups.iter().zip(groups.iter()).all(|(a, b)| {
-                    a.id == b.id && a.description == b.description && a.trigger == b.trigger
-                });
+                let (new_standing, new_transient) = split_groups(group_bindings(&new_bindings));
+                let standing_changed = !same_groups(&new_standing, &groups);
+                let transient_changed = !same_groups(&new_transient, &transient_groups);
+
                 engine.reset(&tx);
                 engine.reload(new_bindings.clone());
-                groups = new_groups;
-                by_shortcut = groups
-                    .iter()
-                    .map(|g| (g.id.clone(), g.binding_ids.clone()))
-                    .collect();
+                groups = new_standing;
+                transient_groups = new_transient;
+                by_shortcut = shortcut_map(&groups, &transient_groups);
 
-                if same_groups {
-                    tracing::info!("portal hotkeys: shortcut triggers unchanged; preserving active portal session");
-                    continue;
+                // A stop key going up or down must not touch the session that
+                // holds the dictation shortcuts. Re-registering those ids under
+                // a second session and then closing the first is what left a
+                // compositor with no working shortcut at all once playback had
+                // been cancelled once.
+                if standing_changed {
+                    // Sessions allow `bind_shortcuts` exactly once, so a real
+                    // change to the user's bindings needs a new one.
+                    let known = [groups.clone(), transient_groups.clone()].concat();
+                    match rebind(&portal, &groups, Some(&known)).await {
+                        Ok((new_session, bound)) => {
+                            let _ = session.close().await;
+                            session = new_session;
+                            health.set_bound_shortcuts(bound);
+                        }
+                        Err(e) => tracing::warn!("Re-binding portal shortcuts failed: {e}"),
+                    }
                 }
 
-                // Re-creating the portal session on reload is required because
-                // GlobalShortcuts portal sessions allow bind_shortcuts to be called only once per session.
-                match portal.create_session(Default::default()).await {
-                    Ok(new_session) => {
-                        match bind_groups(&portal, &new_session, &groups).await {
-                            Ok(bound) => {
-                                let _ = session.close().await;
-                                session = new_session;
-                                health.set_bound_shortcuts(bound);
-                            }
-                            Err(e) => {
-                                let _ = new_session.close().await;
-                                tracing::warn!("Re-binding portal shortcuts failed: {e}");
-                            }
+                if transient_changed {
+                    // Close first: the old session and the new one would be
+                    // registering the same shortcut id under the same app id,
+                    // and closing the loser afterwards takes the winner's
+                    // registration with it on at least one desktop.
+                    if let Some(old) = transient_session.take() {
+                        let _ = old.close().await;
+                    }
+                    if !transient_groups.is_empty() {
+                        // No KDE housekeeping here: nothing the user configured
+                        // has changed, and rewriting their shortcut store every
+                        // time VoxCtrl speaks would be pure churn.
+                        match rebind(&portal, &transient_groups, None).await {
+                            Ok((session, _)) => transient_session = Some(session),
+                            Err(e) => tracing::warn!("Could not register the stop key: {e}"),
                         }
                     }
-                    Err(e) => {
-                        tracing::warn!("Failed to create new portal session for reload: {e}");
-                    }
+                }
+
+                if !standing_changed && !transient_changed {
+                    tracing::info!("portal hotkeys: shortcut triggers unchanged; preserving active portal session");
                 }
             }
         }
@@ -673,6 +790,67 @@ mod tests {
             .id
             .clone();
         assert!(!ids.contains(&ordinary));
+    }
+
+    #[test]
+    fn the_stop_key_is_split_away_from_the_shortcuts_that_stay_registered() {
+        // The regression this exists for: arming and releasing the stop key
+        // used to rebuild the one session that also held the dictation
+        // shortcuts — re-registering their ids under a new session and closing
+        // the old one — and after the first release the compositor fired none
+        // of them. The two now live in separate sessions.
+        let (standing, transient) = split_groups(group_bindings(&[
+            binding("dictate", &["KEY_LEFTMETA", "KEY_SPACE"], GestureType::Hold),
+            binding("__tts_stop__", &["KEY_ESC"], GestureType::Hold),
+        ]));
+
+        assert_eq!(standing.len(), 1);
+        assert_eq!(standing[0].binding_ids, vec!["dictate"]);
+        assert_eq!(transient.len(), 1);
+        assert_eq!(transient[0].binding_ids, vec!["__tts_stop__"]);
+        assert_eq!(transient[0].trigger.as_deref(), Some("Escape"));
+
+        // Both still reach the gesture engine: whichever session delivers the
+        // activation, it is looked up by shortcut id.
+        let map = shortcut_map(&standing, &transient);
+        assert_eq!(map.len(), 2);
+        assert!(map.values().any(|ids| ids == &vec!["__tts_stop__".to_string()]));
+    }
+
+    #[test]
+    fn arming_the_stop_key_leaves_the_standing_shortcuts_alone() {
+        // What the reload compares. Adding or dropping the stop key must not
+        // read as a change to the standing set, or the session holding the
+        // user's dictation shortcuts would be rebuilt for it after all.
+        let dictate = binding("dictate", &["KEY_LEFTMETA", "KEY_SPACE"], GestureType::Hold);
+        let stop = binding("__tts_stop__", &["KEY_ESC"], GestureType::Hold);
+
+        let (idle, idle_transient) = split_groups(group_bindings(std::slice::from_ref(&dictate)));
+        let (armed, armed_transient) = split_groups(group_bindings(&[dictate, stop]));
+
+        assert!(same_groups(&idle, &armed), "the standing set is untouched");
+        assert!(idle_transient.is_empty());
+        assert!(!same_groups(&idle_transient, &armed_transient));
+    }
+
+    #[test]
+    fn a_dictation_binding_on_escape_keeps_its_standing_registration() {
+        // Only VoxCtrl's own stop key is held transiently. A user who chose
+        // Escape to start dictation means it, and a shortcut that worked only
+        // while VoxCtrl happened to be speaking would be worse than the grab
+        // they were warned about — so the shared group stays standing and the
+        // stop key rides along on it.
+        let mut mine = binding("__tts_stop__", &["KEY_ESC"], GestureType::Hold);
+        mine.id = "__tts_stop__".to_string();
+        let theirs = binding("dictate-on-escape", &["KEY_ESC"], GestureType::Hold);
+
+        let (standing, transient) = split_groups(group_bindings(&[mine, theirs]));
+        assert_eq!(standing.len(), 1, "one shortcut, one registration");
+        assert!(transient.is_empty());
+        assert_eq!(
+            standing[0].binding_ids,
+            vec!["__tts_stop__", "dictate-on-escape"]
+        );
     }
 
     #[test]

--- a/crates/voxctrl-hotkeys/src/portal.rs
+++ b/crates/voxctrl-hotkeys/src/portal.rs
@@ -599,10 +599,24 @@ async fn run(
             // spinning on the reload poll while reporting itself healthy.
             event = activated.next() => {
                 let Some(event) = event else { break };
-                if let Some(ids) = by_shortcut.get(event.shortcut_id()) {
-                    for id in ids {
-                        engine.apply(id, Transition::Activated, &tx);
+                match by_shortcut.get(event.shortcut_id()) {
+                    Some(ids) => {
+                        tracing::debug!(
+                            "portal hotkeys: `{}` fired ({})",
+                            event.shortcut_id(),
+                            ids.join(", ")
+                        );
+                        for id in ids {
+                            engine.apply(id, Transition::Activated, &tx);
+                        }
                     }
+                    // The compositor is delivering a shortcut VoxCtrl no longer
+                    // knows about — worth saying, because the mirror image
+                    // (a shortcut that stops arriving) looks identical from here.
+                    None => tracing::debug!(
+                        "portal hotkeys: `{}` fired but matches no binding",
+                        event.shortcut_id()
+                    ),
                 }
             }
             event = deactivated.next() => {
@@ -626,6 +640,18 @@ async fn run(
             new_bindings = next_reload(&rx_reload) => {
                 let Some(new_bindings) = new_bindings else { break };
                 tracing::info!("portal hotkeys: reloading {} bindings", new_bindings.len());
+                if new_bindings.is_empty() {
+                    // Nothing upstream should ever send this: it would ask the
+                    // compositor to forget every shortcut VoxCtrl has, and only
+                    // a restart would bring them back. Refusing costs nothing —
+                    // a genuine "no shortcuts" state is indistinguishable from a
+                    // failed read, and the second is the likely one.
+                    tracing::warn!(
+                        "portal hotkeys: ignoring an empty binding set; keeping the \
+                         shortcuts already registered"
+                    );
+                    continue;
+                }
                 let (new_standing, new_transient) = split_groups(group_bindings(&new_bindings));
                 let standing_changed = !same_groups(&new_standing, &groups);
                 let transient_changed = !same_groups(&new_transient, &transient_groups);
@@ -644,11 +670,24 @@ async fn run(
                 if standing_changed {
                     // Sessions allow `bind_shortcuts` exactly once, so a real
                     // change to the user's bindings needs a new one.
+                    tracing::info!(
+                        "portal hotkeys: the standing shortcuts changed ({} now), \
+                         re-creating their session",
+                        groups.len()
+                    );
                     let known = [groups.clone(), transient_groups.clone()].concat();
                     match rebind(&portal, &groups, Some(&known)).await {
                         Ok((new_session, bound)) => {
                             let _ = session.close().await;
                             session = new_session;
+                            for s in &bound {
+                                tracing::info!(
+                                    "portal hotkeys: `{}` bound={} as `{}`",
+                                    s.binding_ids.join(", "),
+                                    s.bound,
+                                    s.trigger_description
+                                );
+                            }
                             health.set_bound_shortcuts(bound);
                         }
                         Err(e) => tracing::warn!("Re-binding portal shortcuts failed: {e}"),
@@ -663,12 +702,24 @@ async fn run(
                     if let Some(old) = transient_session.take() {
                         let _ = old.close().await;
                     }
-                    if !transient_groups.is_empty() {
+                    if transient_groups.is_empty() {
+                        tracing::info!(
+                            "portal hotkeys: released the stop key; the standing session \
+                             was not touched"
+                        );
+                    } else {
                         // No KDE housekeeping here: nothing the user configured
                         // has changed, and rewriting their shortcut store every
                         // time VoxCtrl speaks would be pure churn.
                         match rebind(&portal, &transient_groups, None).await {
-                            Ok((session, _)) => transient_session = Some(session),
+                            Ok((session, bound)) => {
+                                transient_session = Some(session);
+                                tracing::info!(
+                                    "portal hotkeys: took the stop key on its own session \
+                                     ({} bound)",
+                                    bound.iter().filter(|s| s.bound).count()
+                                );
+                            }
                             Err(e) => tracing::warn!("Could not register the stop key: {e}"),
                         }
                     }

--- a/crates/voxctrl-routing/src/lib.rs
+++ b/crates/voxctrl-routing/src/lib.rs
@@ -7,7 +7,7 @@ pub mod timestamp;
 pub use loader::{config_dir, load_bindings, load_targets, save_bindings, save_targets};
 pub use models::{
     DeliveryResult, DeliveryType, GestureType, HotkeyBinding, OutputTarget,
-    TargetProcessingConfig, TestResult,
+    TargetProcessingConfig, TestResult, TTS_STOP_BINDING_ID,
 };
 pub use router::OutputTargetRouter;
 pub use targets::{

--- a/crates/voxctrl-routing/src/models.rs
+++ b/crates/voxctrl-routing/src/models.rs
@@ -70,6 +70,15 @@ impl HotkeyBinding {
     }
 }
 
+/// Id of the synthetic binding that carries the TTS stop key into the hotkey
+/// listener.
+///
+/// It is not one of the user's saved bindings: the app appends it, `pipeline`
+/// matches it to stop playback, and the portal backend uses it to tell the one
+/// shortcut it may hold transiently from a binding the user chose. Everything
+/// that needs to name it names this.
+pub const TTS_STOP_BINDING_ID: &str = "__tts_stop__";
+
 fn default_tap_ms() -> u32 {
     // Gap allowed between releasing the first tap and pressing the second.
     // 250ms was tight enough that a deliberate but unhurried double-tap missed;

--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -127,6 +127,8 @@ Two consequences worth knowing:
 - **The first fraction of a second of playback may not be interruptible** on the portal backend, because the grab is established as audio starts. Consecutive utterances stay armed, so this is only ever the first one after a quiet stretch.
 - **KDE's shortcut store is left out of it.** The KDE housekeeping — pruning ids VoxCtrl no longer registers, syncing display names into `~/.config/kglobalshortcutsrc` — runs only when the standing set changes, never on an arm or release: nothing the user configured has changed, and rewriting their shortcut store every time VoxCtrl speaks would be pure churn. A transiently-bound id is also exempt from pruning, because KDE keys your "enabled" tick to that id and dropping it would make the next arm register a fresh, disabled shortcut ([bugs.kde.org #483639](https://bugs.kde.org/show_bug.cgi?id=483639)) that never fires.
 
+If any of this goes wrong on a particular compositor, `VOXCTRL_STOP_KEY_ARMING=0` stands the whole mechanism down: a stop key that would need arming is simply never registered (use `Ctrl+Escape` instead), and no session is created or closed while the app runs.
+
 A *dictation* binding on bare Escape is a different matter: those are held for the whole session, so the recorder accepts one and warns you what it costs, rather than silently taking Escape from your desktop.
 
 #### If the portal refuses the session

--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -118,10 +118,14 @@ What VoxCtrl does instead is hold the grab **only while it is speaking**. `src-t
 
 Under `WhileSpeaking` the binding is added to the listener when playback starts and dropped again two seconds after it ends — long enough that the gaps inside one spoken response do not each cost a re-registration, short enough that Escape is yours again almost immediately. The arbiter never re-registers while a dictation gesture is active, because a reload restarts the listener's gesture engine and would drop the recording.
 
+**The transient shortcut lives in its own portal session.** A portal session accepts `BindShortcuts` exactly once, so changing what is registered means a new session — and the first version of this arming did that to the *one* session that also held the dictation shortcuts. Re-registering those ids under a second session and then closing the first left the compositor firing none of them: after the first cancelled playback, the user's own keybinds were dead. So the standing shortcuts and the transient one are now bound on separate sessions. Arming and releasing the stop key creates and closes only its own session, whose id no other session ever registers, and the session holding the dictation shortcuts is rebuilt only when the user actually edits a binding.
+
+Only VoxCtrl's own `__tts_stop__` binding is eligible for that treatment. A user who binds *dictation* to bare Escape shares the group with it, and that group stays standing — a shortcut that worked only while VoxCtrl happened to be speaking would be worse than the grab the recorder warned them about.
+
 Two consequences worth knowing:
 
 - **The first fraction of a second of playback may not be interruptible** on the portal backend, because the grab is established as audio starts. Consecutive utterances stay armed, so this is only ever the first one after a quiet stretch.
-- **KDE's shortcut store is protected from the churn.** `sync_kde_shortcuts` prunes ids VoxCtrl no longer registers; a transiently-bound id is exempt, because KDE keys your "enabled" tick to that id and pruning it would make the next arm register a fresh, disabled shortcut ([bugs.kde.org #483639](https://bugs.kde.org/show_bug.cgi?id=483639)) that never fires.
+- **KDE's shortcut store is left out of it.** The KDE housekeeping — pruning ids VoxCtrl no longer registers, syncing display names into `~/.config/kglobalshortcutsrc` — runs only when the standing set changes, never on an arm or release: nothing the user configured has changed, and rewriting their shortcut store every time VoxCtrl speaks would be pure churn. A transiently-bound id is also exempt from pruning, because KDE keys your "enabled" tick to that id and dropping it would make the next arm register a fresh, disabled shortcut ([bugs.kde.org #483639](https://bugs.kde.org/show_bug.cgi?id=483639)) that never fires.
 
 A *dictation* binding on bare Escape is a different matter: those are held for the whole session, so the recorder accepts one and warns you what it costs, rather than silently taking Escape from your desktop.
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -154,10 +154,13 @@ pub async fn save_config(
     // back out of it.
     drop(guard);
     if stop_key_changed {
-        let bindings = crate::stop_key::listener_bindings_from_disk(&state).await;
-        let reloader_guard = state.hotkey_reloader.lock().await;
-        if let Some(reloader) = &*reloader_guard {
-            let _ = reloader.send(bindings);
+        // A set that could not be read is not worth reloading: the listener
+        // keeps the shortcuts it already has instead of losing all of them.
+        if let Some(bindings) = crate::stop_key::listener_bindings_from_disk(&state).await {
+            let reloader_guard = state.hotkey_reloader.lock().await;
+            if let Some(reloader) = &*reloader_guard {
+                let _ = reloader.send(bindings);
+            }
         }
     }
 
@@ -1169,7 +1172,11 @@ pub async fn open_shortcut_settings() -> Result<(), String> {
 pub async fn retry_portal_shortcuts(state: State<'_, Arc<AppState>>) -> Result<(), String> {
     #[cfg(target_os = "linux")]
     {
-        let bindings = crate::stop_key::listener_bindings_from_disk(&state).await;
+        let Some(bindings) = crate::stop_key::listener_bindings_from_disk(&state).await else {
+            return Err("Could not read your saved shortcuts, so there is nothing to \
+                        register. Check the log for what went wrong reading bindings.toml."
+                .to_string());
+        };
 
         let gesture_tx = {
             let gtx_guard = state.hotkey_gesture_tx.lock().await;

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -122,96 +122,143 @@ pub fn spawn_text_delivery_worker(
 
 pub fn spawn_hotkey_gesture_handler(
     state_for_gesture: Arc<AppState>,
-    mut gesture_rx: voxctrl_hotkeys::GestureReceiver,
+    gesture_rx: voxctrl_hotkeys::GestureReceiver,
 ) {
     // Notices for the silent failure modes of a fresh install: dictating with
     // an unfinished setup, and recording with a mic stream that never delivers
     // audio. The setup notice repeats (throttled) rather than firing once —
     // a single toast at the very first keypress is easy to miss, and the user
     // will keep pressing the shortcut until something explains itself.
+    //
+    // They live out here so a restarted loop does not start nagging again.
     let last_setup_notice = Arc::new(Mutex::new(None::<std::time::Instant>));
     let mic_notice_shown = Arc::new(AtomicBool::new(false));
+    let gesture_rx = Arc::new(Mutex::new(gesture_rx));
 
+    // Supervised, because every shortcut in the app is delivered by this one
+    // task: a panic anywhere inside it — in a notification, an injection, a
+    // lock — would take every hotkey down with it for the rest of the session,
+    // silently, with the app still running and apparently healthy. That is
+    // indistinguishable from a desktop that stopped delivering shortcuts, and
+    // it is the shape of "my keybind stopped working and a restart fixed it".
     tokio::spawn(async move {
-        while let Some(event) = gesture_rx.recv().await {
-            // TTS stop key: fires on key-down (Start), not release.
-            // Only stop the active Rodio sink — do NOT send None to the worker
-            // channel (that would kill the thread and break all future TTS).
-            if event.binding_id == voxctrl_routing::TTS_STOP_BINDING_ID {
-                if event.kind == GestureKind::Start {
-                    // Use the handle's stop() (not the raw stop_current_playback())
-                    // so the generation counter is bumped too — otherwise a
-                    // streaming engine like Pocket-TTS keeps appending the
-                    // frames it already had in flight and audio resumes.
-                    if let Some(tts) = state_for_gesture.tts_handle.lock().await.as_ref() {
-                        tts.stop();
-                    }
+        loop {
+            let task = tokio::spawn(run_gesture_loop(
+                state_for_gesture.clone(),
+                gesture_rx.clone(),
+                last_setup_notice.clone(),
+                mic_notice_shown.clone(),
+            ));
+            match task.await {
+                Ok(()) => {
+                    tracing::warn!(
+                        "Hotkey gesture loop ended: the listener's channel closed. No \
+                         shortcut can fire until VoxCtrl is restarted."
+                    );
+                    return;
                 }
-                continue;
-            }
-
-            match event.kind {
-                GestureKind::Start => {
-                    // Drop gestures while the keybind recorder is open. The user
-                    // is pressing keys to configure a new binding — acting on them
-                    // would start an unwanted dictation session mid-setup.
-                    if state_for_gesture.is_hotkeys_inhibited() {
-                        tracing::debug!(
-                            "Hotkey '{}' gesture suppressed: keybind recorder is active",
-                            event.binding_id
-                        );
-                        continue;
-                    }
-
-                    *state_for_gesture.active_target.lock().await = event.target_id.clone();
-                    *state_for_gesture.active_binding_label.lock().await =
-                        event.binding_label.clone();
-                    *state_for_gesture.active_binding_id.lock().await = event.binding_id.clone();
-                    state_for_gesture.begin_recording().await;
-
-                    // The user just tried to dictate. If the install is not
-                    // finished, say so now — otherwise the shortcut records
-                    // audio that can never become text, which reads as
-                    // "VoxCtrl is broken" rather than "setup is incomplete".
-                    if let Some(msg) = setup_blocker(&state_for_gesture).await {
-                        let now = std::time::Instant::now();
-                        let stale = {
-                            let last = last_setup_notice.lock().await;
-                            last.map(|t: std::time::Instant| {
-                                now.duration_since(t) > SETUP_NOTICE_INTERVAL
-                            })
-                            .unwrap_or(true)
-                        };
-                        if stale {
-                            *last_setup_notice.lock().await = Some(now);
-                            voxctrl_inject::show_notification("VoxCtrl — setup unfinished", &msg);
-                            show_setup_window();
-                        }
-                    }
-
-                    // Warn if the microphone stream never comes up while the
-                    // user is recording (dead input device, audio stack issue).
-                    let st = state_for_gesture.clone();
-                    let mic_shown = mic_notice_shown.clone();
-                    tokio::spawn(async move {
-                        tokio::time::sleep(Duration::from_secs(2)).await;
-                        if st.is_recording()
-                            && !st.is_audio_ready()
-                            && !mic_shown.swap(true, Ordering::SeqCst)
-                        {
-                            voxctrl_inject::show_notification(
-                                "VoxCtrl",
-                                "Recording is active but no microphone audio is arriving. Check the input device in Settings → Audio.",
-                            );
-                        }
-                    });
+                Err(e) if e.is_panic() => {
+                    tracing::error!(
+                        "Hotkey gesture loop panicked ({e}); restarting it so shortcuts \
+                         keep working. Please report this with the backtrace above."
+                    );
                 }
-                GestureKind::Stop => {
-                    state_for_gesture.set_recording(false);
+                Err(e) => {
+                    tracing::warn!("Hotkey gesture loop stopped: {e}");
+                    return;
                 }
             }
         }
     });
+}
+
+async fn run_gesture_loop(
+    state_for_gesture: Arc<AppState>,
+    gesture_rx: Arc<Mutex<voxctrl_hotkeys::GestureReceiver>>,
+    last_setup_notice: Arc<Mutex<Option<std::time::Instant>>>,
+    mic_notice_shown: Arc<AtomicBool>,
+) {
+    // Held for the life of the loop; a restart takes it back and carries on
+    // with whatever the listener queued in between.
+    let mut gesture_rx = gesture_rx.lock().await;
+    while let Some(event) = gesture_rx.recv().await {
+        // TTS stop key: fires on key-down (Start), not release.
+        // Only stop the active Rodio sink — do NOT send None to the worker
+        // channel (that would kill the thread and break all future TTS).
+        if event.binding_id == voxctrl_routing::TTS_STOP_BINDING_ID {
+            if event.kind == GestureKind::Start {
+                // Use the handle's stop() (not the raw stop_current_playback())
+                // so the generation counter is bumped too — otherwise a
+                // streaming engine like Pocket-TTS keeps appending the
+                // frames it already had in flight and audio resumes.
+                if let Some(tts) = state_for_gesture.tts_handle.lock().await.as_ref() {
+                    tts.stop();
+                }
+            }
+            continue;
+        }
+
+        match event.kind {
+            GestureKind::Start => {
+                // Drop gestures while the keybind recorder is open. The user
+                // is pressing keys to configure a new binding — acting on them
+                // would start an unwanted dictation session mid-setup.
+                if state_for_gesture.is_hotkeys_inhibited() {
+                    tracing::debug!(
+                        "Hotkey '{}' gesture suppressed: keybind recorder is active",
+                        event.binding_id
+                    );
+                    continue;
+                }
+
+                *state_for_gesture.active_target.lock().await = event.target_id.clone();
+                *state_for_gesture.active_binding_label.lock().await =
+                    event.binding_label.clone();
+                *state_for_gesture.active_binding_id.lock().await = event.binding_id.clone();
+                state_for_gesture.begin_recording().await;
+
+                // The user just tried to dictate. If the install is not
+                // finished, say so now — otherwise the shortcut records
+                // audio that can never become text, which reads as
+                // "VoxCtrl is broken" rather than "setup is incomplete".
+                if let Some(msg) = setup_blocker(&state_for_gesture).await {
+                    let now = std::time::Instant::now();
+                    let stale = {
+                        let last = last_setup_notice.lock().await;
+                        last.map(|t: std::time::Instant| {
+                            now.duration_since(t) > SETUP_NOTICE_INTERVAL
+                        })
+                        .unwrap_or(true)
+                    };
+                    if stale {
+                        *last_setup_notice.lock().await = Some(now);
+                        voxctrl_inject::show_notification("VoxCtrl — setup unfinished", &msg);
+                        show_setup_window();
+                    }
+                }
+
+                // Warn if the microphone stream never comes up while the
+                // user is recording (dead input device, audio stack issue).
+                let st = state_for_gesture.clone();
+                let mic_shown = mic_notice_shown.clone();
+                tokio::spawn(async move {
+                    tokio::time::sleep(Duration::from_secs(2)).await;
+                    if st.is_recording()
+                        && !st.is_audio_ready()
+                        && !mic_shown.swap(true, Ordering::SeqCst)
+                    {
+                        voxctrl_inject::show_notification(
+                            "VoxCtrl",
+                            "Recording is active but no microphone audio is arriving. Check the input device in Settings → Audio.",
+                        );
+                    }
+                });
+            }
+            GestureKind::Stop => {
+                state_for_gesture.set_recording(false);
+            }
+        }
+    }
 }
 
 #[cfg(target_os = "linux")]

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -137,7 +137,7 @@ pub fn spawn_hotkey_gesture_handler(
             // TTS stop key: fires on key-down (Start), not release.
             // Only stop the active Rodio sink — do NOT send None to the worker
             // channel (that would kill the thread and break all future TTS).
-            if event.binding_id == "__tts_stop__" {
+            if event.binding_id == voxctrl_routing::TTS_STOP_BINDING_ID {
                 if event.kind == GestureKind::Start {
                     // Use the handle's stop() (not the raw stop_current_playback())
                     // so the generation counter is bumped too — otherwise a

--- a/src-tauri/src/stop_key.rs
+++ b/src-tauri/src/stop_key.rs
@@ -31,8 +31,10 @@ use voxctrl_routing::{GestureType, HotkeyBinding};
 
 use crate::state::AppState;
 
-/// The synthetic binding id the gesture handler matches on.
-pub const STOP_BINDING_ID: &str = "__tts_stop__";
+/// The synthetic binding id the gesture handler matches on. Defined in
+/// `voxctrl-routing` because the portal backend needs it too: it tells the one
+/// shortcut VoxCtrl may hold transiently from a binding the user chose.
+pub use voxctrl_routing::TTS_STOP_BINDING_ID as STOP_BINDING_ID;
 
 /// How long the grab is kept after playback stops.
 ///

--- a/src-tauri/src/stop_key.rs
+++ b/src-tauri/src/stop_key.rs
@@ -55,7 +55,8 @@ const TICK: Duration = Duration::from_millis(500);
 /// How long VoxCtrl may hold the stop key.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StopKeyGrab {
-    /// No stop key is configured; there is nothing to register.
+    /// Nothing is registered: no stop key is configured, or one that would need
+    /// arming is switched off with `VOXCTRL_STOP_KEY_ARMING=0`.
     None,
     /// Registered for the whole session. Either VoxCtrl is watching the keys
     /// itself and grabs nothing, or the combination is one no other app is
@@ -64,6 +65,21 @@ pub enum StopKeyGrab {
     /// Registered only while VoxCtrl speaks, because a standing grab would take
     /// the key from the rest of the desktop.
     WhileSpeaking,
+}
+
+/// Set `VOXCTRL_STOP_KEY_ARMING=0` to switch the arming off.
+///
+/// Taking and giving back a shortcut means creating and closing portal sessions
+/// while the app runs, and how a compositor reacts to that is its own business.
+/// Where it goes wrong the cost lands on the user's other shortcuts, so there
+/// has to be a way to stand the whole mechanism down without a rebuild: with
+/// this set, a stop key that would need arming is simply never registered, and
+/// a stop key with a modifier keeps working as it always has.
+fn arming_disabled() -> bool {
+    matches!(
+        std::env::var("VOXCTRL_STOP_KEY_ARMING").as_deref(),
+        Ok("0") | Ok("false") | Ok("no")
+    )
 }
 
 /// How long VoxCtrl may hold `stop_key` on the backend that is running.
@@ -86,6 +102,14 @@ pub fn stop_key_grab(backend: Backend, stop_key: &[String]) -> StopKeyGrab {
     // nothing, and waiting would cost the user a stop key that works.
     if backend == Backend::Starting && !cfg!(target_os = "linux") {
         return StopKeyGrab::Always;
+    }
+
+    if arming_disabled() {
+        tracing::debug!(
+            "VOXCTRL_STOP_KEY_ARMING is off: leaving the stop key unregistered rather \
+             than taking it for playback"
+        );
+        return StopKeyGrab::None;
     }
 
     // Portal, Mint, and — on Linux — a listener still deciding.
@@ -140,11 +164,40 @@ pub async fn listener_bindings(state: &AppState, saved: Vec<HotkeyBinding>) -> V
     all
 }
 
-/// The saved bindings, read from disk, plus the stop key when it is held.
-pub async fn listener_bindings_from_disk(state: &AppState) -> Vec<HotkeyBinding> {
+/// Is this a set worth handing the listener?
+///
+/// `load_bindings` answers a missing file with VoxCtrl's own defaults, so a
+/// successful read is never empty. An empty set therefore means the read
+/// failed — an unparseable file, a torn read of one being saved right now — and
+/// handing it over would unregister every shortcut the user has, with no way
+/// back but a restart. Reloading is always optional; keeping what is already
+/// registered is the safe answer.
+pub fn is_usable(saved: &[HotkeyBinding]) -> bool {
+    !saved.is_empty()
+}
+
+/// The saved bindings plus the stop key, or `None` when the saved bindings
+/// could not be read and the listener should keep what it has.
+pub async fn listener_bindings_from_disk(state: &AppState) -> Option<Vec<HotkeyBinding>> {
     let dir = voxctrl_routing::config_dir();
-    let saved = voxctrl_routing::load_bindings(&dir).unwrap_or_default();
-    listener_bindings(state, saved).await
+    let saved = match voxctrl_routing::load_bindings(&dir) {
+        Ok(saved) => saved,
+        Err(e) => {
+            tracing::warn!(
+                "Could not read the saved shortcuts ({e}); leaving the ones already \
+                 registered alone rather than unregistering them"
+            );
+            return None;
+        }
+    };
+    if !is_usable(&saved) {
+        tracing::warn!(
+            "The saved shortcuts read back empty, which only happens when the read \
+             failed; leaving the ones already registered alone"
+        );
+        return None;
+    }
+    Some(listener_bindings(state, saved).await)
 }
 
 /// Start the task that takes the stop key and gives it back.
@@ -206,9 +259,12 @@ pub fn spawn(state: Arc<AppState>) {
                 continue;
             }
 
-            let bindings = {
-                state.stop_key_held.store(wanted, Ordering::SeqCst);
-                listener_bindings_from_disk(&state).await
+            state.stop_key_held.store(wanted, Ordering::SeqCst);
+            let Some(bindings) = listener_bindings_from_disk(&state).await else {
+                // Nothing to hand over that would not cost the user their
+                // shortcuts. Try again on the next tick.
+                state.stop_key_held.store(held, Ordering::SeqCst);
+                continue;
             };
             let reloader = state.hotkey_reloader.lock().await;
             let Some(reloader) = reloader.as_ref() else {
@@ -216,11 +272,16 @@ pub fn spawn(state: Arc<AppState>) {
                 state.stop_key_held.store(held, Ordering::SeqCst);
                 continue;
             };
+            let count = bindings.len();
             match reloader.send(bindings) {
                 Ok(()) => {
                     held = wanted;
-                    tracing::debug!(
-                        "TTS stop key {} ({grab:?})",
+                    // Info rather than debug: when a shortcut stops working
+                    // after playback, this line and the portal's own reload log
+                    // are what say whether VoxCtrl asked for the wrong thing or
+                    // the desktop stopped delivering what it was asked for.
+                    tracing::info!(
+                        "TTS stop key {} ({grab:?}); listener now has {count} binding(s)",
                         if wanted { "registered" } else { "released" }
                     );
                 }
@@ -303,6 +364,42 @@ mod tests {
         let grab = stop_key_grab(Backend::Portal, &[]);
         assert_eq!(grab, StopKeyGrab::None);
         assert!(!stop_key_wanted(grab, true));
+    }
+
+    #[test]
+    fn the_arming_switch_stands_the_whole_mechanism_down() {
+        // The escape hatch for a compositor that mishandles a session closing.
+        // With it set, nothing is taken and nothing is given back — the stop key
+        // on bare Escape is simply not registered, and a modified one is
+        // untouched, because it never needed arming.
+        let escape = keys(&["KEY_ESC"]);
+        let ctrl_escape = keys(&["KEY_LEFTCTRL", "KEY_ESC"]);
+
+        // SAFETY: single-threaded test, and the variable is read nowhere else.
+        unsafe { std::env::set_var("VOXCTRL_STOP_KEY_ARMING", "0") };
+        assert_eq!(stop_key_grab(Backend::Portal, &escape), StopKeyGrab::None);
+        assert_eq!(
+            stop_key_grab(Backend::Portal, &ctrl_escape),
+            StopKeyGrab::Always
+        );
+        // And where nothing is grabbed in the first place, it changes nothing.
+        assert_eq!(stop_key_grab(Backend::X11, &escape), StopKeyGrab::Always);
+
+        unsafe { std::env::remove_var("VOXCTRL_STOP_KEY_ARMING") };
+        assert_eq!(
+            stop_key_grab(Backend::Portal, &escape),
+            StopKeyGrab::WhileSpeaking
+        );
+    }
+
+    #[test]
+    fn an_empty_binding_set_is_never_handed_to_the_listener() {
+        // `load_bindings` answers a missing file with VoxCtrl's defaults, so an
+        // empty read is a failed read. Passing it on would unregister every
+        // shortcut the user has — dictation included — and nothing short of a
+        // restart would bring them back.
+        assert!(!is_usable(&[]));
+        assert!(is_usable(&[stop_binding(keys(&["KEY_ESC"]))]));
     }
 
     #[test]


### PR DESCRIPTION
## Why this exists

[#83](https://github.com/JRufer/VoxCtrl/pull/83) merged at `7885bad` — the arming design, but **without the three commits that make it safe**. Those are here. The verified-working build on KDE Plasma Wayland (dictate → TTS response → Escape cancels → dictation shortcut still activates) was this branch head, not what is on master today.

Without these, master's arming rebuilds the single portal session that also carries the dictation shortcuts every time playback starts and stops.

## What's in it

**1. The stop key gets its own portal session** (`0c96e36`)

A portal session accepts `BindShortcuts` exactly once, so changing what is registered means a new session. As merged, arming did that to the one session holding the dictation shortcuts: it created a second session, re-registered the same ids under the same app id, then closed the first — and the compositor was left firing none of them.

Standing and transient shortcuts now live on separate sessions. Arming creates and closes only the stop key's own session, whose id no other session registers; the dictation session is rebuilt only when a binding is actually edited. Where ids do move between sessions, the old one is closed *first*, so two sessions never hold the same id. KDE housekeeping (pruning, `kglobalshortcutsrc` rewrites) is skipped entirely for transient binds — nothing the user configured has changed. Only VoxCtrl's own `__tts_stop__` binding is eligible, so a user who binds dictation to bare Escape keeps a standing registration.

**2. A failed binding read can no longer unregister every shortcut** (`5bc8c44`)

`load_bindings` answers a missing file with VoxCtrl's own defaults, so a successful read is never empty — an empty set means the read failed (unparseable file, torn read of one being saved). `unwrap_or_default` turned that into "the user has no shortcuts", and the arbiter made it reachable at runtime, where before the listener was only reloaded on an explicit save. One bad read while arming would have handed the compositor an empty set. The reload paths now skip the cycle instead, and the portal backend refuses an empty set too.

Also adds the diagnostics used to chase this (arming, standing-session rebuilds and per-shortcut bind results at info; shortcuts firing at debug) and `VOXCTRL_STOP_KEY_ARMING=0` to stand the mechanism down without a rebuild.

**3. The hotkey gesture loop is supervised** (`51c725a`)

Every shortcut in the app is delivered by one task. A panic anywhere in it — a notification, an injection, a lock — took every hotkey down for the rest of the session, silently, with the app still running and looking healthy. Indistinguishable from a desktop that stopped delivering shortcuts, and the exact shape of "my keybind stopped working and only a restart fixed it". It now restarts after a panic and logs it, and says so plainly if the listener's channel closes instead.

## Note on scope

`c0ed0a8` ("Stop playback when dictation starts") was dropped by the rebase — its content is already on master via [#84](https://github.com/JRufer/VoxCtrl/pull/84).

## Tests

`voxctrl-app` 78, `voxctrl-hotkeys` 75, `voxctrl-routing` 67, `voxctrl-config` 18, frontend 198 — all green on this rebase. Rust built `--no-default-features --features custom-protocol`; the default build fetches ONNX Runtime, which this sandbox's proxy blocks.

Verified on the reporter's KDE Plasma Wayland desktop end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5G6fAvwSwHCd9JUSV8L2P

---
_Generated by [Claude Code](https://claude.ai/code/session_01B5G6fAvwSwHCd9JUSV8L2P)_