### PR TITLE
TTS model memory: on-demand loading with a 15-minute idle unload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9656,7 +9656,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voxctrl-app"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9699,7 +9699,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-audio"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "cpal",
@@ -9714,7 +9714,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-bugreport"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -9732,7 +9732,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-config"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "dirs 5.0.1",
  "serde",
@@ -9745,7 +9745,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-dbus"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "serde",
@@ -9757,7 +9757,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-hotkeys"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "ashpd",
@@ -9779,7 +9779,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-inference"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "cc",
@@ -9806,7 +9806,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-inject"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9820,7 +9820,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-llm"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "reqwest 0.12.28",
@@ -9834,7 +9834,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-mcp"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "serde",
@@ -9846,7 +9846,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-routing"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9871,14 +9871,14 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-text"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "regex",
 ]
 
 [[package]]
 name = "voxctrl-tts"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -9905,7 +9905,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-update"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -9922,7 +9922,7 @@ dependencies = [
 
 [[package]]
 name = "voxctrl-winput"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 authors = ["VoxCtrl Contributors"]
 license = "MIT"

--- a/crates/voxctrl-bugreport/src/redact.rs
+++ b/crates/voxctrl-bugreport/src/redact.rs
@@ -74,6 +74,9 @@ pub const CONFIG_HANDLING: &[(&str, Handling)] = &[
     ("tts.stop_key", Safe),
     ("tts.hf_token", Secret),
     ("tts.snippets", FreeText),
+    // "always_loaded" or "on_demand" — which one is in force decides whether a
+    // "TTS took seconds to start" report is a reload or a real problem.
+    ("tts.memory_mode", Safe),
     ("tts.pocket_tts.voice", Safe),
     ("tts.pocket_tts.voice_dir", Path),
     ("tts.pocket_tts.hf_token", Secret),

--- a/crates/voxctrl-config/src/lib.rs
+++ b/crates/voxctrl-config/src/lib.rs
@@ -330,6 +330,37 @@ impl Default for TtsEngine {
     }
 }
 
+/// How the TTS engine manages the memory of model-backed engines (currently
+/// Pocket-TTS; Piper and eSpeak shell out to a process and hold nothing).
+///
+/// * `AlwaysLoaded` — once loaded, the model stays resident for the lifetime of
+///   the TTS worker. Fastest, but the weights sit in RAM even when unused.
+/// * `OnDemand` — the model is loaded the moment VoxCtrl knows it will be
+///   needed, kept "primed" while it keeps getting used, and dropped again after
+///   [`TtsConfig::idle_unload_secs`] of inactivity to give the memory back.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TtsMemoryMode {
+    AlwaysLoaded,
+    OnDemand,
+}
+
+impl Default for TtsMemoryMode {
+    fn default() -> Self {
+        // Existing installs keep the behaviour they already had; opting into
+        // the memory saving is a deliberate choice (it costs first-word latency).
+        Self::AlwaysLoaded
+    }
+}
+
+/// 15 minutes — long enough that a back-and-forth conversation never pays the
+/// reload cost twice, short enough that an idle session gives the RAM back.
+pub const DEFAULT_TTS_IDLE_UNLOAD_SECS: u64 = 900;
+
+fn default_tts_idle_unload_secs() -> u64 {
+    DEFAULT_TTS_IDLE_UNLOAD_SECS
+}
+
 fn default_pocket_tts_voice() -> String {
     "alba".into()
 }
@@ -493,6 +524,13 @@ pub struct TtsConfig {
     pub hf_token: Option<String>,
     #[serde(default)]
     pub pocket_tts: PocketTtsConfig,
+    /// Whether a model-backed engine stays resident or is unloaded when idle.
+    #[serde(default)]
+    pub memory_mode: TtsMemoryMode,
+    /// Idle time before the model is unloaded in [`TtsMemoryMode::OnDemand`].
+    /// The countdown restarts every time the model is used or pre-loaded.
+    #[serde(default = "default_tts_idle_unload_secs")]
+    pub idle_unload_secs: u64,
     #[serde(default)]
     pub inflect_micro: InflectMicroConfig,
     #[serde(default)]
@@ -518,6 +556,8 @@ impl Default for TtsConfig {
             gpu: false,
             hf_token: None,
             pocket_tts: PocketTtsConfig::default(),
+            memory_mode: TtsMemoryMode::default(),
+            idle_unload_secs: DEFAULT_TTS_IDLE_UNLOAD_SECS,
             inflect_micro: InflectMicroConfig::default(),
             breeze_tts_2: BreezeTts2Config::default(),
             snippets: {
@@ -528,6 +568,21 @@ impl Default for TtsConfig {
                 map
             },
         }
+    }
+}
+
+impl TtsConfig {
+    /// True when the model should be dropped after an idle period.
+    pub fn unloads_when_idle(&self) -> bool {
+        self.memory_mode == TtsMemoryMode::OnDemand
+    }
+
+    /// Idle window before unloading, clamped to a sane range. A zero or absurdly
+    /// small value would thrash the loader (the model would be dropped between
+    /// two sentences of the same reply), so the floor is 30s.
+    pub fn idle_unload_duration(&self) -> std::time::Duration {
+        const MIN_SECS: u64 = 30;
+        std::time::Duration::from_secs(self.idle_unload_secs.max(MIN_SECS))
     }
 }
 

--- a/crates/voxctrl-tts/src/breeze.rs
+++ b/crates/voxctrl-tts/src/breeze.rs
@@ -141,6 +141,33 @@ fn read_voice_transcript_file(wav_path_str: &str) -> Option<String> {
 
 /// Called from TtsEngineWorker::run when config.engine == TtsEngine::BreezeTts2
 #[allow(clippy::too_many_arguments)]
+/// Loads the Breeze-TTS-2 session into the worker's cache if it is not already
+/// there (or if the GPU preference changed under it). Idempotent, so both the
+/// pre-load path and synthesis call it unconditionally.
+///
+/// This is the expensive step the on-demand memory mode defers and then
+/// reclaims: the session lives entirely in `model`, so dropping it gives the
+/// memory straight back.
+pub(crate) fn ensure_breeze_tts_2_loaded(
+    config: &TtsConfig,
+    model: &mut BreezeModelSlot,
+) -> Result<()> {
+    let cfg = &config.breeze_tts_2;
+    crate::hf::apply_hf_token(config.hf_token.as_deref());
+
+    if model.as_ref().is_none_or(|m| m.gpu != cfg.gpu) {
+        let started = std::time::Instant::now();
+        info!("Loading Breeze-TTS-2 neural speech model session in pure Rust...");
+        *model = Some(LoadedBreezeModel {
+            gpu: cfg.gpu,
+            model: load_pocket_tts_model_on_gpu(POCKET_TTS_VARIANT, cfg.gpu)
+                .context("load Breeze-TTS-2 neural model")?,
+        });
+        info!("Breeze-TTS-2 model loaded in {:?}", started.elapsed());
+    }
+    Ok(())
+}
+
 pub(crate) fn speak_breeze_tts_2(
     config: &TtsConfig,
     u: &Utterance,
@@ -154,16 +181,7 @@ pub(crate) fn speak_breeze_tts_2(
     let cfg = &config.breeze_tts_2;
     let is_prewarm = u.source_label.as_deref() == Some("prewarm");
 
-    crate::hf::apply_hf_token(config.hf_token.as_deref());
-
-    if model.as_ref().is_none_or(|m| m.gpu != cfg.gpu) {
-        info!("Loading Breeze-TTS-2 neural speech model session in pure Rust...");
-        *model = Some(LoadedBreezeModel {
-            gpu: cfg.gpu,
-            model: load_pocket_tts_model_on_gpu(POCKET_TTS_VARIANT, cfg.gpu)
-                .context("load Breeze-TTS-2 neural model")?,
-        });
-    }
+    ensure_breeze_tts_2_loaded(config, model)?;
     let tts_model = &model.as_ref().unwrap().model;
 
     // Determine reference audio clip and transcript based on voice_mode

--- a/crates/voxctrl-tts/src/engine.rs
+++ b/crates/voxctrl-tts/src/engine.rs
@@ -4,18 +4,24 @@
 
 use std::collections::HashMap;
 use std::process::Stdio;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
-use crossbeam_channel::{bounded, Receiver, Sender};
+use crossbeam_channel::{bounded, Receiver, RecvTimeoutError, Sender};
 use tracing::{debug, info, warn};
 use voxctrl_config::{TtsConfig, TtsEngine};
 use voxctrl_text::{correct_custom_vocabulary, expand_snippets};
 
-use crate::breeze::{speak_breeze_tts_2, BreezeModelSlot};
-use crate::inflect::speak_inflect_micro;
+use crate::breeze::{ensure_breeze_tts_2_loaded, speak_breeze_tts_2, BreezeModelSlot};
+use crate::inflect::{ensure_inflect_micro_loaded, speak_inflect_micro};
 use crate::piper::{get_voice_path, piper_binary, sample_rate_for_voice};
-use crate::pocket::speak_pocket_tts;
+use crate::pocket::{ensure_pocket_tts_loaded, speak_pocket_tts};
+
+/// How long the worker parks in `recv_timeout` when there is nothing to expire.
+/// Only a wake-up interval — the channel still wakes it immediately on a command.
+const IDLE_PARK: Duration = Duration::from_secs(3600);
 
 /// The worker's cached Inflect-Micro-v2 sessions. Without the `inflect-micro`
 /// feature there is no model type to cache, so the slot degenerates to `()` and
@@ -40,7 +46,14 @@ pub enum TtsCommand {
         utterance: Utterance,
         generation: u32,
     },
+    /// Live config swap — also how the memory policy reaches a running worker,
+    /// so the tray toggle never has to tear down the engine (and its audio
+    /// device) just to change it.
     UpdateConfig(TtsConfig),
+    /// Load the model now (and restart the idle countdown) without speaking.
+    /// Sent as soon as VoxCtrl knows speech is likely — e.g. the moment a
+    /// recording starts — so the load overlaps with the user still talking.
+    Preload,
     Shutdown,
 }
 
@@ -57,7 +70,10 @@ pub fn stop_current_playback() {
 #[derive(Clone)]
 pub struct TtsEngineHandle {
     tx: Sender<TtsCommand>,
-    generation: Arc<std::sync::atomic::AtomicU32>,
+    generation: Arc<AtomicU32>,
+    /// Mirrors whether the worker currently holds a model in memory, so the UI
+    /// and tray can show the state without interrogating the worker thread.
+    model_loaded: Arc<AtomicBool>,
 }
 
 impl TtsEngineHandle {
@@ -79,6 +95,17 @@ impl TtsEngineHandle {
             utterance: u,
             generation: gen,
         });
+    }
+
+    /// Ask the worker to load the model now. Cheap and idempotent when the model
+    /// is already resident — it just restarts the idle countdown.
+    pub fn preload(&self) {
+        let _ = self.tx.try_send(TtsCommand::Preload);
+    }
+
+    /// Whether a model is currently resident in memory.
+    pub fn is_model_loaded(&self) -> bool {
+        self.model_loaded.load(Ordering::SeqCst)
     }
 
     pub fn stop(&self) {
@@ -106,7 +133,8 @@ pub struct TtsEngineWorker {
     config: TtsConfig,
     custom_vocabulary: Vec<String>,
     rx: Receiver<TtsCommand>,
-    generation: Arc<std::sync::atomic::AtomicU32>,
+    generation: Arc<AtomicU32>,
+    model_loaded: Arc<AtomicBool>,
     on_playback_start: Option<PlaybackCallback>,
     on_playback_end: Option<PlaybackCallback>,
     on_error: Option<ErrorCallback>,
@@ -121,8 +149,13 @@ impl TtsEngineWorker {
         on_error: Option<ErrorCallback>,
     ) -> TtsEngineHandle {
         let (tx, rx) = bounded(32);
-        let generation = Arc::new(std::sync::atomic::AtomicU32::new(0));
-        let handle = TtsEngineHandle { tx, generation: generation.clone() };
+        let generation = Arc::new(AtomicU32::new(0));
+        let model_loaded = Arc::new(AtomicBool::new(false));
+        let handle = TtsEngineHandle {
+            tx,
+            generation: generation.clone(),
+            model_loaded: model_loaded.clone(),
+        };
 
         let prewarm = match config.engine {
             TtsEngine::PocketTts => config.pocket_tts.prewarm,
@@ -130,7 +163,11 @@ impl TtsEngineWorker {
             TtsEngine::BreezeTts2 => config.breeze_tts_2.prewarm,
             _ => false,
         };
-        if prewarm {
+        // Pre-warming loads the model at startup and keeps it there, which is
+        // exactly what the on-demand memory mode exists to avoid — so the two
+        // settings do not fight: on-demand wins and the model waits for its
+        // first real use (or a `preload()`).
+        if prewarm && !config.unloads_when_idle() {
             let _ = handle.tx.send(TtsCommand::Play {
                 utterance: Utterance {
                     text: " ".into(),
@@ -146,6 +183,7 @@ impl TtsEngineWorker {
             custom_vocabulary,
             rx,
             generation,
+            model_loaded,
             on_playback_start,
             on_playback_end,
             on_error,
@@ -159,8 +197,12 @@ impl TtsEngineWorker {
     }
 
     fn run(self) {
-        info!("TTS engine started (engine={:?})", self.config.engine);
+        info!(
+            "TTS engine started (engine={:?}, memory_mode={:?})",
+            self.config.engine, self.config.memory_mode
+        );
         let mut current_config = self.config.clone();
+
 
         // pocket-tts model + per-voice cloned voice state, cached for the lifetime of this worker thread.
         let mut pocket_tts_model: Option<pocket_tts::TTSModel> = None;
@@ -186,13 +228,73 @@ impl TtsEngineWorker {
             Ok(sink)
         };
 
-        while let Ok(cmd) = self.rx.recv() {
+        // ── Idle-unload bookkeeping ──────────────────────────────────────────
+        // In on-demand mode a model is loaded when it is first needed (or
+        // pre-loaded via `TtsCommand::Preload`) and dropped again once it has
+        // gone unused for the configured window. Every use — a spoken utterance
+        // or a preload — restarts the countdown, so an active conversation never
+        // pays the reload cost twice. Read from `current_config` each time round
+        // so an `UpdateConfig` takes effect on the next iteration.
+        let mut last_used = Instant::now();
+
+        loop {
+            let unload_when_idle = current_config.unloads_when_idle();
+            let idle = current_config.idle_unload_duration();
+            // Piper and eSpeak shell out per utterance and hold nothing; only
+            // these three keep weights resident, so only these can be unloaded.
+            let model_resident = pocket_tts_model.is_some()
+                || inflect_model.is_some()
+                || breeze_tts_2_model.is_some();
+
+            // Park until the next command, or until the idle window expires.
+            let wait = if unload_when_idle && model_resident {
+                match idle.checked_sub(last_used.elapsed()) {
+                    Some(remaining) if !remaining.is_zero() => remaining,
+                    _ => {
+                        info!(
+                            "Unloading TTS model after {}s idle (memory mode: on-demand)",
+                            idle.as_secs()
+                        );
+                        // Dropping the model and its cached voice states is the
+                        // whole of the resident footprint; the worker thread,
+                        // its audio device and the queue all stay up.
+                        pocket_tts_model = None;
+                        pocket_tts_voice_states.clear();
+                        inflect_model = None;
+                        breeze_tts_2_model = None;
+                        breeze_tts_2_voice_states.clear();
+                        self.model_loaded.store(false, Ordering::SeqCst);
+                        continue;
+                    }
+                }
+            } else {
+                IDLE_PARK
+            };
+
+            let cmd = match self.rx.recv_timeout(wait) {
+                Ok(cmd) => cmd,
+                // Nothing arrived in the window — go round again so the unload
+                // branch above can run.
+                Err(RecvTimeoutError::Timeout) => continue,
+                Err(RecvTimeoutError::Disconnected) => break,
+            };
+
             match cmd {
                 TtsCommand::UpdateConfig(new_cfg) => {
-                    info!("TTS worker config dynamically updated (engine={:?})", new_cfg.engine);
+                    info!(
+                        "TTS worker config dynamically updated (engine={:?}, memory_mode={:?})",
+                        new_cfg.engine, new_cfg.memory_mode
+                    );
                     current_config = new_cfg;
+                    // Switching to on-demand starts the clock now rather than
+                    // dropping a model that may be about to be used again.
+                    last_used = Instant::now();
                 }
                 TtsCommand::Play { mut utterance, generation } => {
+                    // Synthesis is about to touch the model; hold off the idle
+                    // unload for the whole utterance and restart the countdown
+                    // when it ends (below).
+                    last_used = Instant::now();
                     let current_gen = self.generation.load(std::sync::atomic::Ordering::SeqCst);
                     if generation < current_gen {
                         debug!("Discarding stale utterance: generation={generation} (current={current_gen})");
@@ -308,6 +410,52 @@ impl TtsEngineWorker {
                             cb();
                         }
                     }
+
+                    self.model_loaded.store(
+                        pocket_tts_model.is_some()
+                            || inflect_model.is_some()
+                            || breeze_tts_2_model.is_some(),
+                        Ordering::SeqCst,
+                    );
+                    // A long utterance must not count against the idle window.
+                    last_used = Instant::now();
+                }
+                TtsCommand::Preload => {
+                    // Speculative: failures are logged, not surfaced. The same
+                    // error is reported properly (with a toast) if an utterance
+                    // actually arrives.
+                    let outcome = match current_config.engine {
+                        TtsEngine::PocketTts if pocket_tts_model.is_none() => Some(
+                            ensure_pocket_tts_loaded(
+                                &current_config,
+                                &current_config.pocket_tts.voice.clone(),
+                                &mut pocket_tts_model,
+                                &mut pocket_tts_voice_states,
+                            ),
+                        ),
+                        TtsEngine::InflectMicro if inflect_model.is_none() => {
+                            Some(ensure_inflect_micro_loaded(&current_config, &mut inflect_model))
+                        }
+                        TtsEngine::BreezeTts2 if breeze_tts_2_model.is_none() => {
+                            Some(ensure_breeze_tts_2_loaded(&current_config, &mut breeze_tts_2_model))
+                        }
+                        // Already resident, or an engine that holds no model.
+                        _ => None,
+                    };
+                    match outcome {
+                        Some(Err(e)) => debug!("TTS preload skipped: {e:#}"),
+                        Some(Ok(())) => debug!("TTS model pre-loaded and primed"),
+                        None => {}
+                    }
+                    // A partial load (weights in, voice state failed) still holds
+                    // memory, so track what is actually resident.
+                    self.model_loaded.store(
+                        pocket_tts_model.is_some()
+                            || inflect_model.is_some()
+                            || breeze_tts_2_model.is_some(),
+                        Ordering::SeqCst,
+                    );
+                    last_used = Instant::now();
                 }
                 TtsCommand::Shutdown => {
                     debug!("TTS shutdown signal received");
@@ -444,7 +592,11 @@ mod tests {
     fn test_handle_stop_increments_generation_counter() {
         let (tx, _rx) = bounded(32);
         let generation = Arc::new(std::sync::atomic::AtomicU32::new(0));
-        let handle = TtsEngineHandle { tx, generation: generation.clone() };
+        let handle = TtsEngineHandle {
+            tx,
+            generation: generation.clone(),
+            model_loaded: Arc::new(AtomicBool::new(false)),
+        };
 
         assert_eq!(generation.load(std::sync::atomic::Ordering::SeqCst), 0);
         handle.stop();
@@ -482,5 +634,113 @@ mod tests {
         }
 
         assert_eq!(frames_processed, 2, "loop must abandon remaining frames after stop()");
+    }
+
+    // ── Idle-unload memory mode ──────────────────────────────────────────────
+
+    fn test_handle() -> (TtsEngineHandle, Receiver<TtsCommand>) {
+        let (tx, rx) = bounded(32);
+        let handle = TtsEngineHandle {
+            tx,
+            generation: Arc::new(AtomicU32::new(0)),
+            model_loaded: Arc::new(AtomicBool::new(false)),
+        };
+        (handle, rx)
+    }
+
+    #[test]
+    fn test_preload_sends_preload_command() {
+        let (handle, rx) = test_handle();
+        handle.preload();
+        assert!(matches!(rx.try_recv(), Ok(TtsCommand::Preload)));
+    }
+
+    #[test]
+    fn test_update_config_carries_memory_policy_to_worker() {
+        let (handle, rx) = test_handle();
+        let cfg = TtsConfig {
+            memory_mode: voxctrl_config::TtsMemoryMode::OnDemand,
+            idle_unload_secs: 900,
+            ..TtsConfig::default()
+        };
+        handle.update_config(cfg);
+        match rx.try_recv() {
+            Ok(TtsCommand::UpdateConfig(cfg)) => {
+                assert!(cfg.unloads_when_idle());
+                assert_eq!(cfg.idle_unload_duration(), Duration::from_secs(900));
+            }
+            other => panic!("expected UpdateConfig, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_model_loaded_flag_defaults_false() {
+        let (handle, _rx) = test_handle();
+        assert!(!handle.is_model_loaded());
+    }
+
+    // Mirrors the worker's park-duration decision: while the model is resident
+    // the worker must wake exactly when the idle window runs out, and once it
+    // has expired the remaining time is None (which is the unload trigger).
+    #[test]
+    fn test_idle_window_expiry_arithmetic() {
+        let idle = Duration::from_secs(900);
+
+        let fresh = Duration::from_secs(10);
+        assert_eq!(idle.checked_sub(fresh), Some(Duration::from_secs(890)));
+
+        let expired = Duration::from_secs(901);
+        assert_eq!(idle.checked_sub(expired), None);
+
+        // Exactly at the boundary the remaining window is zero, which the worker
+        // treats as expired rather than parking for 0ns in a tight loop.
+        let boundary = idle.checked_sub(idle).unwrap();
+        assert!(boundary.is_zero());
+    }
+
+    // A use part-way through the window must push the deadline out rather than
+    // letting the original one stand — "the time is reset if it is used again".
+    #[test]
+    fn test_use_resets_idle_countdown() {
+        let idle = Duration::from_secs(900);
+        let first_use = Instant::now();
+        let elapsed_at_second_use = Duration::from_secs(600);
+
+        // Without a reset the model would have 300s left ...
+        assert_eq!(idle.checked_sub(elapsed_at_second_use), Some(Duration::from_secs(300)));
+
+        // ... but the worker stamps `last_used` again, so the full window is back.
+        let last_used = first_use + elapsed_at_second_use;
+        let remaining = idle.checked_sub(last_used.duration_since(last_used)).unwrap();
+        assert_eq!(remaining, idle);
+    }
+
+    #[test]
+    fn test_config_idle_duration_defaults_to_fifteen_minutes() {
+        let cfg = TtsConfig::default();
+        assert_eq!(cfg.idle_unload_secs, 900);
+        assert_eq!(cfg.idle_unload_duration(), Duration::from_secs(900));
+    }
+
+    #[test]
+    fn test_config_defaults_to_always_loaded() {
+        assert!(!TtsConfig::default().unloads_when_idle());
+    }
+
+    #[test]
+    fn test_config_idle_duration_is_floored() {
+        // A 0 (or 1s) setting would drop the model between two sentences of the
+        // same reply; the config floors it instead of honouring it literally.
+        let cfg = TtsConfig { idle_unload_secs: 0, ..TtsConfig::default() };
+        assert_eq!(cfg.idle_unload_duration(), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn test_on_demand_mode_reported_by_config() {
+        let cfg = TtsConfig {
+            memory_mode: voxctrl_config::TtsMemoryMode::OnDemand,
+            ..TtsConfig::default()
+        };
+        assert!(cfg.unloads_when_idle());
     }
 }

--- a/crates/voxctrl-tts/src/inflect/mod.rs
+++ b/crates/voxctrl-tts/src/inflect/mod.rs
@@ -538,6 +538,33 @@ fn split_sentences(text: &str) -> Vec<String> {
 
 // ── Synthesis ─────────────────────────────────────────────────────────────────
 
+/// Loads the Inflect-Micro-v2 ONNX sessions into the worker's cache if they are
+/// not already there. Idempotent, so both the pre-load path and synthesis call
+/// it unconditionally — and since the sessions are the engine's whole resident
+/// footprint, dropping `model` is what the on-demand memory mode reclaims.
+#[cfg(feature = "inflect-micro")]
+pub(crate) fn ensure_inflect_micro_loaded(
+    config: &voxctrl_config::TtsConfig,
+    model: &mut Option<model::InflectModel>,
+) -> Result<()> {
+    let cfg = &config.inflect_micro;
+
+    if !is_inflect_micro_downloaded(&cfg.model_dir) {
+        anyhow::bail!(
+            "Inflect-Micro-v2 model files not found in {}. Download them from TTS settings.",
+            resolve_model_dir(&cfg.model_dir).display()
+        );
+    }
+
+    if model.is_none() {
+        let started = std::time::Instant::now();
+        let dir = resolve_model_dir(&cfg.model_dir);
+        *model = Some(model::InflectModel::load(&dir)?);
+        tracing::info!("Inflect-Micro-v2 sessions loaded in {:?}", started.elapsed());
+    }
+    Ok(())
+}
+
 /// Called from `TtsEngineWorker::run` when `config.engine == TtsEngine::InflectMicro`.
 ///
 /// Takes the worker's model cache by mutable reference so the loaded ONNX
@@ -559,18 +586,7 @@ pub(crate) fn speak_inflect_micro(
     let cfg = &config.inflect_micro;
     let is_prewarm = u.source_label.as_deref() == Some("prewarm");
 
-    if !is_inflect_micro_downloaded(&cfg.model_dir) {
-        anyhow::bail!(
-            "Inflect-Micro-v2 model files not found in {}. Download them from TTS settings.",
-            resolve_model_dir(&cfg.model_dir).display()
-        );
-    }
-
-    // Lazily load — the sessions stay alive for the worker thread's lifetime.
-    if model.is_none() {
-        let dir = resolve_model_dir(&cfg.model_dir);
-        *model = Some(model::InflectModel::load(&dir)?);
-    }
+    ensure_inflect_micro_loaded(config, model)?;
     let model = model.as_mut().unwrap();
 
     if is_prewarm {
@@ -644,6 +660,17 @@ pub(crate) fn speak_inflect_micro(
     }
 
     sink.sleep_until_end();
+    Ok(())
+}
+
+/// Stand-in for builds without the `inflect-micro` feature: there is no model to
+/// load, so a pre-load is a no-op rather than an error (the real message comes
+/// from `speak_inflect_micro` if the engine is actually used).
+#[cfg(not(feature = "inflect-micro"))]
+pub(crate) fn ensure_inflect_micro_loaded(
+    _config: &voxctrl_config::TtsConfig,
+    _model: &mut Option<()>,
+) -> Result<()> {
     Ok(())
 }
 

--- a/crates/voxctrl-tts/src/pocket.rs
+++ b/crates/voxctrl-tts/src/pocket.rs
@@ -378,6 +378,47 @@ pub async fn download_pocket_tts_assets(voice: &str, voice_dir: &str, hf_token: 
 
 // ── pocket-tts synthesis (pure Rust / Candle) ─────────────────────────────────
 
+/// Loads the pocket-tts model and the selected voice's cloned state into the
+/// worker's caches if they are not already there. Idempotent and cheap once
+/// warm, so both the pre-load path (`TtsCommand::Preload`) and synthesis call
+/// it unconditionally.
+///
+/// This is the expensive step the on-demand memory mode defers and then
+/// reclaims: everything the model occupies lives in `model` + `voice_states`,
+/// so dropping those two gives the memory straight back.
+pub(crate) fn ensure_pocket_tts_loaded(
+    config: &voxctrl_config::TtsConfig,
+    voice: &str,
+    model: &mut Option<pocket_tts::TTSModel>,
+    voice_states: &mut HashMap<String, pocket_tts::ModelState>,
+) -> Result<()> {
+    if !is_pocket_tts_ready(voice, &config.pocket_tts.voice_dir) {
+        anyhow::bail!("pocket-tts assets for voice '{voice}' not found. Download them from TTS settings.");
+    }
+
+    if model.is_none() {
+        let started = std::time::Instant::now();
+        info!("Loading pocket-tts model (variant={POCKET_TTS_VARIANT})");
+        *model =
+            Some(load_pocket_tts_model(POCKET_TTS_VARIANT).context("load pocket-tts model")?);
+        info!("pocket-tts model loaded in {:?}", started.elapsed());
+    }
+    let loaded = model.as_ref().unwrap();
+
+    if !voice_states.contains_key(voice) {
+        let reference_clip = resolve_pocket_tts_voice_clip(voice, &config.pocket_tts.voice_dir)
+            .ok_or_else(|| anyhow::anyhow!("unknown pocket-tts voice: {voice}"))?;
+        let clip_path = pocket_tts::weights::download_if_necessary(&reference_clip)
+            .context("resolve pocket-tts reference voice clip")?;
+        let state = loaded
+            .get_voice_state(&clip_path)
+            .context("compute pocket-tts voice state")?;
+        voice_states.insert(voice.to_string(), state);
+    }
+
+    Ok(())
+}
+
 /// Called from `TtsEngineWorker::run` (in `engine.rs`) when `config.engine ==
 /// TtsEngine::PocketTts`. Takes the worker's model/voice-state caches by
 /// mutable reference so they persist across calls for the worker's lifetime.
@@ -394,28 +435,8 @@ pub(crate) fn speak_pocket_tts(
     let is_prewarm = u.source_label.as_deref() == Some("prewarm");
     let voice = u.voice.as_deref().unwrap_or(&config.pocket_tts.voice);
 
-    if !is_pocket_tts_ready(voice, &config.pocket_tts.voice_dir) {
-        anyhow::bail!("pocket-tts assets for voice '{voice}' not found. Download them from TTS settings.");
-    }
-
-    // Lazily load the model — stays alive for the worker thread lifetime.
-    if model.is_none() {
-        info!("Loading pocket-tts model (variant={POCKET_TTS_VARIANT})");
-        *model =
-            Some(load_pocket_tts_model(POCKET_TTS_VARIANT).context("load pocket-tts model")?);
-    }
+    ensure_pocket_tts_loaded(config, voice, model, voice_states)?;
     let model = model.as_ref().unwrap();
-
-    if !voice_states.contains_key(voice) {
-        let reference_clip = resolve_pocket_tts_voice_clip(voice, &config.pocket_tts.voice_dir)
-            .ok_or_else(|| anyhow::anyhow!("unknown pocket-tts voice: {voice}"))?;
-        let clip_path = pocket_tts::weights::download_if_necessary(&reference_clip)
-            .context("resolve pocket-tts reference voice clip")?;
-        let state = model
-            .get_voice_state(&clip_path)
-            .context("compute pocket-tts voice state")?;
-        voice_states.insert(voice.to_string(), state);
-    }
     let voice_state = voice_states.get(voice).unwrap();
 
     if is_prewarm {

--- a/docs/api.md
+++ b/docs/api.md
@@ -732,6 +732,8 @@ interface TtsConfig {
   pocket_tts: PocketTtsConfig;
   inflect_micro: InflectMicroConfig;  // fixed-voice, so no voice field
   breeze_tts_2: BreezeTts2Config;
+  memory_mode: "always_loaded" | "on_demand"; // "on_demand" unloads the model when idle
+  idle_unload_secs: number;  // idle seconds before unloading in "on_demand" mode (default 900)
   snippets: Record<string, string>;   // pronunciation guide, speech only
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,7 +87,9 @@ Full schema with defaults:
       "seed": 0,
       "noise_scale": 0.667,
       "prewarm": false
-    }
+    },
+    "memory_mode": "always_loaded",
+    "idle_unload_secs": 900
   },
   "mcp": {
     "server_enabled": false,
@@ -235,6 +237,8 @@ text) and the **user prompt** (the message itself). The user prompt must contain
 | `breeze_tts_2` | object | | Breeze-TTS-2 engine sub-configuration (see below) |
 | `pocket_tts` | object | | Pocket-TTS engine sub-configuration (see below) |
 | `inflect_micro` | object | | Inflect-Micro-v2 engine sub-configuration (see below) |
+| `memory_mode` | string | `"always_loaded"` | `"always_loaded"` keeps the model resident for the session; `"on_demand"` loads it when it is needed and unloads it again after `idle_unload_secs` of no use. Affects the model-backed engines (Pocket-TTS, Breeze-TTS-2, Inflect-Micro-v2) — Piper and eSpeak hold no model between utterances. |
+| `idle_unload_secs` | int | `900` (15 min) | Idle time before the model is unloaded in `"on_demand"` mode. The countdown restarts on every use. Values below 30s are clamped to 30s. |
 
 **`breeze_tts_2` sub-object:**
 

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -278,6 +278,49 @@ Pocket-TTS loads its model weights on first synthesis. Enable `prewarm` to avoid
 
 When `prewarm` is `true`, `TtsEngineWorker::start()` enqueues a silent synthesis immediately after spawning the worker thread. The worker processes this short request (a single space) at startup, loading the model into memory and computing the configured voice's reference embedding. Subsequent user-triggered syntheses are faster because the model is already warm. This adds startup latency depending on model size and disk speed.
 
+Pre-warming is ignored when `memory_mode` is `"on_demand"` — the two settings want opposite things, and the memory mode wins. The same applies to `breeze_tts_2.prewarm` and `inflect_micro.prewarm`.
+
+---
+
+## Model Memory (on-demand loading)
+
+The neural engines — Pocket-TTS, Breeze-TTS-2 and Inflect-Micro-v2 — are the only parts of the
+TTS stack that occupy significant memory; Piper and eSpeak-NG run a process per utterance and
+hold nothing in between. `memory_mode` decides whether those weights stay resident:
+
+```json
+"tts": {
+  "engine": "pocket_tts",
+  "memory_mode": "on_demand",
+  "idle_unload_secs": 900
+}
+```
+
+| Mode | Behaviour |
+|---|---|
+| `"always_loaded"` (default) | The model is loaded on first use and stays resident for the life of the TTS worker. Fastest, highest memory. |
+| `"on_demand"` | The model is loaded when VoxCtrl knows it is needed, kept primed while it keeps being used, and dropped after `idle_unload_secs` (default 900 = 15 minutes) of inactivity. |
+
+In `"on_demand"` mode TTS itself stays enabled the whole time — only the weights come and go:
+
+* **Loading starts as early as possible.** `TtsCommand::Preload` is sent the moment a recording
+  starts against a target that ends in speech (a `speak` target, or one with a `response_pipe`),
+  so the model loads while the user is still talking rather than after they stop. Dictating into
+  an ordinary injection target does not load it.
+* **The idle countdown restarts on every use.** Speaking an utterance or pre-loading stamps the
+  worker's `last_used`, so a back-and-forth conversation never reloads mid-flow. A long utterance
+  does not count against the window either — the clock restarts when playback ends.
+* **Unloading drops the model and every cached voice state**, which is the whole of the resident
+  footprint. The worker thread, its audio device, and the utterance queue stay up, so nothing
+  else about TTS changes.
+* **The floor is 30 seconds.** A shorter `idle_unload_secs` is clamped, since dropping the model
+  between two sentences of the same reply would cost far more than it saves.
+
+The mode is settable in **Settings → TTS → Model Memory** and from the **VoxCtrl tray icon**
+("Unload TTS model when idle"), which toggles it live — the running worker is told about the new
+policy (through `TtsCommand::UpdateConfig`) rather than restarted, so playback and the audio
+device are untouched.
+
 ---
 
 ## Stopping Playback
@@ -322,6 +365,8 @@ Under `tts` in `config.json`:
 | `breeze_tts_2.model_dir` | string | `""` | Model weights & tokenizer; empty = `~/.local/share/voxctrl/models/breeze-tts-2/` |
 | `breeze_tts_2.prewarm` | bool | `false` | Pre-warm the model on startup for faster first synthesis |
 | `breeze_tts_2.gpu` | bool | `false` | Run synthesis on the GPU; needs a `breeze-cuda` / `breeze-metal` build, CPU otherwise |
+| `memory_mode` | string | `"always_loaded"` | `"always_loaded"` or `"on_demand"` — see [Model Memory](#model-memory-on-demand-loading) |
+| `idle_unload_secs` | int | `900` | Idle seconds before the model is unloaded in `"on_demand"` mode (minimum 30) |
 | `snippets` | object | *(VoxCtrl pronunciations)* | Word → spoken expansion map, applied to speech only |
 
 **Example Pocket-TTS config:**
@@ -362,6 +407,8 @@ pub enum TtsCommand {
         utterance: Utterance,
         generation: u32,
     },
+    UpdateConfig(TtsConfig), // live config swap, including the memory mode
+    Preload,                 // load the model now, without speaking
     Shutdown,
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "voxctrl",
   "private": true,
-  "version": "0.5.2",
+  "version": "0.5.3",
   "type": "module",
   "scripts": {
     "predev": "pkill -x voxctrl 2>/dev/null || true; fuser -k 5173/tcp 2>/dev/null || true",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -57,6 +57,8 @@ pub async fn start_recording(state: State<'_, Arc<AppState>>) -> Result<(), Stri
     *state.active_binding_id.lock().await = String::new();
     state.begin_recording().await;
     info!("Recording started via command");
+    let active_target = state.active_target.lock().await.clone();
+    state.preload_tts_for_target(&active_target).await;
     Ok(())
 }
 
@@ -72,6 +74,8 @@ pub async fn toggle_recording(state: State<'_, Arc<AppState>>) -> Result<bool, S
     let was = state.is_recording();
     if !was {
         *state.active_binding_id.lock().await = String::new();
+        let active_target = state.active_target.lock().await.clone();
+        state.preload_tts_for_target(&active_target).await;
     }
     state.set_recording(!was);
     Ok(!was)
@@ -163,6 +167,9 @@ pub async fn save_config(
             }
         }
     }
+
+    // Keep the tray checkbox in step with the TTS memory setting.
+    crate::tray::update_tray_tts_memory(&app, new_config.tts.unloads_when_idle());
 
     // Emit config-changed event to all windows to enable instant reactivity
     let _ = app.emit("config-changed", new_config);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -408,6 +408,7 @@ pub fn run() {
 
             // Setup system tray
             let _tray = tray::create_tray(app)?;
+            tray::sync_tts_memory_item(app.handle().clone(), app_state.clone());
 
             let record_on_icon =
                 tauri::image::Image::from_bytes(include_bytes!("../../assets/record_on.png"))

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -219,6 +219,16 @@ async fn run_gesture_loop(
                 *state_for_gesture.active_binding_id.lock().await = event.binding_id.clone();
                 state_for_gesture.begin_recording().await;
 
+                // Earliest point at which we know speech is probably coming.
+                // In the on-demand memory mode the model is not resident, so
+                // start pulling it in now — the load runs while the user is
+                // still talking instead of after they stop.
+                let preload_state = state_for_gesture.clone();
+                let preload_target = event.target_id.clone();
+                tokio::spawn(async move {
+                    preload_state.preload_tts_for_target(&preload_target).await;
+                });
+
                 // The user just tried to dictate. If the install is not
                 // finished, say so now — otherwise the shortcut records
                 // audio that can never become text, which reads as

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -259,6 +259,47 @@ impl AppState {
         self.word_count.load(Ordering::SeqCst)
     }
 
+    /// Start loading the TTS model now, before anything asks it to speak.
+    ///
+    /// Only meaningful in the on-demand memory mode, where the model is not
+    /// resident between uses: the load takes seconds, so kicking it off the
+    /// moment we know speech is coming (the user has just started dictating)
+    /// hides most of that behind the time they spend talking. In always-loaded
+    /// mode the model is already there and this is a no-op.
+    pub async fn preload_tts(&self) {
+        let unloads_when_idle = {
+            let cfg = self.config.lock().await;
+            cfg.data.tts.enabled && cfg.data.tts.unloads_when_idle()
+        };
+        if !unloads_when_idle {
+            return;
+        }
+        if let Some(tts) = self.tts_handle.lock().await.as_ref() {
+            tts.preload();
+        }
+    }
+
+    /// True when dictating through `target_id` is likely to end in speech —
+    /// either the target speaks the transcript itself, or it has a response
+    /// pipe whose reply VoxCtrl reads back. Used to decide whether a recording
+    /// is worth pre-loading the TTS model for; dictating into an editor is not.
+    pub async fn target_leads_to_speech(&self, target_id: &str) -> bool {
+        use voxctrl_routing::DeliveryType;
+        let targets = self.targets.lock().await;
+        targets.iter().any(|t| {
+            t.id == target_id
+                && (t.delivery == DeliveryType::Speak
+                    || t.response_pipe.as_deref().is_some_and(|p| !p.trim().is_empty()))
+        })
+    }
+
+    /// Pre-load the TTS model if `target_id` is one that ends in speech.
+    pub async fn preload_tts_for_target(&self, target_id: &str) {
+        if target_id.is_empty() || self.target_leads_to_speech(target_id).await {
+            self.preload_tts().await;
+        }
+    }
+
     pub async fn spawn_fifo_responders(&self, tts: voxctrl_tts::TtsEngineHandle) {
         let targets_guard = self.targets.lock().await;
         let mut active_fifos_guard = self.active_fifos.lock().await;

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -33,6 +33,68 @@ pub fn update_tray_for_setup(app: &tauri::AppHandle, ok: bool) {
     });
 }
 
+/// The tray entry that mirrors (and toggles) the TTS memory mode.
+static TTS_MEMORY_MENU_ITEM: OnceLock<tauri::menu::CheckMenuItem<tauri::Wry>> = OnceLock::new();
+
+pub const TRAY_TTS_MEMORY: &str = "🧠  Unload TTS model when idle";
+
+/// Keep the tray checkbox in step with the setting, whichever side changed it
+/// (the tray item itself, or the TTS settings tab).
+pub fn update_tray_tts_memory(app: &tauri::AppHandle, on_demand: bool) {
+    let app = app.clone();
+    let _ = app.run_on_main_thread(move || {
+        if let Some(item) = TTS_MEMORY_MENU_ITEM.get() {
+            let _ = item.set_checked(on_demand);
+        }
+    });
+}
+
+/// Flip the TTS memory mode from the tray: persist it, tell the running worker
+/// (no restart — that would tear down the engine and its audio device), and
+/// mirror the new state back into the settings window.
+fn toggle_tts_memory_mode(app: &tauri::AppHandle) {
+    use tauri::Manager;
+
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        let state = app.state::<Arc<AppState>>().inner().clone();
+
+        let new_data = {
+            let mut guard = state.config.lock().await;
+            let on_demand = !guard.data.tts.unloads_when_idle();
+            guard.data.tts.memory_mode = if on_demand {
+                voxctrl_config::TtsMemoryMode::OnDemand
+            } else {
+                voxctrl_config::TtsMemoryMode::AlwaysLoaded
+            };
+            if let Err(e) = guard.save() {
+                tracing::error!("Failed to save TTS memory mode from tray: {e}");
+            }
+            guard.data.clone()
+        };
+
+        let on_demand = new_data.tts.unloads_when_idle();
+        if let Some(tts) = state.tts_handle.lock().await.as_ref() {
+            tts.update_config(new_data.tts.clone());
+        }
+
+        update_tray_tts_memory(&app, on_demand);
+        let _ = app.emit("config-changed", new_data.clone());
+
+        voxctrl_inject::show_notification(
+            "VoxCtrl",
+            &if on_demand {
+                format!(
+                    "TTS model will unload after {} minutes idle to save memory.",
+                    new_data.tts.idle_unload_duration().as_secs() / 60
+                )
+            } else {
+                "TTS model will stay loaded in memory for the fastest response.".to_string()
+            },
+        );
+    });
+}
+
 pub fn create_tray(app: &tauri::App) -> Result<tauri::tray::TrayIcon, tauri::Error> {
     let record_off_icon = tauri::image::Image::from_bytes(include_bytes!("../../assets/record_off.png"))
         .expect("Failed to load record_off icon");
@@ -40,13 +102,24 @@ pub fn create_tray(app: &tauri::App) -> Result<tauri::tray::TrayIcon, tauri::Err
 
     let settings_i = tauri::menu::MenuItem::with_id(app, "settings", "⚙  Settings", true, None::<&str>)?;
     let setup_i = tauri::menu::MenuItem::with_id(app, "setup", TRAY_SETUP_OK, true, None::<&str>)?;
+    let tts_memory_i = tauri::menu::CheckMenuItem::with_id(
+        app,
+        "tts_memory",
+        TRAY_TTS_MEMORY,
+        true,
+        // The real value is applied right after the tray is built (see
+        // `sync_tts_memory_item`); a `try_lock` here can miss at startup.
+        false,
+        None::<&str>,
+    )?;
     let separator = tauri::menu::PredefinedMenuItem::separator(app)?;
     let quit_i = tauri::menu::MenuItem::with_id(app, "quit", "Quit VoxCtrl", true, None::<&str>)?;
     let menu = tauri::menu::Menu::with_items(
         app,
-        &[&settings_i, &setup_i, &separator, &quit_i],
+        &[&settings_i, &setup_i, &tts_memory_i, &separator, &quit_i],
     )?;
     let _ = SETUP_MENU_ITEM.set(setup_i);
+    let _ = TTS_MEMORY_MENU_ITEM.set(tts_memory_i);
 
     TrayIconBuilder::with_id("main-tray")
         .icon(tray_icon)
@@ -62,6 +135,9 @@ pub fn create_tray(app: &tauri::App) -> Result<tauri::tray::TrayIcon, tauri::Err
                 "setup" => {
                     crate::window::show_setup_window();
                 }
+                "tts_memory" => {
+                    toggle_tts_memory_mode(app);
+                }
                 "quit" => {
                     app.exit(0);
                 }
@@ -76,6 +152,14 @@ pub fn create_tray(app: &tauri::App) -> Result<tauri::tray::TrayIcon, tauri::Err
             }
         })
         .build(app)
+}
+
+/// Show the stored TTS memory mode on the freshly built tray item.
+pub fn sync_tts_memory_item(app: tauri::AppHandle, state: Arc<AppState>) {
+    tauri::async_runtime::spawn(async move {
+        let on_demand = state.config.lock().await.data.tts.unloads_when_idle();
+        update_tray_tts_memory(&app, on_demand);
+    });
 }
 
 pub fn spawn_status_ticker(

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VoxCtrl",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "identifier": "ai.voxctrl.app",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/Settings/TtsTab.svelte
+++ b/src/lib/Settings/TtsTab.svelte
@@ -276,6 +276,37 @@
     }))
   );
 
+  // ── Model memory ───────────────────────────────────────────────────────────
+  //
+  // Only the neural engines (Pocket-TTS, Breeze-TTS-2, Inflect-Micro-v2) keep
+  // weights resident; Piper and eSpeak shell out to a process per utterance and
+  // hold nothing between them.
+
+  const memoryModeOptions = [
+    { value: "always_loaded", label: "Always loaded (fastest response)" },
+    { value: "on_demand", label: "Load when needed, unload when idle (saves memory)" }
+  ];
+
+  // Derived rather than local state so a change made elsewhere — the tray
+  // toggle, another settings window — shows up here immediately.
+  let idleMinutes = $derived(Math.round((cfg.tts.idle_unload_secs ?? 900) / 60));
+
+  function onMemoryModeChanged() {
+    if (cfg.tts.memory_mode === "on_demand" && !cfg.tts.idle_unload_secs) {
+      cfg.tts.idle_unload_secs = 900;
+    }
+    markDirty();
+  }
+
+  function onIdleMinutesChange(e: Event) {
+    const raw = Number((e.currentTarget as HTMLInputElement).value);
+    // 1 minute floor: anything shorter would drop the model between two
+    // sentences of the same reply. 8 hours is effectively "never".
+    const minutes = Math.min(480, Math.max(1, Math.round(raw) || 15));
+    cfg.tts.idle_unload_secs = minutes * 60;
+    markDirty();
+  }
+
   const engineOptions = [
     { value: "breeze_tts_2", label: "Breeze-TTS-2 (neural, voice design)" },
     { value: "pocket_tts", label: "Pocket-TTS (neural, voice cloning)" },
@@ -721,6 +752,47 @@
     {#if !ttsError && isTestTtsDisabled() && testTtsDisabledReason()}
       <p class="hint">Test TTS unavailable: {testTtsDisabledReason()}</p>
     {/if}
+  </div>
+
+  <!-- ── Model memory section ───────────────────────────────────────────── -->
+  <div class="field-group">
+    <h3>Model Memory</h3>
+    <label class="field col">
+      <span class="field-title">When TTS is enabled</span>
+      <CustomSelect bind:value={cfg.tts.memory_mode} options={memoryModeOptions} onchange={onMemoryModeChanged} />
+    </label>
+
+    {#if cfg.tts.memory_mode === "on_demand"}
+      <label class="field">
+        <span>Unload after (minutes idle)</span>
+        <input
+          type="number"
+          min="1"
+          max="480"
+          step="1"
+          value={idleMinutes}
+          onchange={onIdleMinutesChange}
+          class="idle-minutes-input"
+        />
+      </label>
+      <p class="hint">
+        The model is loaded the moment VoxCtrl knows it will be needed — as soon as you start
+        dictating to a target that speaks — and stays primed while you keep using it. The
+        countdown restarts on every use, so it only unloads after {idleMinutes}
+        {idleMinutes === 1 ? "minute" : "minutes"} of no speech. The first reply after an
+        unload takes a few seconds longer while the model loads again.
+      </p>
+    {:else}
+      <p class="hint">
+        The model stays in memory for the whole session — the fastest possible response, at
+        the cost of holding its memory even while TTS sits unused.
+      </p>
+    {/if}
+    <p class="hint">
+      Applies to the neural engines that hold a model in memory — Pocket-TTS, Breeze-TTS-2 and
+      Inflect-Micro-v2. Piper and eSpeak-NG run a process per utterance and are unaffected. This
+      setting can also be toggled from the VoxCtrl tray icon.
+    </p>
   </div>
 
   <!-- ── Piper section ──────────────────────────────────────────────────── -->
@@ -1215,6 +1287,10 @@
   }
   .btn-preview:disabled {
     @apply opacity-40 cursor-not-allowed;
+  }
+
+  .idle-minutes-input {
+    @apply w-20 bg-[var(--bg)] border border-[var(--border)] text-[var(--text)] rounded-[var(--radius)] p-1.5 px-2.5 text-[13px] text-right;
   }
 
   .voice-status-container {

--- a/src/stores/config.ts
+++ b/src/stores/config.ts
@@ -83,6 +83,8 @@ export interface PocketTtsConfig {
   voice_dir: string;
 }
 
+export type TtsMemoryMode = "always_loaded" | "on_demand";
+
 export interface InflectMicroConfig {
   model_dir: string;
   seed: number;
@@ -111,6 +113,8 @@ export interface TtsConfig {
   pocket_tts: PocketTtsConfig;
   inflect_micro: InflectMicroConfig;
   breeze_tts_2: BreezeTts2Config;
+  memory_mode: TtsMemoryMode;
+  idle_unload_secs: number;
   snippets: Record<string, string>;
 }
 
@@ -202,6 +206,8 @@ const defaultConfig: AppConfig = {
       prewarm: false,
       gpu: false,
     },
+    memory_mode: "always_loaded",
+    idle_unload_secs: 900,
     snippets: {
       "VoxCtrl": "Vox Control"
     },


### PR DESCRIPTION
## What

The neural TTS engines (Pocket-TTS, Breeze-TTS-2, Inflect-Micro-v2) hold a large model in memory for the whole session once loaded. This adds a second memory policy alongside the existing one:

| Mode | Behaviour |
|---|---|
| `always_loaded` (default, unchanged) | Model loads on first use and stays resident. |
| `on_demand` | Model loads the moment VoxCtrl knows it is needed, stays primed while it keeps being used, and is dropped after a user-configurable idle window — default **15 minutes**. |

TTS itself stays enabled the whole time in on-demand mode; only the weights come and go.

## How

- **`voxctrl-config`** — `TtsConfig` gains `memory_mode` (`always_loaded` | `on_demand`) and `idle_unload_secs` (default 900). `idle_unload_duration()` floors the value at 30s, since dropping the model between two sentences of one reply costs far more than it saves. Existing configs keep `always_loaded`.
- **Worker loop** — parks in `recv_timeout` instead of `recv`, so it wakes exactly when the idle window expires and drops the model plus every cached voice state. The worker thread, its audio device and the utterance queue all stay up.
- **Countdown resets on use** — speaking an utterance or pre-loading stamps `last_used`; a long utterance doesn't count against the window (the clock restarts when playback ends).
- **Loads as early as possible** — new `TtsCommand::Preload` loads the model without speaking. It is sent the moment a recording starts against a target that ends in speech (a `speak` target, or one with a `response_pipe`), so the load overlaps with the user still talking. Dictating into an ordinary injection target loads nothing.
- **Live policy changes** — the existing `TtsCommand::UpdateConfig` carries the new mode, so the tray toggle and Settings never tear down the engine or its audio device.
- **Pre-warming is skipped in on-demand mode** — the two settings want opposite things and the memory mode wins.
- **UI** — new "Model Memory" group in Settings → TTS (mode + idle minutes) and a tray checkbox, "🧠 Unload TTS model when idle", which stays in step with the setting whichever side changes it.
- Model loading was extracted into `ensure_pocket_tts_loaded` / `ensure_breeze_tts_2_loaded` / `ensure_inflect_micro_loaded` so the preload path and synthesis share one code path.

## Testing

- `cargo test -p voxctrl-tts -p voxctrl-config` — 176 passed, including new coverage for the idle-window arithmetic, the countdown reset, the config defaults (15 min) and the clamp, and the preload/update-config commands reaching the worker.
- `cargo check -p voxctrl-app --no-default-features --features custom-protocol` — clean. (The default feature set pulls ONNX Runtime from a CDN that this sandbox's proxy blocks, so the ONNX-backed build was not compiled here.)
- `npx vitest run` — 232 passed; `npx svelte-check` — 0 errors.
- Not exercised at runtime: no audio device or model weights in this environment, so the actual load/unload cycle has not been observed end to end.

## Docs

`docs/tts.md` gains a "Model Memory (on-demand loading)" section; `docs/configuration.md` and `docs/api.md` list the two new keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gTEYf1GR2VAetA5yian37

---
_Generated by [Claude Code](https://claude.ai/code/session_012gTEYf1GR2VAetA5yian37)_