### PR TITLE
Stop the clipboard test depending on an environment that can change

### DIFF
--- a/crates/voxctrl-routing/src/tests.rs
+++ b/crates/voxctrl-routing/src/tests.rs
@@ -304,6 +304,9 @@ async fn test_inject_target_success_and_failure() {
 
 #[tokio::test]
 async fn test_inject_target_failure_no_injection() {
+    // Probes the environment like its siblings, so it takes the same lock:
+    // observing another test's mock half-installed proves nothing either way.
+    let _env = env_lock().lock().await;
     let mut config = OutputTarget::default_inject();
     config.delivery = DeliveryType::Inject;
     let target = build_target(config);
@@ -321,22 +324,89 @@ async fn test_clipboard_target_success() {
     // `test` runs, which is exactly how this failed intermittently on headless CI.
     let _env = env_lock().lock().await;
 
+    // The lock is necessary but not sufficient, because the *ambient*
+    // environment is not a fixed thing either: which of the three delivery
+    // paths runs depends on `WAYLAND_DISPLAY`, on what is installed, and — for
+    // the `arboard` fallback — on a display connection that can be there for
+    // one call and not the next. Two probes a moment apart were being asked to
+    // agree about a machine that was free to change its mind in between, and on
+    // a headless runner they sometimes disagreed.
+    //
+    // So the test brings its own environment. What is under test is that
+    // delivery and the reachability probe agree about the same known clipboard,
+    // not what this particular machine happens to have installed.
+    #[cfg(target_os = "linux")]
+    let mock = MockClipboardTool::install();
+
     let mut config = OutputTarget::default_inject();
     config.delivery = DeliveryType::Clipboard;
     let target = build_target(config);
     let res = target.deliver("Test Clipboard").await;
+    // The mock makes the success path the one that runs here, rather than
+    // whatever this machine happens to support — without this, a mock that
+    // stopped being found would quietly send the test down the `else` branch,
+    // where it asserts almost nothing.
+    #[cfg(target_os = "linux")]
+    assert!(
+        res.success,
+        "the mock clipboard tool should have satisfied delivery: {:?}",
+        res.error
+    );
     if res.success {
         // Clipboard delivery ends its text with one space, exactly like inject:
         // dictation arrives an utterance at a time, and without it the next one
-        // starts flush against this one's last word. This assertion only runs
-        // where a clipboard tool exists, which is why it outlived the change
-        // that introduced the trailing space — a headless machine takes the
-        // `else` branch and never checks the text at all.
+        // starts flush against this one's last word.
         assert_eq!(res.delivered_text.as_deref(), Some("Test Clipboard "));
         let test_res = target.test().await;
-        assert!(test_res.reachable);
+        assert!(
+            test_res.reachable,
+            "delivery worked, so the Test button must not call the clipboard \
+             unreachable: {}",
+            test_res.detail
+        );
     } else {
+        // Only reachable off Linux, where the test installs no mock and the
+        // machine may genuinely have no clipboard.
         assert!(res.error.is_some());
+    }
+
+    #[cfg(target_os = "linux")]
+    drop(mock);
+}
+
+/// A stand-in `wl-copy` on `PATH`, with `WAYLAND_DISPLAY` set so the Linux
+/// clipboard path chooses it. Restores both on drop.
+#[cfg(target_os = "linux")]
+struct MockClipboardTool {
+    _wayland: EnvVarGuard,
+    _path: EnvVarGuard,
+    dir: std::path::PathBuf,
+}
+
+#[cfg(target_os = "linux")]
+impl MockClipboardTool {
+    fn install() -> Self {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = std::env::temp_dir().join(format!(
+            "voxctrl_clipboard_probe_{}",
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let bin = dir.join("wl-copy");
+        // Reads stdin so the delivery side sees the same "consumed the text and
+        // exited 0" it would from the real tool.
+        std::fs::write(&bin, "#!/bin/sh\ncat > /dev/null\nexit 0\n").unwrap();
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let _wayland = EnvVarGuard::set("WAYLAND_DISPLAY", "mock-display");
+        let _path = prepend_to_path(&dir);
+        Self { _wayland, _path, dir }
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl Drop for MockClipboardTool {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.dir);
     }
 }
 
@@ -381,6 +451,7 @@ async fn test_clipboard_target_linux_cli() {
 
 #[tokio::test]
 async fn test_clipboard_target_failure_empty_text() {
+    let _env = env_lock().lock().await;
     let mut config = OutputTarget::default_inject();
     config.delivery = DeliveryType::Clipboard;
     let target = build_target(config);


### PR DESCRIPTION
## The failure

```
---- tests::test_clipboard_target_success stdout ----
thread 'tests::test_clipboard_target_success' panicked at crates/voxctrl-routing/src/tests.rs:337:9:
assertion failed: test_res.reachable
```

Pre-existing on `master`, not caused by the hotkey work — that branch touches `voxctrl-routing` only to add one constant.

## Root cause

The test asked two separate probes to agree about the ambient environment: `deliver` first, then `test`. Which of the three delivery paths runs depends on `PATH`, on `WAYLAND_DISPLAY`, and — for the `arboard` fallback — on a display connection that can be there for one call and not the next. On a machine with no clipboard tools and no display, `deliver` can only succeed if a **sibling test's mock `wl-copy` is on `PATH` at that instant**; by the time the reachability probe runs it is gone, the fallback has no display to open, and `reachable` is false.

The shared env lock was added for exactly this window and does not quite close it.

Reproduced here at roughly **one run in eight**, and **never once** under `--test-threads=1` — which is what a race on process-global state looks like.

## The fix

The test brings its own environment: a mock `wl-copy` on `PATH` with `WAYLAND_DISPLAY` set, both restored and the temp dir removed on drop. What is under test is that delivery and the reachability probe agree about the same known clipboard — not what the machine running the suite happens to have installed.

This *strengthens* the test rather than relaxing it: on Linux the success path is now the one that actually runs, pinned by an assertion, where before a machine without a clipboard sent the test down an `else` branch that asserts almost nothing. The two tolerant probes beside it (`test_inject_target_failure_no_injection`, `test_clipboard_target_failure_empty_text`) take the same lock now, so they cannot observe a sibling's mock half-installed either.

Nothing in `targets.rs` changes — I checked for a real asymmetry between `deliver` and `test` first, and on Linux they already mirror each other (wl-copy on Wayland → xclip → arboard).

## Verification

40 consecutive runs of `cargo test -p voxctrl-routing` green, against ~1-in-8 failures before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5G6fAvwSwHCd9JUSV8L2P

---
_Generated by [Claude Code](https://claude.ai/code/session_01B5G6fAvwSwHCd9JUSV8L2P)_